### PR TITLE
CLDR-14145 JSP: automatically push to gcr.io on tag

### DIFF
--- a/.github/workflows/push-jsp-on-tag.yml
+++ b/.github/workflows/push-jsp-on-tag.yml
@@ -7,6 +7,7 @@ jobs:
   build-and-push-to-gcr:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Get the version
         id: get_tag_name
         run: echo ::set-output name=GIT_TAG_NAME::${GITHUB_REF/refs\/tags\//}

--- a/.github/workflows/push-jsp-on-tag.yml
+++ b/.github/workflows/push-jsp-on-tag.yml
@@ -19,3 +19,4 @@ jobs:
           image_name: unicode-jsps
           image_tag: ${{ steps.get_tag_name.outputs.GIT_TAG_NAME}}
           dockerfile: ./UnicodeJsps/Dockerfile
+          context: ./UnicodeJsps/

--- a/.github/workflows/push-jsp-on-tag.yml
+++ b/.github/workflows/push-jsp-on-tag.yml
@@ -1,0 +1,20 @@
+name: Push to GCR Github Action
+on:
+  push:
+    tags:
+    - '*'
+jobs:
+  build-and-push-to-gcr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get the version
+        id: get_tag_name
+        run: echo ::set-output name=GIT_TAG_NAME::${GITHUB_REF/refs\/tags\//}
+      - uses: RafikFarhad/push-to-gcr-github-action@v3
+        with:
+          gcloud_service_key: ${{ secrets.GCLOUD_SERVICE_KEY }}
+          registry: us.gcr.io
+          project_id: dev-infra-273822
+          image_name: unicode-jsps
+          image_tag: ${{ steps.get_tag_name.outputs.GIT_TAG_NAME}}
+          dockerfile: ./UnicodeJsps/Dockerfile

--- a/UnicodeJsps/Dockerfile
+++ b/UnicodeJsps/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2020 and later Unicode, Inc. and others. All Rights Reserved.
 # Use -eJDKVERSION=13 -eTOMCATVERSION=8 for example to change these
-ARG JDKVERSION=14
+ARG JDKVERSION=16
 FROM openjdk:${JDKVERSION}-alpine AS build
 # Need ant, add it. Yes, this pulls in JDK8, but it's an easier
 # way to manage this.


### PR DESCRIPTION
whenever a new release (tag) is created, push the JSPs to gcr.io so it can be deployed.
(CLDR bug number just for tracking purposes)