### PR TITLE
ICU-21243 Migrates desuffixucd.py to Python 3.

### DIFF
--- a/unicodetools/data/desuffixucd.py
+++ b/unicodetools/data/desuffixucd.py
@@ -23,7 +23,7 @@ _file_version_re = re.compile("([a-zA-Z0-9_-]+)" +
 
 def main():
   if len(sys.argv) < 2:
-    print ("Usage: %s  path/to/UCD/root" % sys.argv[0])
+    print("Usage: %s  path/to/UCD/root" % sys.argv[0])
     return
   ucd_root = sys.argv[1]
   source_files = []
@@ -36,7 +36,7 @@ def main():
     if match:
       new_basename = match.group(1) + match.group(2)
       if new_basename != basename:
-        print "Removing version suffix from " + source_file
+        print("Removing version suffix from " + source_file)
         # ... so that we can easily compare UCD files.
         new_source_file = os.path.join(folder, new_basename)
         shutil.move(source_file, new_source_file)


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-21243