### PR TITLE
fewer env vars, require repo dirs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -57,13 +57,10 @@ can be used to:
     3.  Depending on which tool you are running, you may need some or all of the following.
         Adjust the paths to your workspace.
         ```
-        -DSVN_WORKSPACE=/usr/local/google/home/mscherer/unitools/mine/src
-        -DOTHER_WORKSPACE=/usr/local/google/home/mscherer/unitools/mine
-        -DUCD_DIR=/usr/local/google/home/mscherer/unitools/mine/src/unicodetools/data
         -DCLDR_DIR=/usr/local/google/home/mscherer/cldr/uni/src
-        -DUNICODETOOLS_DIR=/usr/local/google/home/mscherer/unitools/mine/src/unicodetools
+        -DUNICODETOOLS_REPO_DIR=/usr/local/google/home/mscherer/unitools/mine/src
+        -DUNICODETOOLS_OUTPUT_DIR=/usr/local/google/home/mscherer/unitools/mine
         -DUNICODE_DRAFT_DIR=/usr/local/google/home/mscherer/svn.unidraft/trunk/TODO
-        -DGEN_DIR=/usr/local/google/home/mscherer/unitools/mine/Generated
         -DUVERSION=14.0.0
         ```
     4.  Please also use the VM argument `-ea` (enable assertions) in your Preferences

--- a/unicodetools/org/unicode/bidi/BidiTestIcu4jConformance.java
+++ b/unicodetools/org/unicode/bidi/BidiTestIcu4jConformance.java
@@ -11,7 +11,7 @@ public class BidiTestIcu4jConformance {
     static com.ibm.icu.text.Bidi bidi;
 
     public static void main(String[] args) throws Exception {
-        final String file = Settings.BASE_DIRECTORY + "Desktop/BidiConformance.txt";
+        final String file = Settings.CLDR.BASE_DIRECTORY + "Desktop/BidiConformance.txt";
         System.out.println("Reading: " + file);
         String result = "";
         final BufferedReader in = new BufferedReader(new FileReader(file));

--- a/unicodetools/org/unicode/draft/CharacterFrequency.java
+++ b/unicodetools/org/unicode/draft/CharacterFrequency.java
@@ -19,9 +19,9 @@ import org.unicode.text.utility.Settings;
  * For a program that uses this, see ScriptPopulation
  */
 public class CharacterFrequency {
-    public static final String DATA_DIR = Settings.OTHER_WORKSPACE_DIRECTORY +
+    public static final String DATA_DIR = Settings.Output.UNICODETOOLS_OUTPUT_DIR +
     		"DATA/frequency/languages/";
-    private static final String DATA_DIR_RANK = Settings.OTHER_WORKSPACE_DIRECTORY +
+    private static final String DATA_DIR_RANK = Settings.Output.UNICODETOOLS_OUTPUT_DIR +
     		"DATA/frequency/languages-rank/";
     public static final boolean DEBUG = false;
     //	static final int MAX_LINE_COUNT = Integer.MAX_VALUE; // 10000;

--- a/unicodetools/org/unicode/draft/Cmudict.java
+++ b/unicodetools/org/unicode/draft/Cmudict.java
@@ -24,7 +24,7 @@ import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ULocale;
 
 public class Cmudict {
-    static final String BASE_DIR = Settings.DATA_DIR + "/translit/";
+    static final String BASE_DIR = Settings.UnicodeTools.DATA_DIR + "/translit/";
     static final Collator col = Collator.getInstance(ULocale.ROOT);
     //static final StressFixer stressFixer = new StressFixer();
     static final Transliterator arpabet = getTransliteratorFromFile("arpabet-ipa", BASE_DIR, "arpabet-ipa.txt");
@@ -148,7 +148,7 @@ public class Cmudict {
             System.out.println("Missing?\t" + entry);
         }
 
-        PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "/translit/", "cmudict.txt") ;
+        PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "/translit/", "cmudict.txt") ;
         for (final Entry<String, Set<String>> entry : toIPA.keyValuesSet()) {
             final String word = entry.getKey();
             final Set<String> values = entry.getValue();
@@ -156,7 +156,7 @@ public class Cmudict {
         }
         out.close();
 
-        out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "/translit/", "homonyms.txt") ;
+        out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "/translit/", "homonyms.txt") ;
         final Set<String> temp = new TreeSet(col);
         for (final Entry<String, Set<String>> entry : fromIpa.keyValuesSet()) {
             final Set<String> values = entry.getValue();
@@ -204,7 +204,7 @@ public class Cmudict {
             reverseIpa.put(reversedRespelledKey, ipa);
         }
 
-        out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "/translit/", "reversed.txt");
+        out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "/translit/", "reversed.txt");
         for (final Entry<String, String> reversed_normal : reverseIpa.entrySet()) {
             final String original = reversed_normal.getValue();
             out.println(CollectionUtilities.join(fromIpa.get(original), ", ") + "\t{"

--- a/unicodetools/org/unicode/draft/GenerateCharacterFrequencyCharts.java
+++ b/unicodetools/org/unicode/draft/GenerateCharacterFrequencyCharts.java
@@ -132,9 +132,9 @@ public class GenerateCharacterFrequencyCharts {
 
             final ExemplarInfo exemplarInfo = ExemplarInfo.make(cldrLanguage, missingExemplars);
             // open files for writing, create table
-            final DataOutputStream dataOutputStream = new DataOutputStream(new FileOutputStream(Settings.GEN_DIR + "/frequency/" + language + ".txt"));
+            final DataOutputStream dataOutputStream = new DataOutputStream(new FileOutputStream(Settings.Output.GEN_DIR + "/frequency/" + language + ".txt"));
             final CompressedDataOutput out = new CompressedDataOutput().set(dataOutputStream);
-            final PrintWriter html = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "/frequency-html", htmlFilename);
+            final PrintWriter html = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "/frequency-html", htmlFilename);
             html.println("<html><head><meta charset='UTF-8'>\n" +
                     "<link rel='stylesheet' type='text/css' href='index.css' media='screen'/>\n" +
                     "</head><body>\n" +
@@ -249,7 +249,7 @@ public class GenerateCharacterFrequencyCharts {
     }
 
     private void printIndex(TablePrinter indexTable, String file) throws IOException {
-        final PrintWriter index = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "/frequency-html", file);
+        final PrintWriter index = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "/frequency-html", file);
         index.println("<html><head><meta charset='UTF-8'>\n" +
                 "<link rel='stylesheet' type='text/css' href='index.css' media='screen'/>\n" +
                 "</head><body>\n");

--- a/unicodetools/org/unicode/draft/GeneratePickerData2.java
+++ b/unicodetools/org/unicode/draft/GeneratePickerData2.java
@@ -162,7 +162,7 @@ class GeneratePickerData2 {
     enum MyOptions {
         output(".*", CLDRPaths.BASE_DIRECTORY + "tools/java/org/unicode/cldr/draft/picker/",
             "output data directory"),
-        unicodedata(".*", Settings.UCD_DATA_DIRECTORY, "Unicode Data directory"),
+        unicodedata(".*", Settings.CLDR.UCD_DATA_DIRECTORY, "Unicode Data directory"),
         verbose(null, null, "verbose debugging messages"),
         korean(null, null, "generate korean hangul defectives instead"), ;
         // boilerplate

--- a/unicodetools/org/unicode/draft/HanFrequencies.java
+++ b/unicodetools/org/unicode/draft/HanFrequencies.java
@@ -37,7 +37,7 @@ public class HanFrequencies {
     }
 
     private static void generateReadings() throws IOException {
-        final BufferedReader freq = FileUtilities.openUTF8Reader(Settings.GEN_DIR + "/hanfrequency", "unifiedZh.txt");
+        final BufferedReader freq = FileUtilities.openUTF8Reader(Settings.Output.GEN_DIR + "/hanfrequency", "unifiedZh.txt");
         final UnicodeMap<Integer> rank = new UnicodeMap<Integer>();
         int count = 0;
         while (true) {
@@ -50,7 +50,7 @@ public class HanFrequencies {
             rank.put(parts[0], ++count);
         }
         freq.close();
-        final BufferedReader readings = FileUtilities.openUTF8Reader(Settings.DATA_DIR + "/frequency", "han-reading-diff.txt");
+        final BufferedReader readings = FileUtilities.openUTF8Reader(Settings.UnicodeTools.DATA_DIR + "/frequency", "han-reading-diff.txt");
         final Set<R2<Integer, Map<ReadingRows,String>>> ordered = new TreeSet<R2<Integer,Map<ReadingRows,String>>>();
         while (true) {
             String line = readings.readLine();
@@ -100,7 +100,7 @@ public class HanFrequencies {
         }
         readings.close();
 
-        final PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "/hanfrequency", "han-reading-diff.html");
+        final PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "/hanfrequency", "han-reading-diff.html");
         //PrintStream out = System.out;
         final ReadingRows[] values = ReadingRows.values();
         out.println("<html><body><table>");
@@ -139,7 +139,7 @@ public class HanFrequencies {
     }
 
     private static void showInterleaved() {
-        final PrintWriter out = org.unicode.text.utility.Utility.openPrintWriter(Settings.GEN_DIR + "/hanfrequency",
+        final PrintWriter out = org.unicode.text.utility.Utility.openPrintWriter(Settings.Output.GEN_DIR + "/hanfrequency",
                 "unifiedZh.txt", org.unicode.text.utility.Utility.UTF8_WINDOWS);
 
         final LinkedHashMap<String, Integer> rank1 = getFilteredList("zh");
@@ -189,7 +189,7 @@ public class HanFrequencies {
 
     private static void show(String locale) {
         System.out.println("Writing:\t" + locale);
-        final PrintWriter out = org.unicode.text.utility.Utility.openPrintWriter(Settings.GEN_DIR + "/hanfrequency",
+        final PrintWriter out = org.unicode.text.utility.Utility.openPrintWriter(Settings.Output.GEN_DIR + "/hanfrequency",
                 locale + ".txt", org.unicode.text.utility.Utility.UTF8_WINDOWS);
         final Counter<Integer> counter = CharacterFrequency.getCodePointCounter(locale, true);
         long total = 0;

--- a/unicodetools/org/unicode/draft/IdnaLabelTester2.java
+++ b/unicodetools/org/unicode/draft/IdnaLabelTester2.java
@@ -222,7 +222,7 @@ public class IdnaLabelTester2 {
 
     public static XEquivalenceClass<String, String> getConfusables() throws IOException {
         XEquivalenceClass<String, String> result = new XEquivalenceClass<String, String>();
-        BufferedReader in = openFile(Settings.UCD_DATA_DIRECTORY + "security/" + Settings.latestVersion + "/confusables.txt");
+        BufferedReader in = openFile(Settings.CLDR.UCD_DATA_DIRECTORY + "security/" + Settings.latestVersion + "/confusables.txt");
         String original = null;
         try {
             while (true) {

--- a/unicodetools/org/unicode/draft/LanguageDetectionVsTags.java
+++ b/unicodetools/org/unicode/draft/LanguageDetectionVsTags.java
@@ -33,7 +33,7 @@ public class LanguageDetectionVsTags {
     enum LineFormat {L1, http, meta, lang, xmllang, detected, occurrences, documents, navboost, pagerank, lang2, enc, url};
 
     public static void main(String[] args) throws IOException {
-        final BufferedReader in = FileUtilities.openUTF8Reader(Settings.BASE_DIRECTORY + "Documents/Data/", "lang78.txt");
+        final BufferedReader in = FileUtilities.openUTF8Reader(Settings.CLDR.BASE_DIRECTORY + "Documents/Data/", "lang78.txt");
         final Map<String,Counter<String>> detectedToCountAndTag = new TreeMap<String,Counter<String>>();
         final Counter<String> detectedToCount = new Counter<String>();
         final Counter<String> taggedToCount = new Counter<String>();

--- a/unicodetools/org/unicode/draft/LanguageQuadgrams.java
+++ b/unicodetools/org/unicode/draft/LanguageQuadgrams.java
@@ -19,7 +19,7 @@ import com.ibm.icu.impl.Row;
 public class LanguageQuadgrams {
 
     public static void main(String[] args) throws IOException {
-        final BufferedReader in = FileUtilities.openUTF8Reader(Settings.BASE_DIRECTORY + "Downloads/", "languageQuadgrams.txt");
+        final BufferedReader in = FileUtilities.openUTF8Reader(Settings.CLDR.BASE_DIRECTORY + "Downloads/", "languageQuadgrams.txt");
         while (true) {
             final String line = in.readLine();
             if (line == null) {

--- a/unicodetools/org/unicode/draft/RadicalStroke2.java
+++ b/unicodetools/org/unicode/draft/RadicalStroke2.java
@@ -45,7 +45,7 @@ public class RadicalStroke2 {
             Matcher iiCore = IICORE.matcher("");
             radStrokesToRadToRemainingStrokes = new TreeMap<Integer, Map<String, Map<Integer, UnicodeSet>>>();
             remainder = ScriptCategories2.parseUnicodeSet("[:script=Han:]").removeAll(GeneratePickerData2.SKIP);
-            String dataDir = Settings.UCD_DATA_DIRECTORY + "/Unihan/";
+            String dataDir = Settings.CLDR.UCD_DATA_DIRECTORY + "/Unihan/";
 
             BufferedReader in = new BufferedReader(
                 new FileReader(

--- a/unicodetools/org/unicode/draft/ScriptCount.java
+++ b/unicodetools/org/unicode/draft/ScriptCount.java
@@ -162,7 +162,7 @@ public class ScriptCount {
         //        pf.setMaximumSignificantDigits(3);
         final int counter = 0;
         final double max = langCounter.getTotal();
-        PrintWriter out = org.unicode.text.utility.Utility.openPrintWriter(Settings.GEN_DIR + "/frequency-text",
+        PrintWriter out = org.unicode.text.utility.Utility.openPrintWriter(Settings.Output.GEN_DIR + "/frequency-text",
                 language
                 + (nfd ? "-nfd" : "")
                 + (filter != null ? "-" + filter : "") +
@@ -186,7 +186,7 @@ public class ScriptCount {
         }
         out.close();
         if (secondary) {
-            out = org.unicode.text.utility.Utility.openPrintWriter(Settings.GEN_DIR + "/frequency-text",
+            out = org.unicode.text.utility.Utility.openPrintWriter(Settings.Output.GEN_DIR + "/frequency-text",
                     language + "-sec"
                             + (nfd ? "-nfd" : "")
                             + (filter != null ? "-" + filter : "") +

--- a/unicodetools/org/unicode/draft/WebpageCharacterData.java
+++ b/unicodetools/org/unicode/draft/WebpageCharacterData.java
@@ -72,7 +72,7 @@ public class WebpageCharacterData {
 
     static public void doData() throws IOException {
         final BufferedReader in = FileUtilities.openUTF8Reader(
-                Settings.OTHER_WORKSPACE_DIRECTORY + "DATA/frequency/", SOURCE_DATA);
+                Settings.Output.UNICODETOOLS_OUTPUT_DIR + "DATA/frequency/", SOURCE_DATA);
         int lineCounter = 0;
         final int zeroCountLines = 0;
         final HashMap<String, String> langSeen = new HashMap<String,String>();
@@ -112,10 +112,10 @@ public class WebpageCharacterData {
         in.close();
         System.out.println("Writing data");
         //System.out.println("zeroCountLines " + zeroCountLines);
-        writeData(lang2chars, Settings.OTHER_WORKSPACE_DIRECTORY +
+        writeData(lang2chars, Settings.Output.UNICODETOOLS_OUTPUT_DIR +
         		"DATA/frequency/languages");
         System.out.println("Writing ranked data");
-        writeData(lang2charsPageRank, Settings.OTHER_WORKSPACE_DIRECTORY +
+        writeData(lang2charsPageRank, Settings.Output.UNICODETOOLS_OUTPUT_DIR +
         		"DATA/frequency/languages-rank");
     }
 

--- a/unicodetools/org/unicode/idna/CheckIdna2008.java
+++ b/unicodetools/org/unicode/idna/CheckIdna2008.java
@@ -19,7 +19,7 @@ public class CheckIdna2008 {
 
     public static void main(String[] args) {
 
-        for (final String line : FileUtilities.in(Settings.DATA_DIR + "/idna/", "f.txt")) {
+        for (final String line : FileUtilities.in(Settings.UnicodeTools.DATA_DIR + "/idna/", "f.txt")) {
             if (line.startsWith("Codepoints")) {continue;}
             final String[] parts = line.split(";");
             // 0041;DISALLOWED;Y;AB;LATIN CAPITAL LETTER A
@@ -33,7 +33,7 @@ public class CheckIdna2008 {
             patriksData.put(cp, allButFirst(parts));
         }
 
-        for (String line : FileUtilities.in(Settings.DATA_DIR + "/idna/" +
+        for (String line : FileUtilities.in(Settings.UnicodeTools.DATA_DIR + "/idna/" +
                 Settings.latestVersion +
         		"/", "IdnaMappingTable.txt")) {
             final int pos2 = line.indexOf('#');

--- a/unicodetools/org/unicode/idna/GenerateIdna.java
+++ b/unicodetools/org/unicode/idna/GenerateIdna.java
@@ -37,7 +37,7 @@ public class GenerateIdna {
 		// MUST BE FIRST
 		GenerateIdnaTest.setUnicodeVersion();
 	}
-    public static final String GEN_IDNA_DIR = Settings.GEN_DIR + "idna/" + Default.ucdVersion() + "/";
+    public static final String GEN_IDNA_DIR = Settings.Output.GEN_DIR + "idna/" + Default.ucdVersion() + "/";
 
 	// Utility.WORKSPACE_DIRECTORY + "draft/reports/tr46/data";
 	private static final int MAX_STATUS_LENGTH = "disallowed_STD3_mapped".length();

--- a/unicodetools/org/unicode/idna/GenerateIdnaTest.java
+++ b/unicodetools/org/unicode/idna/GenerateIdnaTest.java
@@ -169,7 +169,7 @@ public class GenerateIdnaTest {
                     "update GenerateIdnaTest.ucdTypesLastVersion to match " + Settings.lastVersion);
         }
         Set<TestLine> testLines = LoadIdnaTest.load(
-                Settings.UNICODETOOLS_DIRECTORY + "data/idna/" + Settings.lastVersion);
+                Settings.UnicodeTools.UNICODETOOLS_DIR + "data/idna/" + Settings.lastVersion);
 
         for (TestLine testLine : testLines) {
             count += generateLine(replaceNewerThan(testLine.source, ucdTypesLastVersion), out, out2);

--- a/unicodetools/org/unicode/idna/LoadIdnaTest.java
+++ b/unicodetools/org/unicode/idna/LoadIdnaTest.java
@@ -163,7 +163,7 @@ V2
 
     public static void main(String[] args) {
         Set<Idna2008Status> seen = EnumSet.noneOf(Idna2008Status.class);
-        for (TestLine testLine : load(Settings.UNICODETOOLS_DIRECTORY + "data/idna/13.0.0")) {
+        for (TestLine testLine : load(Settings.UnicodeTools.UNICODETOOLS_DIR + "data/idna/13.0.0")) {
             System.out.println(testLine);
         }
     }

--- a/unicodetools/org/unicode/idna/Uts46.java
+++ b/unicodetools/org/unicode/idna/Uts46.java
@@ -21,7 +21,7 @@ public class Uts46 extends Idna {
     public static Uts46 SINGLETON = new Uts46();
 
     private Uts46() {
-        new MyHandler().process(Settings.DATA_DIR + "idna/" + Settings.latestVersion, "IdnaMappingTable.txt");
+        new MyHandler().process(Settings.UnicodeTools.DATA_DIR + "idna/" + Settings.latestVersion, "IdnaMappingTable.txt");
         types.freeze();
         mappings.freeze();
         mappings_display.freeze();

--- a/unicodetools/org/unicode/jsp/Globe.java
+++ b/unicodetools/org/unicode/jsp/Globe.java
@@ -226,7 +226,7 @@ public class Globe {
         // Add the ubiquitous "Hello World" label.
         // JLabel label = new JLabel("Hello World");
         // frame.getContentPane().add(label);
-        final String sname = Settings.BASE_DIRECTORY + "workspace/unicode-jsps/WebContent/images/earth-living.jpg";
+        final String sname = Settings.CLDR.BASE_DIRECTORY + "workspace/unicode-jsps/WebContent/images/earth-living.jpg";
         // "ev11656_land_shallow_topo_8192.tiff";
         // "ev11656_land_shallow_topo_8192.PNG";
         // earthmap1k.jpg";
@@ -555,7 +555,7 @@ public class Globe {
         final File file = new File("jsp/Globe.txt");
         System.out.println(file.getAbsolutePath());
 
-        String globe = Settings.BASE_DIRECTORY + "workspace/unicodetools/org/unicode/jsp/Globe.txt";
+        String globe = Settings.CLDR.BASE_DIRECTORY + "workspace/unicodetools/org/unicode/jsp/Globe.txt";
         System.out.println(new File(globe).getCanonicalPath());
 
         final BufferedReader br = new BufferedReader(

--- a/unicodetools/org/unicode/jsptest/TestTypology.java
+++ b/unicodetools/org/unicode/jsptest/TestTypology.java
@@ -71,8 +71,8 @@ public class TestTypology extends TestFmwk {
             System.out.println(list);
         }
 
-        final PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "/categories", "CategoryLabels.txt");
-        final PrintWriter html = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "/categories", "CategoryLabels.html");
+        final PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "/categories", "CategoryLabels.txt");
+        final PrintWriter html = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "/categories", "CategoryLabels.html");
         final String fontList = "Georgia, 'Times New Roman', Times, Symbola, Aegyptus, Aegean, Akkadian, Analecta, Musica, Code2000,  Code2001,  Code2002, serif";
         html.println(
                 "<!DOCTYPE html PUBLIC '-//W3C//DTD HTML 4.0 Transitional//EN'>\n" +

--- a/unicodetools/org/unicode/props/GenerateEnums.java
+++ b/unicodetools/org/unicode/props/GenerateEnums.java
@@ -33,8 +33,8 @@ public class GenerateEnums {
     public static final String ENUM_VERSION = Settings.latestVersion;
     public static final VersionInfo ENUM_VERSION_INFO = VersionInfo.getInstance(GenerateEnums.ENUM_VERSION);
 
-    public static final String PROPERTY_FILE_OUTPUT = Settings.UNICODETOOLS_DIRECTORY + "/org/unicode/props/UcdProperty.java";
-    public static final String PROPERTY_VALUE_OUTPUT = Settings.UNICODETOOLS_DIRECTORY + "/org/unicode/props/UcdPropertyValues.java";
+    public static final String PROPERTY_FILE_OUTPUT = Settings.UnicodeTools.UNICODETOOLS_DIR + "/org/unicode/props/UcdProperty.java";
+    public static final String PROPERTY_VALUE_OUTPUT = Settings.UnicodeTools.UNICODETOOLS_DIR + "/org/unicode/props/UcdPropertyValues.java";
 
     //    private static class Locations {
     //        private static Set<String> files = addAll(new HashSet<String>(), new File(SOURCE_DIR));

--- a/unicodetools/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/org/unicode/props/IndexUnicodeProperties.java
@@ -457,7 +457,7 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
     private UnicodeMap<String> getCachedMap(UcdProperty prop2, String sourceFileName) {
         File cacheFile;
         try {
-            final String cacheFileName = Settings.BIN_DIR + getUcdVersion() + "/" + prop2 + ".bin";
+            final String cacheFileName = Settings.Output.BIN_DIR + getUcdVersion() + "/" + prop2 + ".bin";
             cacheFile = new File(cacheFileName);
             // if the source file is older than the cached, skip
             if (sourceFileName != null) {

--- a/unicodetools/org/unicode/props/PropertyParsingInfo.java
+++ b/unicodetools/org/unicode/props/PropertyParsingInfo.java
@@ -696,7 +696,7 @@ public class PropertyParsingInfo implements Comparable<PropertyParsingInfo>{
             }
             data.freeze();
             if (IndexUnicodeProperties.FILE_CACHE) {
-                indexUnicodeProperties.internalStoreCachedMap(Settings.BIN_DIR, propInfo.property, data);
+                indexUnicodeProperties.internalStoreCachedMap(Settings.Output.BIN_DIR, propInfo.property, data);
             }
         }
     }

--- a/unicodetools/org/unicode/propstest/CheckProperties.java
+++ b/unicodetools/org/unicode/propstest/CheckProperties.java
@@ -46,7 +46,7 @@ import com.ibm.icu.text.UnicodeSet;
 public class CheckProperties {
     private static final boolean VERBOSE = true;
     private static final String LAST_RELEASE = Utility.searchPath[0];;
-    private static final String JUNK = Settings.UCD_DIR; // force load
+    private static final String JUNK = Settings.UnicodeTools.UCD_DIR; // force load
 
     private static final int DEBUG_CODE_POINT = 0x0600;
 
@@ -87,9 +87,9 @@ public class CheckProperties {
             } catch (final Exception e) {}
 
             if (arg.equals("file")) {
-                out = FileUtilities.openUTF8Writer(Settings.GEN_DIR, "CheckProperties.txt");
-                outCJK = FileUtilities.openUTF8Writer(Settings.GEN_DIR, "CheckPropertiesCJK.txt");
-                outLog = FileUtilities.openUTF8Writer(Settings.GEN_DIR, "CheckPropertiesLog.txt");
+                out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR, "CheckProperties.txt");
+                outCJK = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR, "CheckPropertiesCJK.txt");
+                outLog = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR, "CheckPropertiesLog.txt");
                 LIMIT_CHANGES = Integer.MAX_VALUE;
                 NAME_LIMIT = Integer.MAX_VALUE;
                 continue;
@@ -277,7 +277,7 @@ public class CheckProperties {
                         }
 
                         final Set<String> latestFiles = latest.getFileNames();
-                        final File dir = new File(Settings.UCD_DIR);
+                        final File dir = new File(Settings.UnicodeTools.UCD_DIR);
                         final List<File> result = new ArrayList<File>();
                         checkFiles(latestFiles, dir, result);
                         showInfo("Files Not Read", result, outLog);

--- a/unicodetools/org/unicode/propstest/CheckXmlProperties.java
+++ b/unicodetools/org/unicode/propstest/CheckXmlProperties.java
@@ -74,7 +74,7 @@ Warning tests:  4
         System.out.println("Loading XML Props");
         timer.start();
         final XMLProperties xmlProps = new XMLProperties(
-                Settings.DATA_DIR + "/ucdxml/" + ucdVersion + "/",
+                Settings.UnicodeTools.DATA_DIR + "/ucdxml/" + ucdVersion + "/",
                 INCLUDE_UNIHAN, MAX_LINE_COUNT);
         timer.stop();
         System.out.println(timer);

--- a/unicodetools/org/unicode/propstest/CopyPropsToUnicodeJsp.java
+++ b/unicodetools/org/unicode/propstest/CopyPropsToUnicodeJsp.java
@@ -22,8 +22,8 @@ public class CopyPropsToUnicodeJsp {
     public static void main(String[] args) throws IOException {
         IndexUnicodeProperties latest = IndexUnicodeProperties.make();
 
-        String fromDir = Settings.BIN_DIR + latest.getUcdVersion() + "/";
-        String toDir = Settings.UNICODEJSPS_DIRECTORY + "src/org/unicode/jsp/props/";
+        String fromDir = Settings.Output.BIN_DIR + latest.getUcdVersion() + "/";
+        String toDir = Settings.UnicodeTools.UNICODEJSPS_DIR + "src/org/unicode/jsp/props/";
         //overwrite existing file, if exists
         CopyOption[] options = new CopyOption[] {StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES};
         Set<String> kExceptions = ImmutableSet.of("kAccountingNumeric.bin", "kOtherNumeric.bin", "kPrimaryNumeric.bin", "kSimplifiedVariant.bin", "kTraditionalVariant.bin");

--- a/unicodetools/org/unicode/propstest/Ids.java
+++ b/unicodetools/org/unicode/propstest/Ids.java
@@ -20,7 +20,7 @@ import com.ibm.icu.text.UnicodeSet;
 
 public class Ids {
     static final Pattern NCR_PATTERN = Pattern.compile("\\&[^;]+;");
-    static final String BASE = Settings.OTHER_WORKSPACE_DIRECTORY + "DATA/ids-b6bb70e/";
+    static final String BASE = Settings.Output.UNICODETOOLS_OUTPUT_DIR + "DATA/ids-b6bb70e/";
 
     static class NcrToPua {
         int puaCounter = 0xE000;
@@ -56,7 +56,7 @@ public class Ids {
     static final UnicodeSet RADICAL_ID = new UnicodeSet("[:radical:]").addAll(ID).freeze();
 
     static {
-        for (String line : FileUtilities.in(Settings.SVN_WORKSPACE_DIRECTORY + "/unicodetools/data/ucd/8.0.0-Update", "CJKRadicals.txt")) {
+        for (String line : FileUtilities.in(Settings.UnicodeTools.UNICODETOOLS_REPO_DIR + "/unicodetools/data/ucd/8.0.0-Update", "CJKRadicals.txt")) {
             if (line.isEmpty() || line.startsWith("#")) {
                 continue;
             }

--- a/unicodetools/org/unicode/propstest/ListProps.java
+++ b/unicodetools/org/unicode/propstest/ListProps.java
@@ -141,7 +141,7 @@ public class ListProps {
                             uprop.getValueAliases(pval);
                         }
                     }
-                    latest.internalStoreCachedMap(Settings.GEN_DIR + "/bin-props/", item, map);
+                    latest.internalStoreCachedMap(Settings.Output.GEN_DIR + "/bin-props/", item, map);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/unicodetools/org/unicode/test/CaseBitTest.java
+++ b/unicodetools/org/unicode/test/CaseBitTest.java
@@ -92,7 +92,7 @@ public class CaseBitTest extends TestFmwk {
     public UCA getUca() {
         if (uca == null) {
             try {
-                final String file = Utility.searchDirectory(new File(Settings.DATA_DIR + "UCA/" + Default.ucdVersion() + "/"), "allkeys", true, ".txt");
+                final String file = Utility.searchDirectory(new File(Settings.UnicodeTools.DATA_DIR + "UCA/" + Default.ucdVersion() + "/"), "allkeys", true, ".txt");
                 uca = new UCA(file, Default.ucdVersion(), null);
             } catch (final IOException e) {
                 throw new IllegalArgumentException(e);

--- a/unicodetools/org/unicode/test/TestSecurity.java
+++ b/unicodetools/org/unicode/test/TestSecurity.java
@@ -54,7 +54,7 @@ import com.ibm.icu.text.UnicodeSet;
 
 
 public class TestSecurity extends TestFmwkPlus {
-    private static final String GEN_SECURITY_DIR = Settings.GEN_DIR + "security/" + Settings.latestVersion;
+    private static final String GEN_SECURITY_DIR = Settings.Output.GEN_DIR + "security/" + Settings.latestVersion;
 
     public static XIDModifications XIDMOD = new XIDModifications(GEN_SECURITY_DIR);
     public static final Confusables CONFUSABLES = new Confusables(GEN_SECURITY_DIR);

--- a/unicodetools/org/unicode/test/TestUnicodeBnf.java
+++ b/unicodetools/org/unicode/test/TestUnicodeBnf.java
@@ -36,7 +36,7 @@ public class TestUnicodeBnf {
         Pattern gcbRegex = Pattern.compile(fixed);
         int lineCount = 0;
         // test
-        for (String line : FileUtilities.in(Settings.UNICODETOOLS_DIRECTORY, 
+        for (String line : FileUtilities.in(Settings.UnicodeTools.UNICODETOOLS_DIR, 
                 "data/ucd/11.0.0-Update/auxiliary/GraphemeBreakTest.txt")) {
             ++lineCount;
             BreakTest breakTest = BreakTest.forLine(line);

--- a/unicodetools/org/unicode/text/UCA/CompareDucetToCldr.java
+++ b/unicodetools/org/unicode/text/UCA/CompareDucetToCldr.java
@@ -30,7 +30,7 @@ import com.ibm.icu.text.UnicodeSet;
 
 public class CompareDucetToCldr {
     private static final Date DATE = new Date();
-    private static final String BASE_DIR = Settings.DATA_DIR + "/UCA/6.1.0/";  // TODO: parameterize
+    private static final String BASE_DIR = Settings.UnicodeTools.DATA_DIR + "/UCA/6.1.0/";  // TODO: parameterize
     static class Birelation<K,V> {
         private final Relation<K,V> keyValues;
         private final Relation<V,K> valueKeys;
@@ -115,7 +115,7 @@ public class CompareDucetToCldr {
     }
 
     public static void writeValues(Birelation<WeightList, String> cldr, String filename, boolean showWeights) throws IOException {
-        final PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "uca_COMP/", filename);
+        final PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "uca_COMP/", filename);
         out.println("#Date: " + DATE);
         for (final Entry<WeightList, Set<String>> kvs : cldr.keyValuesSet()) {
             final WeightList weights = kvs.getKey();

--- a/unicodetools/org/unicode/text/UCA/UCA.java
+++ b/unicodetools/org/unicode/text/UCA/UCA.java
@@ -1718,7 +1718,7 @@ final public class UCA implements Comparator<String>, UCA_Types {
         //  } catch (IOException e) {
         //    throw (IllegalArgumentException) new IllegalArgumentException().initCause(e);
         //  }
-        return Settings.BASE_UCA_GEN_DIR + Default.ucdVersion() + "/"; //  + getDataVersion() + "/";
+        return Settings.Output.BASE_UCA_GEN_DIR + Default.ucdVersion() + "/"; //  + getDataVersion() + "/";
     }
 
 
@@ -1735,7 +1735,7 @@ final public class UCA implements Comparator<String>, UCA_Types {
     public static UCA buildCollator(Remap primaryRemap) {
         try {
             if (VERBOSE) System.out.println("Building UCA");
-            final String file = Utility.searchDirectory(new File(Settings.DATA_DIR + "uca/" + Default.ucdVersion() + "/"), "allkeys", true, ".txt");
+            final String file = Utility.searchDirectory(new File(Settings.UnicodeTools.DATA_DIR + "uca/" + Default.ucdVersion() + "/"), "allkeys", true, ".txt");
             final UCA collator = new UCA(file, Default.ucdVersion(), primaryRemap);
             if (VERBOSE) System.out.println("Built version " + collator.getDataVersion() + "/ucd: " + collator.getUCDVersion());
             if (VERBOSE) System.out.println("Building UCD data");

--- a/unicodetools/org/unicode/text/UCA/WriteCharts.java
+++ b/unicodetools/org/unicode/text/UCA/WriteCharts.java
@@ -1132,7 +1132,7 @@ public class WriteCharts implements UCD_Types {
 
         // UnicodeSet latin = new UnicodeSet("[:latin:]");
 
-        final PrintWriter out = Utility.openPrintWriter(Settings.GEN_DIR + "log/", "composition_chart.html", Utility.UTF8_WINDOWS);
+        final PrintWriter out = Utility.openPrintWriter(Settings.Output.GEN_DIR + "log/", "composition_chart.html", Utility.UTF8_WINDOWS);
         try {
             out.println("<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01 Transitional//EN' 'http://www.w3.org/TR/html4/loose.dtd'>\n" +
                     UtilityBase.HTML_HEAD);
@@ -1367,7 +1367,7 @@ public class WriteCharts implements UCD_Types {
             Reserved (other)
          */
 
-        final PrintWriter out = Utility.openPrintWriter(Settings.GEN_DIR + "log/", "allocation.html", Utility.UTF8_WINDOWS);
+        final PrintWriter out = Utility.openPrintWriter(Settings.Output.GEN_DIR + "log/", "allocation.html", Utility.UTF8_WINDOWS);
         try {
             out.println("<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01 Transitional//EN' 'http://www.w3.org/TR/html4/loose.dtd'>\n" +
                     UtilityBase.HTML_HEAD);

--- a/unicodetools/org/unicode/text/UCD/CheckICU.java
+++ b/unicodetools/org/unicode/text/UCD/CheckICU.java
@@ -194,7 +194,7 @@ public class CheckICU {
                 leading.add(i);
             }
         }
-        final PrintWriter pw = FileUtilities.openUTF8Writer(Settings.GEN_DIR, "Trailing.txt");
+        final PrintWriter pw = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR, "Trailing.txt");
         pw.println("+Trailing+Starter");
         bf.showSetNames(pw,  new UnicodeSet(trailing).retainAll(starter));
         pw.println("+Trailing-Starter");

--- a/unicodetools/org/unicode/text/UCD/ChineseFrequency.java
+++ b/unicodetools/org/unicode/text/UCD/ChineseFrequency.java
@@ -31,7 +31,7 @@ public class ChineseFrequency {
 
     public static void test() throws IOException{
         final Set freq_char = new TreeSet(new InverseCompareTo());
-        final BufferedReader br = FileUtilities.openUTF8Reader(Settings.DICT_DIR, "kHYPLCDPF.txt");
+        final BufferedReader br = FileUtilities.openUTF8Reader(Settings.UnicodeTools.DICT_DIR, "kHYPLCDPF.txt");
         double grandTotal = 0.0;
         while (true) {
             final String line = br.readLine();
@@ -52,7 +52,7 @@ public class ChineseFrequency {
             freq_char.add(new Pair(new Long(total), new Integer(cp)));
         }
         br.close();
-        final PrintWriter pw = FileUtilities.openUTF8Writer(Settings.DICT_DIR, "kHYPLCDPF_frequency.txt");
+        final PrintWriter pw = FileUtilities.openUTF8Writer(Settings.UnicodeTools.DICT_DIR, "kHYPLCDPF_frequency.txt");
         pw.write("\uFEFF");
         pw.println("No.\tPercentage\tAccummulated\tHex\tChar");
 

--- a/unicodetools/org/unicode/text/UCD/Compare14652.java
+++ b/unicodetools/org/unicode/text/UCD/Compare14652.java
@@ -187,7 +187,7 @@ tolower
                 Utility.showSetDifferences("ID", ID, "Alphabetic+Digit+Pc", alphanumSet, false, Default.ucd());
             }
 
-            final BufferedReader br = Utility.openReadFile(Settings.DATA_DIR + "ISO14652_CTYPE.txt", Utility.LATIN1);
+            final BufferedReader br = Utility.openReadFile(Settings.UnicodeTools.DATA_DIR + "ISO14652_CTYPE.txt", Utility.LATIN1);
             while (true) {
                 String line = br.readLine();
                 if (line == null) {

--- a/unicodetools/org/unicode/text/UCD/ConvertUCD.java
+++ b/unicodetools/org/unicode/text/UCD/ConvertUCD.java
@@ -267,7 +267,7 @@ public final class ConvertUCD implements UCD_Types {
 
         log = new PrintWriter(new BufferedWriter(
                 new OutputStreamWriter(
-                        new FileOutputStream(Settings.GEN_DIR_OLD + "ConvertUCD-log.txt"),
+                        new FileOutputStream(Settings.Output.GEN_DIR_OLD + "ConvertUCD-log.txt"),
                         "UTF8"),
                         32*1024));
         log.write("\uFEFF"); // BOM
@@ -711,7 +711,7 @@ public final class ConvertUCD implements UCD_Types {
         System.out.println("Writing " + dataFilePrefix + version);
         final DataOutputStream dataOut = new DataOutputStream(
                 new BufferedOutputStream(
-                        new FileOutputStream(Settings.BIN_DIR +  dataFilePrefix + version + ".bin"),
+                        new FileOutputStream(Settings.Output.BIN_DIR +  dataFilePrefix + version + ".bin"),
                         128*1024));
 
         // write header

--- a/unicodetools/org/unicode/text/UCD/GenerateCaseFolding.java
+++ b/unicodetools/org/unicode/text/UCD/GenerateCaseFolding.java
@@ -49,7 +49,7 @@ public class GenerateCaseFolding implements UCD_Types {
     public static void makeCaseFold(boolean normalized) throws java.io.IOException {
         PICK_SHORT = NF_CLOSURE = normalized;
 
-        log = Utility.openPrintWriter(Settings.GEN_DIR_OLD + "/log", "CaseFoldingLog" + FileInfix.fromFlags(Settings.BUILD_FOR_COMPARE, true).getFileInfix() + ".txt", Utility.LATIN1_UNIX);
+        log = Utility.openPrintWriter(Settings.Output.GEN_DIR_OLD + "/log", "CaseFoldingLog" + FileInfix.fromFlags(Settings.BUILD_FOR_COMPARE, true).getFileInfix() + ".txt", Utility.LATIN1_UNIX);
         System.out.println("Writing Log: " + "CaseFoldingLog" + FileInfix.fromFlags(Settings.BUILD_FOR_COMPARE, true).getFileInfix() + ".txt");
 
         System.out.println("Making Full Data");
@@ -549,7 +549,7 @@ public class GenerateCaseFolding implements UCD_Types {
             suffix2 = "-Normalized";
         }
 
-        final PrintWriter log = Utility.openPrintWriter(Settings.GEN_DIR_OLD, "log/SpecialCasingExceptions"
+        final PrintWriter log = Utility.openPrintWriter(Settings.Output.GEN_DIR_OLD, "log/SpecialCasingExceptions"
         + suffix2 + FileInfix.fromFlags(Settings.BUILD_FOR_COMPARE, true).getFileInfix() + ".txt", Utility.LATIN1_UNIX);
 
         for (int ch = 0; ch <= 0x10FFFF; ++ch) {

--- a/unicodetools/org/unicode/text/UCD/GenerateConfusables.java
+++ b/unicodetools/org/unicode/text/UCD/GenerateConfusables.java
@@ -86,8 +86,8 @@ public class GenerateConfusables {
     private static final String REVISION = Settings.latestVersion;
     static final String VERSION_PROP_VALUE = REVISION; // "V7_0";
 
-    static final String reformatedInternal = Settings.UNICODETOOLS_DIRECTORY + "data/security/" + REVISION + "/data/";
-    public static final String GEN_SECURITY_DIR = Settings.GEN_DIR + "security/" + REVISION + "/";
+    static final String reformatedInternal = Settings.UnicodeTools.UNICODETOOLS_DIR + "data/security/" + REVISION + "/data/";
+    public static final String GEN_SECURITY_DIR = Settings.Output.GEN_DIR + "security/" + REVISION + "/";
 
     //    static final XIDModifications REFERENCE_VALUES = new XIDModifications(Settings.UNICODETOOLS_DIRECTORY + "data/security/"
     //            + REFERENCE_VERSION
@@ -99,7 +99,7 @@ public class GenerateConfusables {
     static final boolean DEBUG = false;
 
     static {
-        Confusables REFERENCE_VALUES = new Confusables(Settings.UNICODETOOLS_DIRECTORY + "data/security/"
+        Confusables REFERENCE_VALUES = new Confusables(Settings.UnicodeTools.UNICODETOOLS_DIR + "data/security/"
             + REFERENCE_VERSION);
         for (EntryRange<String> entry : REFERENCE_VALUES.getRawMapToRepresentative(Confusables.Style.MA).entryRanges()) {
             if (entry.string != null) {

--- a/unicodetools/org/unicode/text/UCD/GenerateConfusablesCopy.java
+++ b/unicodetools/org/unicode/text/UCD/GenerateConfusablesCopy.java
@@ -86,7 +86,7 @@ public class GenerateConfusablesCopy {
     private static final String REVISION = Settings.latestVersion;
     private static final String VERSION_PROP_VALUE = "V7_0";
 
-    private static final String outdir = Settings.UNICODETOOLS_DIRECTORY + "data/security/" + REVISION + "/data/";
+    private static final String outdir = Settings.UnicodeTools.UNICODETOOLS_DIR + "data/security/" + REVISION + "/data/";
     private static final String indir = outdir + "source/";
     private static final UCD DEFAULT_UCD = Default.ucd();
     private static final UnicodeProperty.Factory ups = ToolUnicodePropertySource.make(version); // ICUPropertyFactory.make();

--- a/unicodetools/org/unicode/text/UCD/GenerateHanTransliterator.java
+++ b/unicodetools/org/unicode/text/UCD/GenerateHanTransliterator.java
@@ -311,7 +311,7 @@ public final class GenerateHanTransliterator implements UCD_Types {
             s.add(it.codepoint);
         }
         final String filename = "Raw_Transliterator_Han_Latin.txt";
-        final PrintWriter out = FileUtilities.openUTF8Writer((String) Settings.GEN_DIR, (String) filename);
+        final PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR, filename);
         for (final Iterator it = outmap.keySet().iterator(); it.hasNext();) {
             final String pinyin = (String) it.next();
             final UnicodeSet uset = (UnicodeSet) outmap.get(pinyin);
@@ -347,8 +347,8 @@ public final class GenerateHanTransliterator implements UCD_Types {
 
     public static void quickMandarin() throws Exception {
         final UnicodeMap gcl = new UnicodeMap();
-        addField(Settings.DATA_DIR + "dict/", "gcl_icu.txt", 2, 3, gcl);
-        addField(Settings.DATA_DIR + "dict/", "gcl_other.txt", 2, 5, gcl);
+        addField(Settings.UnicodeTools.DATA_DIR + "dict/", "gcl_icu.txt", 2, 3, gcl);
+        addField(Settings.UnicodeTools.DATA_DIR + "dict/", "gcl_other.txt", 2, 5, gcl);
         final Transliterator icuPinyin = Transliterator.getInstance("han-latin");
         IndexUnicodeProperties iup = IndexUnicodeProperties.make(Default.ucd().getVersionInfo());
         final UnicodeMap kMandarin = iup.load(UcdProperty.kMandarin);
@@ -619,7 +619,7 @@ public final class GenerateHanTransliterator implements UCD_Types {
             log.println();
             log.println("@Unihan Data");
             log.println();
-            out2 = FileUtilities.openUTF8Writer((String) Settings.GEN_DIR, (String) "unihan_kmandarinDump.txt");
+            out2 = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR, "unihan_kmandarinDump.txt");
 
             readUnihanData(key);
 
@@ -1478,7 +1478,7 @@ U+7878	·	nüè	#nuè
 
             if (type == CHINESE) {
                 System.out.println("Reading chinese_frequency.txt");
-                br = Utility.openReadFile(Settings.DATA_DIR + "dict/chinese_frequency.txt", Utility.UTF8);
+                br = Utility.openReadFile(Settings.UnicodeTools.DATA_DIR + "dict/chinese_frequency.txt", Utility.UTF8);
                 counter = 0;
                 while (true) {
                     line = Utility.readDataLine(br);
@@ -1501,7 +1501,7 @@ U+7878	·	nüè	#nuè
             if (type == JAPANESE) {
                 System.out.println("Reading japanese_frequency.txt");
 
-                br = Utility.openReadFile( Settings.DATA_DIR + "dict/japanese_frequency.txt", Utility.UTF8);
+                br = Utility.openReadFile(Settings.UnicodeTools.DATA_DIR + "dict/japanese_frequency.txt", Utility.UTF8);
                 final Map japaneseMap = new HashMap();
                 while (true) {
                     line = Utility.readDataLine(br);
@@ -1699,7 +1699,7 @@ U+7878	·	nüè	#nuè
         }
 
         System.out.println("Reading " + fname);
-        final BufferedReader br = Utility.openReadFile(Settings.DATA_DIR + "dict/" + fname, Utility.UTF8);
+        final BufferedReader br = Utility.openReadFile(Settings.UnicodeTools.DATA_DIR + "dict/" + fname, Utility.UTF8);
         int counter = 0;
         final String[] pieces = new String[50];
         String line = "";
@@ -1752,7 +1752,7 @@ U+7878	·	nüè	#nuè
         final String fname = "Chinese_override.txt";
 
         System.out.println("Reading " + fname);
-        final BufferedReader br = Utility.openReadFile(Settings.DATA_DIR + "dict/" + fname, Utility.UTF8);
+        final BufferedReader br = Utility.openReadFile(Settings.UnicodeTools.DATA_DIR + "dict/" + fname, Utility.UTF8);
         int counter = 0;
         final String[] pieces = new String[50];
         String line = "";
@@ -1819,7 +1819,7 @@ Bad pinyin data: \u4E7F	?	LE
             final String pinyinPrefix = "Bad pinyin data: ";
 
             System.out.println("Reading " + fname);
-            final BufferedReader br = Utility.openReadFile(Settings.DATA_DIR + "dict/" + fname, Utility.UTF8);
+            final BufferedReader br = Utility.openReadFile(Settings.UnicodeTools.DATA_DIR + "dict/" + fname, Utility.UTF8);
             try {
                 while (true) {
                     line = Utility.readDataLine(br);
@@ -2123,7 +2123,7 @@ Bad pinyin data: \u4E7F	?	LE
         System.out.println("Reading cdict.txt");
         final String fname = "cdict.txt";
 
-        final BufferedReader br = Utility.openReadFile(Settings.DATA_DIR + "dict/" + fname, Utility.UTF8);
+        final BufferedReader br = Utility.openReadFile(Settings.UnicodeTools.DATA_DIR + "dict/" + fname, Utility.UTF8);
         int counter = 0;
         final String[] pieces = new String[50];
         String line = "";

--- a/unicodetools/org/unicode/text/UCD/GenerateStringPrep.java
+++ b/unicodetools/org/unicode/text/UCD/GenerateStringPrep.java
@@ -129,9 +129,9 @@ class GenerateStringPrep implements UCD_Types {
         System.out.println(bf.showSetNames(hasNoUpper));
 
         Utility.fixDot();
-        final PrintWriter htmlOut = FileUtilities.openUTF8Writer(Settings.GEN_DIR, "idn-chars.html");
-        final PrintWriter htmlOut2 = FileUtilities.openUTF8Writer(Settings.GEN_DIR, "script-chars.html");
-        PrintWriter textOut = FileUtilities.openUTF8Writer(Settings.GEN_DIR, "idn-chars.txt");
+        final PrintWriter htmlOut = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR, "idn-chars.html");
+        final PrintWriter htmlOut2 = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR, "script-chars.html");
+        PrintWriter textOut = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR, "idn-chars.txt");
         textOut.println('\uFEFF');
         textOut.println("For documentation, see idn-chars.html");
 
@@ -189,7 +189,7 @@ class GenerateStringPrep implements UCD_Types {
             bf.showSetNames(textOut, suspect.keySet(value));
         }
         textOut.close();
-        textOut = FileUtilities.openUTF8Writer(Settings.GEN_DIR, "idn_vs_cfnfkcid.txt");
+        textOut = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR, "idn_vs_cfnfkcid.txt");
         bf = new BagFormatter();
         bf.setUnicodePropertyFactory(ups);
         textOut.println();
@@ -440,7 +440,7 @@ class GenerateStringPrep implements UCD_Types {
      */
     private UnicodeMap getPositions() throws IOException {
         final UnicodeMap result = new UnicodeMap();
-        final BufferedReader in = FileUtilities.openUTF8Reader(Settings.DATA_DIR + "confusables/", "positions.txt");
+        final BufferedReader in = FileUtilities.openUTF8Reader(Settings.UnicodeTools.DATA_DIR + "confusables/", "positions.txt");
         String type="Undetermined";
         while (true) {
             final String line = Utility.readDataLine(in);

--- a/unicodetools/org/unicode/text/UCD/GetTypology.java
+++ b/unicodetools/org/unicode/text/UCD/GetTypology.java
@@ -29,7 +29,7 @@ public class GetTypology {
         final Map<String,Set<String>> toOriginals = new TreeMap();
 
         final String filename = "U52M09XXXX.lst";
-        final BufferedReader br = FileUtilities.openUTF8Reader(Settings.UCD_DIR, filename);
+        final BufferedReader br = FileUtilities.openUTF8Reader(Settings.UnicodeTools.UCD_DIR, filename);
         final StringBuilder name = new StringBuilder();
         String nameString = null;
 
@@ -102,7 +102,7 @@ public class GetTypology {
         }
         br.close();
 
-        final PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "/classification", "classification_analysis.txt");
+        final PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "/classification", "classification_analysis.txt");
         out.println("# Source:\t" + filename);
         int count;
         out.println();

--- a/unicodetools/org/unicode/text/UCD/IANANames.java
+++ b/unicodetools/org/unicode/text/UCD/IANANames.java
@@ -74,7 +74,7 @@ public class IANANames implements UCD_Types {
     }
 
     public IANANames() throws IOException {
-        final BufferedReader in = Utility.openReadFile(Settings.DATA_DIR + "IANA/character-sets.txt", Utility.LATIN1);
+        final BufferedReader in = Utility.openReadFile(Settings.UnicodeTools.DATA_DIR + "IANA/character-sets.txt", Utility.LATIN1);
         try {
             boolean atStart = true;
             String lastName = "";

--- a/unicodetools/org/unicode/text/UCD/IDNTester.java
+++ b/unicodetools/org/unicode/text/UCD/IDNTester.java
@@ -31,7 +31,7 @@ public class IDNTester {
 
     public static void main(String[] args) throws IOException {
         initialize();
-        pw = FileUtilities.openUTF8Writer(Settings.GEN_DIR, "idnCount.html");
+        pw = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR, "idnCount.html");
         pw.println("<html><body>");
         showSet("IDN InputOnly: ", IDNInputOnly);
         showSet("IDN Output: ", IDNOutput);

--- a/unicodetools/org/unicode/text/UCD/MakeUnicodeFiles.java
+++ b/unicodetools/org/unicode/text/UCD/MakeUnicodeFiles.java
@@ -1348,7 +1348,7 @@ public class MakeUnicodeFiles {
     //	};
 
     public static void showDiff() throws IOException {
-        final PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR, "propertyDifference.txt");
+        final PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR, "propertyDifference.txt");
         try {
             showDifferences(out, "4.0.1", "LB", "GC");
             showDifferences(out, "4.0.1", "East Asian Width", "LB");
@@ -1359,7 +1359,7 @@ public class MakeUnicodeFiles {
     }
 
     public static void showAllDiff() throws IOException {
-        final PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR, "propertyDifference.txt");
+        final PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR, "propertyDifference.txt");
         try {
             final UnicodeProperty.Factory fac = ToolUnicodePropertySource.make("4.0.1");
             final List<String> props = fac.getAvailableNames(

--- a/unicodetools/org/unicode/text/UCD/QuickTest.java
+++ b/unicodetools/org/unicode/text/UCD/QuickTest.java
@@ -469,7 +469,7 @@ public class QuickTest implements UCD_Types {
         //proposed = status.getSet("Px");
         System.out.println(proposed);
         //showStatus(status);
-        final PrintWriter pw = FileUtilities.openUTF8Writer(Settings.GEN_DIR, "bidimirroring_chars.txt");
+        final PrintWriter pw = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR, "bidimirroring_chars.txt");
         showStatus(pw, status);
         pw.close();
     }

--- a/unicodetools/org/unicode/text/UCD/TernaryStore.java
+++ b/unicodetools/org/unicode/text/UCD/TernaryStore.java
@@ -58,7 +58,7 @@ public final class TernaryStore {
 
             //if (true) return;
 
-            final BufferedReader br = Utility.openReadFile(Settings.DATA_DIR + "dict/DiploFreq.txt", Utility.LATIN1);
+            final BufferedReader br = Utility.openReadFile(Settings.UnicodeTools.DATA_DIR + "dict/DiploFreq.txt", Utility.LATIN1);
             String line;
             counter = 0;
             while (counter < tests.length) {

--- a/unicodetools/org/unicode/text/UCD/TestData.java
+++ b/unicodetools/org/unicode/text/UCD/TestData.java
@@ -611,7 +611,7 @@ public class TestData implements UCD_Types {
     static PrintWriter log;
 
     public static void checkShaping() throws IOException {
-        log = FileUtilities.openUTF8Writer(Settings.GEN_DIR, "checklog.txt");
+        log = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR, "checklog.txt");
         checkProperty("Joining_Type", "Non_Joining", "Joining_Type", "Transparent");
         checkProperty("Joining_Group", "No_Joining_Group", "Joining_Type", "Transparent");
         checkProperty("Line_Break", "Unknown", "Line_Break", "Combining_Mark");

--- a/unicodetools/org/unicode/text/UCD/TestNameUniqueness.java
+++ b/unicodetools/org/unicode/text/UCD/TestNameUniqueness.java
@@ -42,8 +42,8 @@ public class TestNameUniqueness implements UCD_Types {
          * @return null when done
          */
         static String[][] files = {
-            {Settings.DATA_DIR + "", "pdam1040630.lst"},
-            {Settings.UCD_DIR + "4.1.0-Update/", "NamedCompositeEntities-4.1.0d2.txt"}
+            {Settings.UnicodeTools.DATA_DIR + "", "pdam1040630.lst"},
+            {Settings.UnicodeTools.UCD_DIR + "4.1.0-Update/", "NamedCompositeEntities-4.1.0d2.txt"}
         };
 
         public String next() {

--- a/unicodetools/org/unicode/text/UCD/TestNormalization.java
+++ b/unicodetools/org/unicode/text/UCD/TestNormalization.java
@@ -33,7 +33,7 @@ import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 
 public final class TestNormalization {
-    static final String DIR = Settings.UCD_DIR + "Update 3.0.1/";
+    static final String DIR = Settings.UnicodeTools.UCD_DIR + "Update 3.0.1/";
     static final boolean SKIP_FILE = true;
 
     static PrintWriter out = null;

--- a/unicodetools/org/unicode/text/UCD/TestUnicodeInvariants.java
+++ b/unicodetools/org/unicode/text/UCD/TestUnicodeInvariants.java
@@ -115,7 +115,7 @@ public class TestUnicodeInvariants {
 
     public static void testInvariants(String outputFile, boolean doRange) throws IOException {
         boolean showScript = false;
-        try (final PrintWriter out2 = FileUtilities.openUTF8Writer(Settings.GEN_DIR, "UnicodeTestResults." + (doHtml ? "html" : "txt"))) {
+        try (final PrintWriter out2 = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR, "UnicodeTestResults." + (doHtml ? "html" : "txt"))) {
             final StringWriter writer = new StringWriter();
             try (PrintWriter out3 = new PrintWriter(writer)) {
                 out = out3;

--- a/unicodetools/org/unicode/text/UCD/UCD.java
+++ b/unicodetools/org/unicode/text/UCD/UCD.java
@@ -1964,7 +1964,7 @@ to guarantee identifier closure.
 
     private void fillFromFile2(String version) {
         DataInputStream dataIn = null;
-        final String fileName = Settings.BIN_DIR + "UCD_Data" + version + ".bin";
+        final String fileName = Settings.Output.BIN_DIR + "UCD_Data" + version + ".bin";
         try {
             dataIn = new DataInputStream(
                     new BufferedInputStream(

--- a/unicodetools/org/unicode/text/UCD/VerifyUCD.java
+++ b/unicodetools/org/unicode/text/UCD/VerifyUCD.java
@@ -1802,7 +1802,7 @@ E0020-E007F; [TAGGING CHARACTERS]
 
     public static int verifyUTFMap(BitSet mappedOut) throws IOException {
         int errorCount = 0;
-        final BufferedReader input = new BufferedReader(new FileReader(Settings.IDN_DIR + "IDN-Mapping.txt"),32*1024);
+        final BufferedReader input = new BufferedReader(new FileReader(Settings.UnicodeTools.IDN_DIR + "IDN-Mapping.txt"),32*1024);
         String line = "";
         final Map idnFold = new TreeMap();
         final Map idnWhy = new HashMap();
@@ -1890,7 +1890,7 @@ E0020-E007F; [TAGGING CHARACTERS]
     }
 
     static BitSet getIDNList(String file) throws IOException {
-        final BufferedReader input = new BufferedReader(new FileReader(Settings.IDN_DIR + file),32*1024);
+        final BufferedReader input = new BufferedReader(new FileReader(Settings.UnicodeTools.IDN_DIR + file),32*1024);
         final BitSet result = new BitSet();
         String line;
         try {

--- a/unicodetools/org/unicode/text/tools/CheckSecurityProposals.java
+++ b/unicodetools/org/unicode/text/tools/CheckSecurityProposals.java
@@ -40,7 +40,7 @@ public class CheckSecurityProposals {
         HashMap<String, String> contributor = new HashMap<>();
 
 
-        for (String line : FileUtilities.in(Settings.UNICODETOOLS_DIRECTORY + "data/security/" + Settings.latestVersion + "/data/source/", "proposals.txt")) {
+        for (String line : FileUtilities.in(Settings.UnicodeTools.UNICODETOOLS_DIR + "data/security/" + Settings.latestVersion + "/data/source/", "proposals.txt")) {
             List<String> parts = TAB_SPLITTER.splitToList(line);
             String sourceRaw = parts.get(1);
             String source = NFD.normalize(Utility.fromHex(sourceRaw, true));

--- a/unicodetools/org/unicode/text/tools/CheckUnihan.java
+++ b/unicodetools/org/unicode/text/tools/CheckUnihan.java
@@ -19,7 +19,7 @@ public class CheckUnihan {
         final SortedSet<String> props = new TreeSet<String>();
         final Relation<String,String> values = Relation.of(new HashMap<String,Set<String>>(), HashSet.class);
         final Pattern tabSplitter = Pattern.compile("\t");
-        for (final File file : new File(Settings.UCD_DIR + "/Unihan").listFiles()) {
+        for (final File file : new File(Settings.UnicodeTools.UCD_DIR + "/Unihan").listFiles()) {
             System.out.println(file.getName());
             for (final String line : FileUtilities.in(file.getParent(), file.getName())) {
                 if (line.length() == 0 || line.startsWith("#")) {

--- a/unicodetools/org/unicode/text/tools/FindDuplicateFiles.java
+++ b/unicodetools/org/unicode/text/tools/FindDuplicateFiles.java
@@ -26,7 +26,7 @@ public class FindDuplicateFiles {
     private static Map<String,String> DIRS = new LinkedHashMap<>();
     static {
         String[] dirs = {
-                Settings.UNICODETOOLS_DIRECTORY,
+                Settings.UnicodeTools.UNICODETOOLS_DIR,
                 CLDRPaths.BASE_DIRECTORY
         };
         for (String dir : dirs) {

--- a/unicodetools/org/unicode/text/tools/IcannMsr.java
+++ b/unicodetools/org/unicode/text/tools/IcannMsr.java
@@ -37,7 +37,7 @@ import com.ibm.icu.text.UnicodeSet.EntryRange;
 import com.ibm.icu.util.ULocale;
 
 public class IcannMsr {
-    private static final String ICANN_DIR = Settings.OTHER_WORKSPACE_DIRECTORY + "DATA/icann/";
+    private static final String ICANN_DIR = Settings.Output.UNICODETOOLS_OUTPUT_DIR + "DATA/icann/";
     
     // Change these with new versions
     
@@ -168,7 +168,7 @@ public class IcannMsr {
         }
     }
 
-    private static final String SECURITY = Settings.UNICODETOOLS_DIRECTORY + "data/security/";
+    private static final String SECURITY = Settings.UnicodeTools.UNICODETOOLS_DIR + "data/security/";
 
     public static void main(String[] args) {
         // for (Entry<String, Set<IdentifierType>> x : DATA2TYPE.keyValues()) {
@@ -238,7 +238,7 @@ public class IcannMsr {
     }
 
     private static <T> void showValues(String file, UnicodeRelation<T> remap2, T skipValue) {
-        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "icann/", file)) {
+        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "icann/", file)) {
             TreeSet<T> sorted = new TreeSet<T>(remap2.values());
             for (T value : sorted) {
                 UnicodeSet set = remap2.getKeys(value);
@@ -316,7 +316,7 @@ public class IcannMsr {
     }
 
     private static void showValues(String file, UnicodeMap<Pair<Identifier_Type, Identifier_Type>> diff) {
-        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "icann/", file)) {
+        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "icann/", file)) {
             Set<Pair<Identifier_Type, Identifier_Type>> sorted = new TreeSet<>(IDPAIR);
             sorted.addAll(diff.values());
 

--- a/unicodetools/org/unicode/text/tools/ShowCharacters.java
+++ b/unicodetools/org/unicode/text/tools/ShowCharacters.java
@@ -149,7 +149,7 @@ public class ShowCharacters {
             us.add(ch);
         }
 
-        final PrintWriter log = Utility.openPrintWriter(Settings.GEN_DIR, "showChars.html", Utility.UTF8_WINDOWS);
+        final PrintWriter log = Utility.openPrintWriter(Settings.Output.GEN_DIR, "showChars.html", Utility.UTF8_WINDOWS);
         log.println("<html><body>");
         log.println("<table style='border-collapse:collapse' border='1'>");
         log.println("<tr>"

--- a/unicodetools/org/unicode/text/tools/VerifyIdna.java
+++ b/unicodetools/org/unicode/text/tools/VerifyIdna.java
@@ -111,7 +111,7 @@ public class VerifyIdna {
     }
 
     private static UnicodeMap getPatriksMapping() throws IOException {
-        final BufferedReader in = FileUtilities.openReader(Settings.DATA_DIR + "/IDN/", "draft-faltstrom-idnabis-tables-05.txt", "ascii");
+        final BufferedReader in = FileUtilities.openReader(Settings.UnicodeTools.DATA_DIR + "/IDN/", "draft-faltstrom-idnabis-tables-05.txt", "ascii");
         boolean inTable = false;
         final UnicodeMap patrik = new UnicodeMap();
         int count = 0;

--- a/unicodetools/org/unicode/text/tools/VerifyUCD.java
+++ b/unicodetools/org/unicode/text/tools/VerifyUCD.java
@@ -40,7 +40,7 @@ public class VerifyUCD {
         final String x = Default.ucd().getCase("\u0130", UCD_Types.FULL, UCD_Types.LOWER);
         final String y = Default.ucd().getCase(Default.nfd().normalize("\u0130"), UCD_Types.FULL, UCD_Types.LOWER);
 
-        Log.setLog(Settings.GEN_DIR + "verifyUCD.html");
+        Log.setLog(Settings.Output.GEN_DIR + "verifyUCD.html");
         Log.logln("<html><head><meta http-equiv='Content-Type' content='text/html; charset=utf-8'>");
         Log.logln("<title>UCD Canonical Check</title></head><body>");
         Log.getLog().println("<h2 align='right'>L2/06-386R2</h2>");

--- a/unicodetools/org/unicode/text/tools/VerifyXmlUcd.java
+++ b/unicodetools/org/unicode/text/tools/VerifyXmlUcd.java
@@ -43,7 +43,7 @@ public class VerifyXmlUcd {
     public static void main(String[] args) throws IOException {
         try {
             //checkRegex();
-            testFile(Settings.UCD_DIR + "/xml/ucd.nounihan.grouped.xml");
+            testFile(Settings.UnicodeTools.UCD_DIR + "/xml/ucd.nounihan.grouped.xml");
             // too many errors to test: testFile("C:/DATA/UCD/xml/ucd.nounihan.grouped.xml");
         } finally {
             System.out.println("DONE");

--- a/unicodetools/org/unicode/text/tools/WordFrequency.java
+++ b/unicodetools/org/unicode/text/tools/WordFrequency.java
@@ -24,7 +24,7 @@ public class WordFrequency {
     static long total;
     static {
         Splitter tab = Splitter.on("\t").trimResults();
-        for (String line : FileUtilities.in(Settings.OTHER_WORKSPACE_DIRECTORY + "data/words/", "freq.txt")) {
+        for (String line : FileUtilities.in(Settings.Output.UNICODETOOLS_OUTPUT_DIR + "data/words/", "freq.txt")) {
             List<String> list = tab.splitToList(line);
             long count = Long.parseLong(list.get(1));
             data.put(list.get(0), count);

--- a/unicodetools/org/unicode/text/utility/DirectoryIterator.java
+++ b/unicodetools/org/unicode/text/utility/DirectoryIterator.java
@@ -145,7 +145,7 @@ public class DirectoryIterator {
 
 
     static public void test() {
-        final File testDir = new File(Settings.UCD_DIR);
+        final File testDir = new File(Settings.UnicodeTools.UCD_DIR);
         DirectoryIterator di;
 
         di = new DirectoryIterator(testDir, new RootFileFilter("DerivedBinaryProperties"));

--- a/unicodetools/org/unicode/text/utility/TestUtility.java
+++ b/unicodetools/org/unicode/text/utility/TestUtility.java
@@ -195,7 +195,7 @@ public class TestUtility {
         total = testUnicodeMapSerialization(iterations, total, pname, umap);
     }
 
-    static String outdircore = Settings.GEN_DIR + "UCD_Data/";
+    static String outdircore = Settings.Output.GEN_DIR + "UCD_Data/";
     static String outdir = outdircore + "4.1.0/";
     /**
      * @param pname

--- a/unicodetools/org/unicode/text/utility/Utility.java
+++ b/unicodetools/org/unicode/text/utility/Utility.java
@@ -902,7 +902,7 @@ public final class Utility implements UCD_Types {    // COMMON UTILITIES
      */
 
     public static PrintWriter openPrintWriterGenDir(String filename, Encoding options) {
-	return openPrintWriter(Settings.GEN_DIR, filename, options);
+	return openPrintWriter(Settings.Output.GEN_DIR, filename, options);
     }
 
     public static PrintWriter openPrintWriter(String filename, Encoding options) {
@@ -937,7 +937,7 @@ public final class Utility implements UCD_Types {    // COMMON UTILITIES
     }
 
     public static String getOutputName(String filename) {
-	return Settings.GEN_DIR + filename;
+	return Settings.Output.GEN_DIR + filename;
     }
 
     public static void print(PrintWriter pw, Collection c, String separator) {
@@ -1336,11 +1336,11 @@ public final class Utility implements UCD_Types {    // COMMON UTILITIES
 			return null;
 		    }
 		}
-		String directoryName = Settings.DATA_DIR + base + "/" + element + "/";
+		String directoryName = Settings.UnicodeTools.DATA_DIR + base + "/" + element + "/";
 		result = directoryName + parts[2] + fileType;
 		break;
 	    }
-	    String directoryName = Settings.UCD_DIR + element + "-Update" + File.separator;
+	    String directoryName = Settings.UnicodeTools.UCD_DIR + element + "-Update" + File.separator;
 	    result = searchDirectory(new File(directoryName), filename, show, fileType);
 	    if (result != null) {
 		break;
@@ -1353,7 +1353,7 @@ public final class Utility implements UCD_Types {    // COMMON UTILITIES
 	    }
 	}
 	if (show && !tries.isEmpty()) {
-	    System.out.println("\tTried: '" + Settings.UCD_DIR + File.separator + "("
+	    System.out.println("\tTried: '" + Settings.UnicodeTools.UCD_DIR + File.separator + "("
 		    + CollectionUtilities.join(tries, "|") + ")-Update"
 		    + File.separator + filename + "*" + fileType + "'");
 	}

--- a/unicodetools/org/unicode/text/utility/testParser.java
+++ b/unicodetools/org/unicode/text/utility/testParser.java
@@ -24,7 +24,7 @@ import com.ibm.icu.text.UTF16;
 
 
 public class testParser implements XMLParseTypes {
-    public static final String BASE_DIR = Settings.UCD_DIR + "/UNIDATA 3.0.1/";
+    public static final String BASE_DIR = Settings.UnicodeTools.UCD_DIR + "/UNIDATA 3.0.1/";
     public static final boolean VERBOSE = false;
 
     private static final String testFile = BASE_DIR + "UCD-Main.xml"; // "test.xml"; // BASE_DIR + "UCD-Main.xml";

--- a/unicodetools/org/unicode/tools/Confusables.java
+++ b/unicodetools/org/unicode/tools/Confusables.java
@@ -354,7 +354,7 @@ public class Confusables {
     public static void main(String[] args) throws IOException {
         final String SECURITY_PUBLIC = Settings.UNICODE_DRAFT_PUBLIC + "security/";
         final Confusables CONFUSABLES = new Confusables(SECURITY_PUBLIC + Settings.latestVersion);
-        try (PrintWriter pw = FileUtilities.openUTF8Writer(Settings.GEN_UCD_DIR, "confusablesWholeScript.txt")) {
+        try (PrintWriter pw = FileUtilities.openUTF8Writer(Settings.Output.GEN_UCD_DIR, "confusablesWholeScript.txt")) {
             CONFUSABLES.print(pw);
             pw.flush();
         }

--- a/unicodetools/org/unicode/tools/DraftUtils.java
+++ b/unicodetools/org/unicode/tools/DraftUtils.java
@@ -12,6 +12,6 @@ public class DraftUtils {
     /**
      * This actually refers into the unicodetools project.
      */
-    public static final String UCD_DIRECTORY = Settings.UCD_DIR + "/" + Settings.latestVersion + "-Update";
+    public static final String UCD_DIRECTORY = Settings.UnicodeTools.UCD_DIR + "/" + Settings.latestVersion + "-Update";
 
 }

--- a/unicodetools/org/unicode/tools/FixedProps.java
+++ b/unicodetools/org/unicode/tools/FixedProps.java
@@ -358,10 +358,10 @@ public class FixedProps {
                 literalTemp.put(s, newValue + "\t;\t" + dtv.getShortName());
            }
 
-            try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "fixed/", "FixedNfkd.txt")) {
+            try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "fixed/", "FixedNfkd.txt")) {
                 showmap(out, FixedNfkd.changes, temp, literalTemp);
             }
-            try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "fixed/", "FixedNfkdDiff.txt")) {
+            try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "fixed/", "FixedNfkdDiff.txt")) {
                 showmap(out, diff.keySet(), diff, literalDiff);
             }
         }
@@ -377,10 +377,10 @@ public class FixedProps {
                     diff.put(s, oldValue.getShortName() + "\t≠\t" + newValue.getShortName());
                 }
             }
-            try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "fixed/", "FixedGc.txt")) {
+            try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "fixed/", "FixedGc.txt")) {
                 showmap(out, FixedGeneralCategory.changes, FixedGeneralCategory.generalCategoryRev, FixedGeneralCategory.generalCategoryRev);
             }
-            try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "fixed/", "FixedGcDiff.txt")) {
+            try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "fixed/", "FixedGcDiff.txt")) {
                 showmap(out, diff.keySet(), diff, diff);
             }
         }
@@ -396,10 +396,10 @@ public class FixedProps {
                     diff.put(s, oldValue + "\t≠\t" + newValue);
                 }
             }
-            try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "fixed/", "FixedScx.txt")) {
+            try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "fixed/", "FixedScx.txt")) {
                 showmap(out, FixedScriptExceptions.changes, FixedScriptExceptions.scriptRev, FixedScriptExceptions.scriptRev);
             }
-            try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "fixed/", "FixedScxDiff.txt")) {
+            try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "fixed/", "FixedScxDiff.txt")) {
                 showmap(out, diff.keySet(), diff, diff);
             }
         }

--- a/unicodetools/org/unicode/tools/GenerateNormalizeForMatch.java
+++ b/unicodetools/org/unicode/tools/GenerateNormalizeForMatch.java
@@ -48,7 +48,7 @@ import com.ibm.icu.text.UnicodeSet.EntryRange;
 
 public class GenerateNormalizeForMatch {
 
-    private static final String dir = Settings.BASE_DIRECTORY + "Google Drive/workspace/DATA/frequency/";
+    private static final String dir = Settings.CLDR.BASE_DIRECTORY + "Google Drive/workspace/DATA/frequency/";
     private static final String GOOGLE_FOLDING_TXT = "google_folding.txt";
     private static final Pattern SPACES = Pattern.compile("[,\\s]+");
 
@@ -110,7 +110,7 @@ public class GenerateNormalizeForMatch {
     private static final UnicodeMap<Set<SpecialReason>> REASONS = new UnicodeMap<>();
     private static final UnicodeMap<Set<SpecialReason>> REASONS_BASE = new UnicodeMap<>();
     private static final NormalizeForMatch ADDITIONS_TO_NFKCCF = NormalizeForMatch.load(null, "XNFKCCF-Curated.txt", true);
-    private static final NormalizeForMatch ADDITIONS_TO_NFKC = NormalizeForMatch.load(Settings.UNICODETOOLS_DIRECTORY + "data/cldr/", "NFXC-Curated.txt", true);
+    private static final NormalizeForMatch ADDITIONS_TO_NFKC = NormalizeForMatch.load(Settings.UnicodeTools.UNICODETOOLS_DIR + "data/cldr/", "NFXC-Curated.txt", true);
 
 
     private static final UnicodeSet HANGUL_COMPAT_minus_DI_CN 
@@ -210,7 +210,7 @@ public class GenerateNormalizeForMatch {
         NormalizeForMatch curated = NormalizeForMatch.load(null, "XNFKCCF-Curated.txt", true);
         
         showSimpleData(curated.getSourceToTarget(), curated.getSourceToReason(), "XNFKCCF-Curated.txt", "# Curated file of exceptions", null);
-        NormalizeForMatch newCurated = NormalizeForMatch.load(Settings.DATA_DIR + "n4m/9.0.0/", "XNFKCCF-Curated.txt", true);
+        NormalizeForMatch newCurated = NormalizeForMatch.load(Settings.UnicodeTools.DATA_DIR + "n4m/9.0.0/", "XNFKCCF-Curated.txt", true);
         checkNewCurated(curated, newCurated);
         //    private static final NormalizeForMatch ADDITIONS_TO_NFKCCF = NormalizeForMatch.load("XNFKCCF-Curated.txt");
 
@@ -264,7 +264,7 @@ public class GenerateNormalizeForMatch {
     }
 
     private static void compareTrial(boolean ucaOnly) throws IOException {
-        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "n4m/", "XNFKCCF" + (ucaOnly ? "-comp-uca" : "-comp")
+        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "n4m/", "XNFKCCF" + (ucaOnly ? "-comp-uca" : "-comp")
                 + ".txt")) {
             UnicodeSet interest = new UnicodeSet(N4M.keySet())
             .addAll(TRIAL.keySet())
@@ -418,7 +418,7 @@ public class GenerateNormalizeForMatch {
 
     private static <T> void showSimpleData(UnicodeMap<String> mapping, UnicodeMap<T> reasons2, String filename, String header, 
             UnicodeMap<String> skipIfSame) throws IOException {
-        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "n4m/", filename)) {
+        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "n4m/", filename)) {
             out.println(header);
             out.println("# Source; \tTarget; \tOther; \tReason(s); \tComments");
             UnicodeSet trialWithoutReason = new UnicodeSet(mapping.keySet()).removeAll(reasons2.keySet());

--- a/unicodetools/org/unicode/tools/GeneratePickerData.java
+++ b/unicodetools/org/unicode/tools/GeneratePickerData.java
@@ -161,7 +161,7 @@ class GeneratePickerData {
     final static Options myOptions = new Options();
 
     enum MyOptions {
-        output(".*", Settings.GEN_DIR + "picker/", "output data directory"),
+        output(".*", Settings.Output.GEN_DIR + "picker/", "output data directory"),
         unicodedata(".*", DraftUtils.UCD_DIRECTORY, "Unicode Data directory"),
         verbose(null, null, "verbose debugging messages"),
         korean(null, null, "generate korean hangul defectives instead"), ;

--- a/unicodetools/org/unicode/tools/Ids.java
+++ b/unicodetools/org/unicode/tools/Ids.java
@@ -713,7 +713,7 @@ public class Ids {
         }
 
         static void listSpecials() throws IOException {
-            try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "ids/", "specials.html");
+            try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "ids/", "specials.html");
                     ) {
                 showHeader(out);
                 out.println("<tr><td>" + "key"
@@ -811,7 +811,7 @@ public class Ids {
 
     private static void showRadicalMissing() throws IOException {
         // Relation<List<CpPart>, String> invert = Relation.of(new HashMap(), HashSet.class);
-        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "ids/", "radicalMissing.html");
+        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "ids/", "radicalMissing.html");
                 ) {
             showHeader(out);     
             int count = 0;
@@ -878,7 +878,7 @@ public class Ids {
     }
 
     static void showParseErrors(M3<String, String, String> problems, String fileName) throws IOException {
-        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "ids/", fileName);
+        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "ids/", fileName);
                 ) {
             showHeader(out);
             out.println("<tr><th>Count</th><th>Reason for failure</th><th>Source</th><th>IDS</th><th>Source Radical + RS(.0)</th><th>Source RS</th></tr>");
@@ -920,7 +920,7 @@ public class Ids {
 
     private static void showRadicalCompare() throws IOException {
 
-        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "ids/", "radicalCompare.html");
+        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "ids/", "radicalCompare.html");
                 ) {
             showHeader(out);
             Map<Double, R2<Set<String>,Set<String>>> sorted = new TreeMap<>();
@@ -984,7 +984,7 @@ public class Ids {
 
     private static void showRadicalCompareTxt() throws IOException {
 
-        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "ids/", "radicalCompare.txt");
+        try (PrintWriter out = FileUtilities.openUTF8Writer(orgSettings.Output.GEN_DIR + "ids/", "radicalCompare.txt");
                 ) {
             out.println("# Additional Radical Mappings (beyond CJKRadicals.txt)\n"
                     + "#\n"
@@ -1137,7 +1137,7 @@ public class Ids {
                     showFooter(out);
                     out.close();
                 }
-                out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "ids/", "ids" + type + fileCount + ".html");
+                out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "ids/", "ids" + type + fileCount + ".html");
                 oldFileCount = fileCount;
                 showHeader(out);
                 out.println("<tr><th>Count</th><th>Source</th><th>IDS App. Pos.</th><th>IDS</th><th>App. Pos.</th></tr>");
@@ -1150,7 +1150,7 @@ public class Ids {
     }
 
     private static void showConfusables() throws IOException {
-        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "ids/", "cjkConfusableCandidates.txt");
+        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "ids/", "cjkConfusableCandidates.txt");
                 ) {
             Relation<String,String> invert = Relation.of(new TreeMap<String,Set<String>>(), TreeSet.class, UNIHAN);
             for (EntryRange<CharacterIds> entry : IDS_RECURSIVE.entryRanges()) {
@@ -1264,7 +1264,7 @@ public class Ids {
         CharacterIds [] biggest = new CharacterIds[50];
         Counter<Integer> counter = new Counter<>();
 
-        for (String line : FileUtilities.in(Settings.OTHER_WORKSPACE_DIRECTORY + "DATA/ids/", SOURCE_IDS)) {
+        for (String line : FileUtilities.in(Settings.Output.UNICODETOOLS_OUTPUT_DIR + "DATA/ids/", SOURCE_IDS)) {
             // U+3FCD 㿍 ⿸疒解
             if (line.startsWith("#") || line.startsWith(";")) {
                 line = line.substring(1).trim();
@@ -1379,7 +1379,7 @@ public class Ids {
     private static Map<String,String> getMacros() {
         Relation<String,String> temp = Relation.of(new HashMap(), HashSet.class);
         // fetch the data
-        for (String line : FileUtilities.in(Settings.OTHER_WORKSPACE_DIRECTORY + "DATA/ids/", SOURCE_IDS)) {
+        for (String line : FileUtilities.in(Settings.Output.UNICODETOOLS_OUTPUT_DIR + "DATA/ids/", SOURCE_IDS)) {
             // CDP-8DA8 &CDP-8DA8;  ⿻廿木 ⿱丗木 ⿱𠀍木
             // U+3022   〢   ⿰丨丨
             // CDP-8DBA    &CDP-8DBA;  &CDP-8DBA;

--- a/unicodetools/org/unicode/tools/IdsFileData.java
+++ b/unicodetools/org/unicode/tools/IdsFileData.java
@@ -25,7 +25,7 @@ public class IdsFileData {
     public static final UnicodeMap<List<Integer>> TOTAL_STROKES = new UnicodeMap<>();
 
     static {
-        for (String line : FileUtilities.in(Settings.OTHER_WORKSPACE_DIRECTORY, "/DATA/ids/ucs-strokes.txt")) {
+        for (String line : FileUtilities.in(Settings.Output.UNICODETOOLS_OUTPUT_DIR, "/DATA/ids/ucs-strokes.txt")) {
             if (line.isEmpty()) {
                 continue;
             }

--- a/unicodetools/org/unicode/tools/NormalizeForMatchDiff.java
+++ b/unicodetools/org/unicode/tools/NormalizeForMatchDiff.java
@@ -14,7 +14,7 @@ public class NormalizeForMatchDiff {
         NormalizeForMatch sourceDirectory = NormalizeForMatch.load(
                 null,"XNFKCCF-Curated.txt");
         NormalizeForMatch dir90 = NormalizeForMatch.load(
-                Settings.DATA_DIR + "n4m/9.0.0/", "XNFKCCF-Curated.txt");
+                Settings.UnicodeTools.DATA_DIR + "n4m/9.0.0/", "XNFKCCF-Curated.txt");
         NormalizeForMatch gen = NormalizeForMatch.load(
                 "/Users/markdavis/Google Drive/workspace/Generated/n4m/", "XNFKCCF-Curated.txt");
                 

--- a/unicodetools/org/unicode/tools/Segmenter.java
+++ b/unicodetools/org/unicode/tools/Segmenter.java
@@ -1237,7 +1237,7 @@ public class Segmenter {
 	for (int i = 0; i < cannedRules.length; ++i) {
 	    String type = cannedRules[i][0];
 	    boolean hadHash = false;
-	    try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "segmentation/", type + "Rules.txt")) {
+	    try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "segmentation/", type + "Rules.txt")) {
 		out.println("# Segmentation rules for " + type);
 		out.println("#");
 		out.println("# Character Classes");
@@ -1260,7 +1260,7 @@ public class Segmenter {
 	    }
 	}
 
-	try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "cldr/segmentation/", "rootAddon.xml")) {
+	try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "cldr/segmentation/", "rootAddon.xml")) {
 	    out.println("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
 		    + "<!DOCTYPE ldml SYSTEM \"../../common/dtd/ldml.dtd\">\n"
 		    + "<!--\n"

--- a/unicodetools/org/unicode/tools/emoji/CarrierGlyphs.java
+++ b/unicodetools/org/unicode/tools/emoji/CarrierGlyphs.java
@@ -46,7 +46,7 @@ public class CarrierGlyphs {
         carrier.addAll(Emoji_KDDI.keySet());
         carrier.addAll(Emoji_DCM.keySet());
         carrier.addAll(Emoji_SB.keySet());
-        PrintWriter out = FileUtilities.openUTF8Writer(Settings.SVN_WORKSPACE_DIRECTORY
+        PrintWriter out = FileUtilities.openUTF8Writer(Settings.UnicodeTools.UNICODETOOLS_REPO_DIR
                 + "/reports/tr51/", "carrier-emoji.html");
         out.println("<html>\n" +
                 "<head>\n" +
@@ -96,7 +96,7 @@ public class CarrierGlyphs {
         if (code == null) {
             return "";
         }
-        final String dir = Settings.SVN_WORKSPACE_DIRECTORY + "/reports/tr51/";
+        final String dir = Settings.UnicodeTools.UNICODETOOLS_REPO_DIR + "/reports/tr51/";
         final String filename = "images/"
                 + type
                 + "/" 

--- a/unicodetools/org/unicode/tools/emoji/Emoji.java
+++ b/unicodetools/org/unicode/tools/emoji/Emoji.java
@@ -188,8 +188,8 @@ public class Emoji {
     public static final String DATA_DIR_PRODUCTION_BASE = "https://unicode.org/Public/emoji/";
     public static final String DATA_DIR_PRODUCTION = DATA_DIR_PRODUCTION_BASE + VERSION_STRING + "/";
 
-    public static final String IMAGES_SOURCE_DIR_SVG = Settings.UNICODETOOLS_DIRECTORY + "data/images/";
-    public static final String IMAGES_OUTPUT_DIR = Settings.UNICODETOOLS_DIRECTORY + "../../images/emoji/";
+    public static final String IMAGES_SOURCE_DIR_SVG = Settings.UnicodeTools.UNICODETOOLS_DIR + "data/images/";
+    public static final String IMAGES_OUTPUT_DIR = Settings.UnicodeTools.UNICODETOOLS_DIR + "../../images/emoji/";
 
     public enum ModifierStatus {
 	none, modifier, modifier_base;
@@ -837,7 +837,7 @@ public class Emoji {
 		return output;
 	    }
 
-	    static final String INTERNAL_OUTPUT_DIR = Settings.OTHER_WORKSPACE_DIRECTORY + "Generated/emoji/" + VERSION_TO_GENERATE + "/";
+	    static final String INTERNAL_OUTPUT_DIR = Settings.Output.UNICODETOOLS_OUTPUT_DIR + "Generated/emoji/" + VERSION_TO_GENERATE + "/";
 	    public static final String HEALTHCARE = "⚕";
 	    public static final String UN = "🇺🇳";
 

--- a/unicodetools/org/unicode/tools/emoji/EmojiData.java
+++ b/unicodetools/org/unicode/tools/emoji/EmojiData.java
@@ -170,7 +170,7 @@ public class EmojiData implements EmojiDataSource {
 		Emoji.EMOJI_VARIANT_STRING + Emoji.KEYCAP_MARK_STRING, };
 
 	this.version = version;
-	final String directory = Settings.DATA_DIR + "emoji/" + version.getVersionString(2, 4);
+	final String directory = Settings.UnicodeTools.DATA_DIR + "emoji/" + version.getVersionString(2, 4);
 	UnicodeRelation<EmojiProp> emojiData = new UnicodeRelation<>();
 
 	boolean oldFormat = version.compareTo(Emoji.VERSION2) < 0;

--- a/unicodetools/org/unicode/tools/emoji/EmojiFlagOrder.java
+++ b/unicodetools/org/unicode/tools/emoji/EmojiFlagOrder.java
@@ -281,7 +281,7 @@ public class EmojiFlagOrder {
 
     public static String getFile(String s) {
         String core = Emoji.buildFileName(s,"_");
-        return Settings.OTHER_WORKSPACE_DIRECTORY + "DATA/emoji_images/country-flags/ref_" +
+        return Settings.Output.UNICODETOOLS_OUTPUT_DIR + "DATA/emoji_images/country-flags/ref_" +
         core +
         ".png";
     }

--- a/unicodetools/org/unicode/tools/emoji/EmojiFrequencyOld.java
+++ b/unicodetools/org/unicode/tools/emoji/EmojiFrequencyOld.java
@@ -27,7 +27,7 @@ public class EmojiFrequencyOld {
     static long total;
     static {
         Matcher m = Pattern.compile("id=\"score-(\\p{XDigit}+)(-\\p{XDigit}+)?\">(\\d+)</span>").matcher("");
-        for (String line : FileUtilities.in(Settings.OTHER_WORKSPACE_DIRECTORY + "data/frequency/emoji/", "emoji-tracker.txt")) {
+        for (String line : FileUtilities.in(Settings.Output.UNICODETOOLS_OUTPUT_DIR + "data/frequency/emoji/", "emoji-tracker.txt")) {
             if (line.startsWith("<section")) {
                 continue;
             }

--- a/unicodetools/org/unicode/tools/emoji/EmojiLinkAdder.java
+++ b/unicodetools/org/unicode/tools/emoji/EmojiLinkAdder.java
@@ -12,7 +12,7 @@ public class EmojiLinkAdder {
 
     public static void main(String[] args) {
         if (args.length == 0) {
-            args = new String[] {Settings.SVN_WORKSPACE_DIRECTORY + "/reports/tr51/pri294-emoji-image-backgroundA.html"};  
+            args = new String[] {Settings.UnicodeTools.UNICODETOOLS_REPO_DIR + "/reports/tr51/pri294-emoji-image-backgroundA.html"};  
         }
         Matcher m = TO_FIX.matcher("");
 

--- a/unicodetools/org/unicode/tools/emoji/EmojiOrder.java
+++ b/unicodetools/org/unicode/tools/emoji/EmojiOrder.java
@@ -21,7 +21,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.util.MapComparator;
 import org.unicode.cldr.util.MultiComparator;
-//import org.unicode.text.UCA.UCA;
 import org.unicode.text.utility.Settings;
 import org.unicode.text.utility.Utility;
 
@@ -264,7 +263,7 @@ public class EmojiOrder {
 		Output<Set<String>> lastLabel = new Output<Set<String>>(new TreeSet<String>());
 		MajorGroup majorGroup = null;
 		EmojiIterator ei = new EmojiIterator(emojiData, false);
-		final String directory = Settings.DATA_DIR + "/emoji/" + version.getVersionString(2, 2) + "/source";
+		final String directory = Settings.UnicodeTools.DATA_DIR + "/emoji/" + version.getVersionString(2, 2) + "/source";
 		int lineCounter = 0;
 
 		for (String line : FileUtilities.in(EmojiOrder.class,

--- a/unicodetools/org/unicode/tools/emoji/EmojiRename.java
+++ b/unicodetools/org/unicode/tools/emoji/EmojiRename.java
@@ -13,7 +13,7 @@ import com.ibm.icu.text.Transform;
 
 public class EmojiRename {
     static final boolean NO_ACTION = false;
-    static final File DIR = new File(Settings.OTHER_WORKSPACE_DIRECTORY + "DATA/emoji_images_source");
+    static final File DIR = new File(Settings.Output.UNICODETOOLS_OUTPUT_DIR + "DATA/emoji_images_source");
     static final Splitter DOT = Splitter.on('.');
     static final Splitter UNDERBAR = Splitter.on('_');
     static final Splitter DASH = Splitter.on('-');

--- a/unicodetools/org/unicode/tools/emoji/FixEmojiText.java
+++ b/unicodetools/org/unicode/tools/emoji/FixEmojiText.java
@@ -31,7 +31,7 @@ public class FixEmojiText {
 
     private static void process(String arg) {
         try (
-                PrintWriter out = FileUtilities.openUTF8Writer(Settings.OTHER_WORKSPACE_DIRECTORY, "Generated/images/listing.html")
+                PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.UNICODETOOLS_OUTPUT_DIR, "Generated/images/listing.html")
                 ) {
             out.println("<html><body><p>");
             StringBuilder result = new StringBuilder();
@@ -54,7 +54,7 @@ public class FixEmojiText {
         }
     }
 
-    static final String DATA_SOURCE = Settings.OTHER_WORKSPACE_DIRECTORY + "DATA/emoji_images/";
+    static final String DATA_SOURCE = Settings.Output.UNICODETOOLS_OUTPUT_DIR + "DATA/emoji_images/";
 
     private static void process2(String cp, StringBuilder result) {
         if (EmojiData.EMOJI_DATA.getChars().contains(cp)) {

--- a/unicodetools/org/unicode/tools/emoji/GenerateMissingAnnotations.java
+++ b/unicodetools/org/unicode/tools/emoji/GenerateMissingAnnotations.java
@@ -179,7 +179,7 @@ public class GenerateMissingAnnotations {
         Set<String> locales = StandardCodes.make().getLocaleCoverageLocales(Organization.google, EnumSet.of(Level.MODERN));
 
 
-        final String emojiDir = Settings.GEN_DIR + "emoji/";
+        final String emojiDir = Settings.Output.GEN_DIR + "emoji/";
         final String annotationDir = emojiDir + "annotations-v4.0/";
         try (PrintWriter out = FileUtilities.openUTF8Writer(emojiDir, "images.txt")) {
             for (String s : SORTED_EMOJI) {

--- a/unicodetools/org/unicode/tools/emoji/GenerateOldestAnnotations.java
+++ b/unicodetools/org/unicode/tools/emoji/GenerateOldestAnnotations.java
@@ -44,7 +44,7 @@ public class GenerateOldestAnnotations {
     static final Set<String> SORTED_EMOJI_CHARS_SET
     = EmojiOrder.sort(EmojiOrder.STD_ORDER.codepointCompare, english.map.keySet());
 
-    public static String dir = Settings.OTHER_WORKSPACE_DIRECTORY + "DATA/emoji/annotations/";
+    public static String dir = Settings.Output.UNICODETOOLS_OUTPUT_DIR + "DATA/emoji/annotations/";
 
     public static void main(String[] args) throws IOException {
         if (false) showSimple();
@@ -93,7 +93,7 @@ public class GenerateOldestAnnotations {
     }
 
     private static void printText(OldAnnotationData data) throws IOException {
-        try (PrintWriter outText = FileUtilities.openUTF8Writer(Settings.OTHER_WORKSPACE_DIRECTORY + "Generated/emoji/tts/", data.locale + ".tsv")) {
+        try (PrintWriter outText = FileUtilities.openUTF8Writer(Settings.Output.UNICODETOOLS_OUTPUT_DIR + "Generated/emoji/tts/", data.locale + ".tsv")) {
             //#Code Image   TTS English TTS German  Annotations English Annotations German  Comments    INTERNAL
             //U+1F600   =vlookup(A2,Internal!A:B,2,0)   grinning face   Lachender Smiley    face; grin  Lachender Smiley; Gesicht; lustig; lol       
             int line = 1;

--- a/unicodetools/org/unicode/tools/emoji/GmailEmoji.java
+++ b/unicodetools/org/unicode/tools/emoji/GmailEmoji.java
@@ -172,7 +172,7 @@ U+2711 => U+2712
         final Splitter semi = Splitter.on("\t").trimResults();
         Data google = null;
         Data crab = null;
-        for (String line : FileUtilities.in(Settings.OTHER_WORKSPACE_DIRECTORY + "/data/emoji_images", "gmail_emoji.txt")) {
+        for (String line : FileUtilities.in(Settings.Output.UNICODETOOLS_OUTPUT_DIR + "/data/emoji_images", "gmail_emoji.txt")) {
             if (line.startsWith("#")) continue;
             List<String> list = semi.splitToList(line);
             Data data = new Data(list);

--- a/unicodetools/org/unicode/tools/emoji/ListFonts.java
+++ b/unicodetools/org/unicode/tools/emoji/ListFonts.java
@@ -30,7 +30,7 @@ public class ListFonts {
         System.out.print("#fonts:\t" + fonts.length);
         UnicodeRelation<String> fontsForChars = new UnicodeRelation<>();
         UnicodeSet ascii = new UnicodeSet("[:ascii:]").freeze();
-        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "fonts", "fontContents.txt")) {
+        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "fonts", "fontContents.txt")) {
             for ( int i = 0; i < fonts.length; i++ ) {
                 Font font = new Font(fonts[i],0,24);
                 UnicodeSet uset = checkCanDisplay(font);
@@ -58,7 +58,7 @@ public class ListFonts {
             }
         }
 
-        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "fonts", "fontContentsMissing.txt")) {
+        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "fonts", "fontContentsMissing.txt")) {
             for (String value : missingForScripts.values()) {
                 UnicodeSet us = missingForScripts.getKeys(value);
                 out.println(value + "\t" + us.toPattern(false));
@@ -66,7 +66,7 @@ public class ListFonts {
         }
 
         System.out.println("#Missing:\t" + missing.size());
-        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "fonts", "fontContentsMissingByChar.txt")) {
+        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "fonts", "fontContentsMissingByChar.txt")) {
             for (Entry<String, Set<String>> entry : missingForScripts.keyValues()) {
                 String cp = entry.getKey();
                 out.println("U+" + Utility.hex(cp, ", U+") + "\t" + UCharacter.getName(cp,", ") + "\t" + CollectionUtilities.join(entry.getValue(), "; "));
@@ -75,7 +75,7 @@ public class ListFonts {
         
 
         System.out.println("#found:\t" + found.size());
-        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.GEN_DIR + "fonts", "fontContentsByChar.txt")) {
+        try (PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.GEN_DIR + "fonts", "fontContentsByChar.txt")) {
             for (Entry<String, Set<String>> entry : fontsForChars.keyValues()) {
                 String cp = entry.getKey();
                 out.println("U+" + Utility.hex(cp, ", U+") + "\t" + UCharacter.getName(cp,", ") + "\t" + CollectionUtilities.join(entry.getValue(), "; "));

--- a/unicodetools/org/unicode/tools/emoji/LoadImage.java
+++ b/unicodetools/org/unicode/tools/emoji/LoadImage.java
@@ -157,8 +157,8 @@ public class LoadImage extends Component {
     static final UnicodeSet OLD_TWITTER_CHARS = new UnicodeSet(
             "[©®‼⁉™ℹ↔-↙↩↪⌚⌛⏩-⏬⏰⏳Ⓜ▪▫▶◀◻-◾☀☁☎☑☔☕☝☺♈-♓♠♣♥♦♨♻♿⚓⚠⚡⚪⚫⚽⚾⛄⛅⛎⛔⛪⛲⛳⛵⛺⛽✂✅✈-✌✏✒✔✖✨✳✴❄❇❌❎❓-❕❗❤➕-➗➡➰➿⤴⤵⬅-⬇⬛⬜⭐⭕〰〽㊗㊙🀄🃏🅰🅱🅾🅿🆎🆑-🆚🇦-🇿🈁🈂🈚🈯🈲-🈺🉐🉑🌀-🌠🌰-🌵🌷-🍼🎀-🎓🎠-🏄🏆-🏊🏠-🏰🐀-🐾👀👂-📷📹-📼🔀-🔽🕐-🕧🗻-🙀🙅-🙏🚀-🛅{#⃣}{0⃣}{1⃣}{2⃣}{3⃣}{4⃣}{5⃣}{6⃣}{7⃣}{8⃣}{9⃣}{🇨🇳}{🇩🇪}{🇪🇸}{🇫🇷}{🇬🇧}{🇮🇹}{🇯🇵}{🇰🇷}{🇷🇺}{🇺🇸}]");
 
-    static String inputDir = Settings.OTHER_WORKSPACE_DIRECTORY + "DATA/emoji_images/";
-    static String outputDir = Settings.OTHER_WORKSPACE_DIRECTORY + "Generated/images/";
+    static String inputDir = Settings.Output.UNICODETOOLS_OUTPUT_DIR + "DATA/emoji_images/";
+    static String outputDir = Settings.Output.UNICODETOOLS_OUTPUT_DIR + "Generated/images/";
 
     public static void main(String[] args) throws IOException {
 	
@@ -723,7 +723,7 @@ public class LoadImage extends Component {
 
     public static void doTwitter(String inputDir, String outputDir)
             throws IOException {
-        String inputDirectory = Settings.OTHER_WORKSPACE_DIRECTORY + "Generated/twemoji/72x72/";
+        String inputDirectory = Settings.Output.UNICODETOOLS_OUTPUT_DIR + "Generated/twemoji/72x72/";
         UnicodeSet twitterChars = new UnicodeSet();
         for (File file : new File(inputDirectory).listFiles()) {
             if (file.isDirectory()) {
@@ -1198,7 +1198,7 @@ public class LoadImage extends Component {
             return null;
         }
         public static void makeTest() throws IOException {
-            PrintWriter out = FileUtilities.openUTF8Writer(Settings.OTHER_WORKSPACE_DIRECTORY + "temp/", "tarot.html");
+            PrintWriter out = FileUtilities.openUTF8Writer(Settings.Output.UNICODETOOLS_OUTPUT_DIR + "temp/", "tarot.html");
             out.println("<html><body><table>");
             for (TarotSuits x : values()) {
                 int counter = x.start;

--- a/unicodetools/org/unicode/unittest/TestIdnaTest.java
+++ b/unicodetools/org/unicode/unittest/TestIdnaTest.java
@@ -54,7 +54,7 @@ public class TestIdnaTest extends TestFmwkPlus{
         super.init();
         TEST_DIR = getProperty("DIR");
         if (TEST_DIR == null) {
-            TEST_DIR = Settings.UNICODETOOLS_DIRECTORY + "data/idna/" + Default.ucdVersion();
+            TEST_DIR = Settings.UnicodeTools.UNICODETOOLS_DIR + "data/idna/" + Default.ucdVersion();
         } else if (TEST_DIR.equalsIgnoreCase("DRAFT")) {
             TEST_DIR = GenerateIdna.GEN_IDNA_DIR;
         }

--- a/unicodetools/org/unicode/unused/GenerateUcaDecompositions.java
+++ b/unicodetools/org/unicode/unused/GenerateUcaDecompositions.java
@@ -118,7 +118,7 @@ public class GenerateUcaDecompositions {
     public static void compareUcaDecomp() {
         final UnicodeMap<String> kensDecomp = new UnicodeMap();
         final UnicodeMap<String> kensDecompType = new UnicodeMap();
-        for (final String line : FileUtilities.in(Settings.BASE_DIRECTORY + "Documents/indigo/" +
+        for (final String line : FileUtilities.in(Settings.CLDR.BASE_DIRECTORY + "Documents/indigo/" +
         		"DATA/UCA/6.2.0/","decomps-6.2.0.txt")) {
             final String[] parts = FileUtilities.cleanSemiFields(line);
             if (parts == null) {


### PR DESCRIPTION
Groups related path variables into nested subclasses. Makes relationships clearer. Also defers fetching an environment variable until needed, which allows us to fail with an exception when a required path is not specified.

Renames path variables and environment variables to be clearer. *Everyone will need to adjust their environment variables after this change.*

Reduces the number of path environment variables: 1 per repo + 1 for output