### PR TITLE
UCA 14 delta 13

### DIFF
--- a/c/uca/sifter/unidata.txt
+++ b/c/uca/sifter/unidata.txt
@@ -1,5 +1,5 @@
 # unidata-14.0.0.txt
-# Date: 2021-06-07, 00:00:00 GMT [KW]
+# Date: 2021-07-10, 00:00:00 GMT [KW]
 # © 2021 Unicode®, Inc.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #
@@ -10,7 +10,7 @@
 # the Unicode Collation Algorithm.
 #
 # Version 14.0.0 draft 12 (Unicode Version: 14.0.0)
-# based on Unicode data file UnicodeData-14.0.0d12.txt
+# based on Unicode data file UnicodeData-14.0.0d13.txt
 # Ordering for Unicode 14.0
 #
 # Fields:
@@ -19893,12 +19893,12 @@ AB06;ETHIOPIC SYLLABLE TTHO;Lo;;;;;;
 
 1E7E8;ETHIOPIC SYLLABLE GURAGE HHWA;Lo;;;;;;
 12C0;ETHIOPIC SYLLABLE KXWA;Lo;;;;;;
-1E7E9;ETHIOPIC SYLLABLE HWI;Lo;;;;;;
+1E7E9;ETHIOPIC SYLLABLE HHWI;Lo;;;;;;
 12C2;ETHIOPIC SYLLABLE KXWI;Lo;;;;;;
 12C3;ETHIOPIC SYLLABLE KXWAA;Lo;;;;;;
-1E7EA;ETHIOPIC SYLLABLE HWEE;Lo;;;;;;
+1E7EA;ETHIOPIC SYLLABLE HHWEE;Lo;;;;;;
 12C4;ETHIOPIC SYLLABLE KXWEE;Lo;;;;;;
-1E7EB;ETHIOPIC SYLLABLE HWE;Lo;;;;;;
+1E7EB;ETHIOPIC SYLLABLE HHWE;Lo;;;;;;
 12C5;ETHIOPIC SYLLABLE KXWE;Lo;;;;;;
 
 12C8;ETHIOPIC SYLLABLE WA;Lo;;;;;;

--- a/c/uca/sifter/unisift.c
+++ b/c/uca/sifter/unisift.c
@@ -1,5 +1,5 @@
 // © 2019 and later: Unicode, Inc. and others.
-// License & terms of use: http://www.unicode.org/copyright.html
+// License & terms of use: https://www.unicode.org/copyright.html
 /*
 **      Unilib
 **      Copyright 2021
@@ -41,6 +41,8 @@
  *               to the isAlphabeticException list.
  *               Updates to unisift_GetKatakanaBase to account for
  *               4 new archaic kana: U+1B11F..U+1B122.
+ *   2021-Jul-06 Fix for 3 local array overflows for sprintf in getName().
+ *   2021-Jul-12 Bump version number for memory leak fix in unisyms.c.
  */
 
 /*
@@ -165,7 +167,7 @@
 #define PATHNAMELEN (256)
 #define LONGESTARG  (256)
 
-static char versionString[] = "Sifter version 14.0.0d3, 2021-06-07\n";
+static char versionString[] = "Sifter version 14.0.0d5, 2021-07-12\n";
 
 static char unidatafilename[] = "unidata-14.0.0.txt";
 static char allkeysfilename[] = "allkeys-14.0.0.txt";

--- a/c/uca/sifter/unisyms.c
+++ b/c/uca/sifter/unisyms.c
@@ -2,7 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 /*
 **      Unilib
-**      Copyright 2019
+**      Copyright 2021
 **      Ken Whistler, All rights reserved.
 */
 
@@ -34,6 +34,8 @@
  *   2018-Oct-16 Code warning removals.
  *   2019-Oct-04 Added 2 secondary weight symbols for Vietnamese reading marks.
  *               Other adjustments for UCA 13.0.
+ *   2021-Jul-12 Added test and free of outputstring in unisift_DropSymTreeP
+ *               to fix memory leak.
  */
 
 #define _CRT_SECURE_NO_WARNINGS
@@ -2185,6 +2187,10 @@ PSTRLISTNODE temp2;
         while ( temp1 != NULL )
         {
             temp2 = temp1->next;
+            if ( temp1->outputstring != NULL )
+            {
+                free ( temp1->outputstring );
+            }
             free ( temp1 );
             temp1 = temp2;
         }
@@ -2195,6 +2201,10 @@ PSTRLISTNODE temp2;
         while ( temp1 != NULL )
         {
             temp2 = temp1->next;
+            if ( temp1->outputstring != NULL )
+            {
+                free ( temp1->outputstring );
+            }
             free ( temp1 );
             temp1 = temp2;
         }

--- a/docs/inputdata.md
+++ b/docs/inputdata.md
@@ -66,7 +66,7 @@ On other platforms, you can use a script like this Python script:
 `desuffixucd.py`
 
 ```python
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # desuffixucd.py
 #
@@ -91,7 +91,7 @@ _file_version_re = re.compile("([a-zA-Z0-9_-]+)" +
 
 def main():
   if len(sys.argv) < 2:
-    print ("Usage: %s  path/to/UCD/root" % sys.argv[0])
+    print("Usage: %s  path/to/UCD/root" % sys.argv[0])
     return
   ucd_root = sys.argv[1]
   source_files = []
@@ -104,7 +104,7 @@ def main():
     if match:
       new_basename = match.group(1) + match.group(2)
       if new_basename != basename:
-        print "Removing version suffix from " + source_file
+        print("Removing version suffix from " + source_file)
         # ... so that we can easily compare UCD files.
         new_source_file = os.path.join(folder, new_basename)
         shutil.move(source_file, new_source_file)


### PR DESCRIPTION
From Ken:

I've now regenerated and staged unidata.txt and allkeys.txt to fix the 3
Ethiopic character names.

No change for the decomps.txt file, because those character aren't
implicated in any decompositions or other equivalences.

----

Ken also fixed a memory leak in the sifter.

And I upgraded a UCD data helper script to Python 3.