### PR TITLE
Unicode 14 AIs 168-A9 & 168-A11

### DIFF
--- a/unicodetools/data/security/14.0.0/data/confusablesSummaryIdentifier.txt
+++ b/unicodetools/data/security/14.0.0/data/confusablesSummaryIdentifier.txt
@@ -1,5 +1,5 @@
 ﻿# confusablesSummaryIdentifier.txt
-# Date: 2021-07-10, 00:52:51 GMT
+# Date: 2021-08-12, 01:13:33 GMT
 # © 2021 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see http://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/security/14.0.0/data/idnchars.txt
+++ b/unicodetools/data/security/14.0.0/data/idnchars.txt
@@ -1,5 +1,5 @@
 ﻿# idnchars.txt
-# Date: 2021-07-10, 00:52:53 GMT
+# Date: 2021-08-12, 01:13:35 GMT
 # © 2021 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see http://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/security/14.0.0/data/source/formatted-cherokee.txt
+++ b/unicodetools/data/security/14.0.0/data/source/formatted-cherokee.txt
@@ -1,5 +1,5 @@
 ﻿# formatted-cherokee.txt
-# Date: 2021-07-10, 00:52:49 GMT
+# Date: 2021-08-12, 01:13:30 GMT
 # © 2021 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see http://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/security/14.0.0/data/source/formatted-cjk
+++ b/unicodetools/data/security/14.0.0/data/source/formatted-cjk
@@ -1,5 +1,5 @@
 ﻿# formatted-cjk.txt
-# Date: 2021-07-10, 00:52:50 GMT
+# Date: 2021-08-12, 01:13:31 GMT
 # © 2021 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see http://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/security/14.0.0/data/source/formatted-macFonts.txt
+++ b/unicodetools/data/security/14.0.0/data/source/formatted-macFonts.txt
@@ -1,5 +1,5 @@
 ﻿# formatted-macFonts.txt
-# Date: 2021-07-10, 00:52:49 GMT
+# Date: 2021-08-12, 01:13:30 GMT
 # © 2021 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see http://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/security/14.0.0/data/source/formatted-source.txt
+++ b/unicodetools/data/security/14.0.0/data/source/formatted-source.txt
@@ -1,5 +1,5 @@
 ﻿# formatted-source.txt
-# Date: 2021-07-10, 00:52:49 GMT
+# Date: 2021-08-12, 01:13:30 GMT
 # © 2021 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see http://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/security/14.0.0/data/source/formatted-winFonts.txt
+++ b/unicodetools/data/security/14.0.0/data/source/formatted-winFonts.txt
@@ -1,5 +1,5 @@
 ﻿# formatted-winFonts.txt
-# Date: 2021-07-10, 00:52:49 GMT
+# Date: 2021-08-12, 01:13:31 GMT
 # © 2021 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see http://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/security/14.0.0/data/source/removals.txt
+++ b/unicodetools/data/security/14.0.0/data/source/removals.txt
@@ -727,8 +727,9 @@ AB63; uncommon-use # LATIN SMALL LETTER UO
 0289	;	uncommon_use Technical
 0292	;	uncommon_use
 068E	;	Obsolete
-17CB..17CD	;	Technical
-17D0	;	Technical
+# 168-A11 Change U+17CB, U+17CC, U+17CD, U+17D0 to Identifier_Type=Recommended
+17CB..17CD	;	Recommended
+17D0	;	Recommended
 
 # Corbett Thu May 9 14:28:21 CDT 2019, etc.
 

--- a/unicodetools/data/security/14.0.0/data/xidAllowed.txt
+++ b/unicodetools/data/security/14.0.0/data/xidAllowed.txt
@@ -1,5 +1,5 @@
 ﻿# xidAllowed.txt
-# Date: 2021-07-10, 00:52:52 GMT
+# Date: 2021-08-12, 01:13:34 GMT
 # © 2021 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see http://www.unicode.org/terms_of_use.html

--- a/unicodetools/org/unicode/text/UCD/MakeUnicodeFiles.txt
+++ b/unicodetools/org/unicode/text/UCD/MakeUnicodeFiles.txt
@@ -1,6 +1,6 @@
 Generate: .
 CopyrightYear: 2021
-DeltaVersion: 19
+DeltaVersion: 20
 
 File: extra/ScriptNfkc
 Property: SPECIAL

--- a/unicodetools/org/unicode/text/UCD/ToolUnicodePropertySource.java
+++ b/unicodetools/org/unicode/text/UCD/ToolUnicodePropertySource.java
@@ -810,14 +810,27 @@ extend -and not GCB = Virama
 	    //            unicodeMap.put(0, "Prepend");
 	    //            unicodeMap.setErrorOnReset(true);
 
-	    unicodeMap.putAll(
-		    cat.getSet("Spacing_Mark")
-		    //.addAll(new UnicodeSet("[\u0E30 \u0E32 \u0E33 \u0E45 \u0EB0 \u0EB2 \u0EB3]"))
-		    .addAll(new UnicodeSet("[\u0E33 \u0EB3]"))
-		    .removeAll(new UnicodeSet("[\u102B\u102C\u1038\u1062-\u1064\u1067-\u106D\u1083\u1087-\u108C\u108F\u109A-\u109C\u19B0-\u19B4\u19B8\u19B9\u19BB-\u19C0\u19C8\u19C9\u1A61\u1A63\u1A64\uAA7B]"))
-		    .removeAll(unicodeMap.keySet("Extend"))
-		    .remove(0xAA7D)
-		    , "SpacingMark");
+            // https://www.unicode.org/reports/tr29/#SpacingMark
+            UnicodeSet gcbSpacingMarkSet =
+                    cat.getSet("Spacing_Mark")
+                    // any of the following (which have General_Category = Other_Letter):
+                    .addAll(new UnicodeSet("[\u0E33 \u0EB3]"))
+                    // Exceptions: The following
+                    // (which have General_Category = Spacing_Mark and would otherwise be included)
+                    // are specifically excluded:
+                    .removeAll(new UnicodeSet(
+                            "[\u102B\u102C\u1038\u1062-\u1064\u1067-\u106D" + // Myanmar
+                            "\u1083\u1087-\u108C\u108F\u109A-\u109C" + // Myanmar
+                            // Note 2021-aug: These U+19xx are gc=Lo so removing them is a no-op.
+                            // They may have been gc=Spacing_Mark in an earlier version.
+                            "\u19B0-\u19B4\u19B8\u19B9\u19BB-\u19C0\u19C8\u19C9" + // New Tai Lue
+                            "\u1A61\u1A63\u1A64" + // Tai Tham
+                            "\uAA7B\uAA7D]")) // Myanmar
+                    .removeAll(unicodeMap.keySet("Extend"));
+            if (compositeVersion >= (14 << 16)) {
+                gcbSpacingMarkSet.remove(0x11720).remove(0x11721); // AHOM VOWEL SIGN A & AA
+            }
+            unicodeMap.putAll(gcbSpacingMarkSet, "SpacingMark");
 
 	    final UnicodeProperty hangul = getProperty("Hangul_Syllable_Type");
 	    unicodeMap.putAll(hangul.getSet("L"), "L");

--- a/unicodetools/org/unicode/text/UCD/UnicodeInvariantTest.txt
+++ b/unicodetools/org/unicode/text/UCD/UnicodeInvariantTest.txt
@@ -561,10 +561,10 @@ Let $EgyptianControls = [\U00013430-\U00013438]
 \p{RI=Y} = [\p{WB=RI}]
 
 # Post-base spacing combining marks of most SE Asian scripts are explicitly excluded from GCB=SpacingMark
-# See http://www.unicode.org/reports/tr29/#SpacingMark
+# See https://www.unicode.org/reports/tr29/#SpacingMark
 Let $PostBaseSpacingMarks_All = [[[:lb=SA:]-[:sc=Khmr:]] & [:gc=Mc:] & [:InPC=Right:]]
 Let $PostBaseSpacingMarks_Tweak = [\u103B \u1056 \u1057 \u1A57 \u1A6D]
-Let $PostBaseSpacingMarks_Missed = [\U00011720-\U00011721]
+Let $PostBaseSpacingMarks_Missed = []
 [$PostBaseSpacingMarks_All - $PostBaseSpacingMarks_Tweak - $PostBaseSpacingMarks_Missed] ⊂ [:GCB=XX:]
 
 ##########################


### PR DESCRIPTION
- 168-A9 Remove the assignment of GCB=SpacingMark for U+11720..11721 AHOM VOWEL SIGN A & AA, letting them default to GCB=Other
- 168-A11 Change U+17CB, U+17CC, U+17CD, U+17D0 to Identifier_Type=Recommended