### PR TITLE
Unicode 14 AI 168-A2

### DIFF
--- a/unicodetools/data/ucd/14.0.0-Update/PropList.txt
+++ b/unicodetools/data/ucd/14.0.0-Update/PropList.txt
@@ -1149,7 +1149,16 @@ A770          ; Other_Lowercase # Lm       MODIFIER LETTER US
 A7F8..A7F9    ; Other_Lowercase # Lm   [2] MODIFIER LETTER CAPITAL H WITH STROKE..MODIFIER LETTER SMALL LIGATURE OE
 AB5C..AB5F    ; Other_Lowercase # Lm   [4] MODIFIER LETTER SMALL HENG..MODIFIER LETTER SMALL U WITH LEFT HOOK
 
-# Total code points: 189
+# 168-A2 Assign Other_Lowercase to the modifier letters in Latin Extended-F listed in L2/21-126 item β2
+# Assign Other_Lowercase to the modifier letters in Latin Extended-F recommended by Charlotte: 10780, 10783..10785, 10787..107B0, 107B2..107B5, 107BA; and also to 107B6..107B9
+10780 ; Other_Lowercase
+10783..10785 ; Other_Lowercase
+10787..107B0 ; Other_Lowercase
+107B2..107B5 ; Other_Lowercase
+107BA ; Other_Lowercase
+107B6..107B9 ; Other_Lowercase
+
+# Total code points: ?
 
 # ================================================
 

--- a/unicodetools/org/unicode/text/UCD/MakeUnicodeFiles.txt
+++ b/unicodetools/org/unicode/text/UCD/MakeUnicodeFiles.txt
@@ -1,6 +1,6 @@
 Generate: .
 CopyrightYear: 2021
-DeltaVersion: 20
+DeltaVersion: 21
 
 File: extra/ScriptNfkc
 Property: SPECIAL


### PR DESCRIPTION
Assign Other_Lowercase to the modifier letters in Latin Extended-F listed in L2/21-126 item β2:
10780, 10783..10785, 10787..107B0, 107B2..107B5, 107BA; and also to 107B6..107B9

Generated files in https://corp.unicode.org/~book/incoming/markus/u14/20210812/d21/
For example:

PropList.txt
```
10780         ; Other_Lowercase # Lm       MODIFIER LETTER SMALL CAPITAL AA
10783..10785  ; Other_Lowercase # Lm   [3] MODIFIER LETTER SMALL AE..MODIFIER LETTER SMALL B WITH HOOK
10787..107B0  ; Other_Lowercase # Lm  [42] MODIFIER LETTER SMALL DZ DIGRAPH..MODIFIER LETTER SMALL V WITH RIGHT HOOK
107B2..107BA  ; Other_Lowercase # Lm   [9] MODIFIER LETTER SMALL CAPITAL Y..MODIFIER LETTER SMALL S WITH CURL
```

SentenceBreakProperty.txt
```
10780         ; Lower # Lm       MODIFIER LETTER SMALL CAPITAL AA
10783..10785  ; Lower # Lm   [3] MODIFIER LETTER SMALL AE..MODIFIER LETTER SMALL B WITH HOOK
10787..107B0  ; Lower # Lm  [42] MODIFIER LETTER SMALL DZ DIGRAPH..MODIFIER LETTER SMALL V WITH RIGHT HOOK
107B2..107BA  ; Lower # Lm   [9] MODIFIER LETTER SMALL CAPITAL Y..MODIFIER LETTER SMALL S WITH CURL
```