### PR TITLE
Unicode 14 line break rule changes

### DIFF
--- a/unicodetools/org/unicode/text/UCD/GenerateBreakTest.java
+++ b/unicodetools/org/unicode/text/UCD/GenerateBreakTest.java
@@ -1288,7 +1288,9 @@ abstract public class GenerateBreakTest implements UCD_Types {
 	                    ToolUnicodePropertySource.make(ucd.getVersion()),
 	                    "LineBreak", target),
 	            "aa", "Line",
+	            // extraSamples
 		    new String[]{}, 
+		    // extraSingleSamples
 		    new String[]{
 			    "\u000Bぁ",     //4.0
 			    "\rぁ",     //5.02
@@ -1545,6 +1547,23 @@ abstract public class GenerateBreakTest implements UCD_Types {
 			    "\uD83C\uDDF7\uD83C\uDDFA\u200B\uD83C\uDDF8\uD83C\uDDEA",
 			    "\u05D0-\u05D0",
 	    });
+
+            // Additions for Unicode 14 LB30b   [\p{Extended_Pictographic}&\p{Cn}] × EM
+            ToolUnicodePropertySource propSource = ToolUnicodePropertySource.make(ucd.getVersion());
+            UnicodeSet unassigned = propSource.getSet("gc=Cn");
+            UnicodeSet extPict = propSource.getSet("ExtPict=yes");
+            // [\p{Extended_Pictographic}&\p{Cn}] 
+            UnicodeSet extPictUnassigned = extPict.cloneAsThawed().retainAll(unassigned);
+            String firstExtPictUnassigned = UTF16.valueOf(extPictUnassigned.charAt(0));
+            // [\p{Extended_Pictographic}&\p{Cn}] × EM
+            extraSingleSamples.add(firstExtPictUnassigned + sampleEMod);
+
+            UnicodeSet lb_EBase = propSource.getSet("lb=EB");
+            // [\p{Extended_Pictographic}-\p{Cn}-\p{lb=EB}]
+            UnicodeSet extPictAssigned = extPict.cloneAsThawed().removeAll(unassigned).removeAll(lb_EBase);
+            String firstExtPictAssigned = UTF16.valueOf(extPictAssigned.charAt(0));
+            // [\p{Extended_Pictographic}-\p{Cn}-\p{lb=EB}] ÷ EM
+            extraSingleSamples.add(firstExtPictAssigned + sampleEMod);
 	}
 	@Override
 	public boolean isBreak(String source, int offset) {

--- a/unicodetools/org/unicode/text/UCD/MakeUnicodeFiles.txt
+++ b/unicodetools/org/unicode/text/UCD/MakeUnicodeFiles.txt
@@ -1,6 +1,6 @@
 Generate: .
 CopyrightYear: 2021
-DeltaVersion: 21
+DeltaVersion: 22
 
 File: extra/ScriptNfkc
 Property: SPECIAL

--- a/unicodetools/org/unicode/text/UCD/UCD.java
+++ b/unicodetools/org/unicode/text/UCD/UCD.java
@@ -156,12 +156,7 @@ public final class UCD implements UCD_Types {
      * Get the character name.
      */
     public String getName(int codePoint) {
-        String name = getName(codePoint, NORMAL);
-        // make sure labels are unique.
-    	if (name.equals("<control>")) {
-    		name = "<control-" + Utility.hex(codePoint) + ">";
-    	}
-    	return name;
+        return getName(codePoint, NORMAL);
     }
 
     /**
@@ -175,10 +170,20 @@ public final class UCD implements UCD_Types {
      * Get the character name.
      */
     public String getName(int codePoint, byte style) {
+        String name;
         if (style == SHORT) {
-            return get(codePoint, true).shortName;
+            name = get(codePoint, true).shortName;
+        } else {
+            name = get(codePoint, true).name;
         }
-        return get(codePoint, true).name;
+        if (name == null) {
+            return "<reserved-" + Utility.hex(codePoint) + ">";
+        }
+        // Make sure labels are unique.
+        if (name.equals("<control>")) {
+            name = "<control-" + Utility.hex(codePoint) + ">";
+        }
+        return name;
     }
 
     /**

--- a/unicodetools/org/unicode/tools/SegmenterCldr.txt
+++ b/unicodetools/org/unicode/tools/SegmenterCldr.txt
@@ -105,6 +105,8 @@ $ZWJ=\p{Line_Break=ZWJ}
 $CP30=[$CP-[\p{ea=F}\p{ea=W}\p{ea=H}]]
 $OP30=[$OP-[\p{ea=F}\p{ea=W}\p{ea=H}]]
 
+$ExtPictUnassigned=[\p{Extended_Pictographic}&\p{Cn}]
+
 # SPECIAL EXTENSIONS
 
 $CM=[$CM1 $ZWJ]
@@ -273,9 +275,8 @@ $AL=($AL | ^ $CM | (?<=$Spec1_) $CM)
 26.02) $JV | $H2 × $JV | $JT
 26.03) $JT | $H3 × $JT
 # LB 27 Treat a Korean Syllable Block the same as ID.
-27.01) $JL | $JV | $JT | $H2 | $H3 × $IN
-27.02) $JL | $JV | $JT | $H2 | $H3  × $PO
-27.03) $PR × $JL | $JV | $JT | $H2 | $H3
+27.01) $JL | $JV | $JT | $H2 | $H3  × $PO
+27.02) $PR × $JL | $JV | $JT | $H2 | $H3
 # LB 28  Do not break between alphabetics (\"at\").
 28) ($AL | $HL) × ($AL | $HL)
 # LB 29  Do not break between numeric punctuation and alphabetics (\"e.g.\").
@@ -287,7 +288,9 @@ $AL=($AL | ^ $CM | (?<=$Spec1_) $CM)
 30.11) ^ ($RI $RI)* $RI × $RI
 30.12) [^$RI] ($RI $RI)* $RI × $RI
 30.13) $RI ÷ $RI
-30.2) $EB × $EM
+# LB 30b Do not break between an emoji base (or potential emoji) and an emoji modifier.
+30.21) $EB × $EM
+30.22) $ExtPictUnassigned × $EM
 
 @SentenceBreak
 

--- a/unicodetools/org/unicode/tools/SegmenterDefault.txt
+++ b/unicodetools/org/unicode/tools/SegmenterDefault.txt
@@ -105,6 +105,8 @@ $ZWJ=\p{Line_Break=ZWJ}
 $CP30=[$CP-[\p{ea=F}\p{ea=W}\p{ea=H}]]
 $OP30=[$OP-[\p{ea=F}\p{ea=W}\p{ea=H}]]
 
+$ExtPictUnassigned=[\p{Extended_Pictographic}&\p{Cn}]
+
 # SPECIAL EXTENSIONS
 
 $CM=[$CM1 $ZWJ]
@@ -273,9 +275,8 @@ $AL=($AL | ^ $CM | (?<=$Spec1_) $CM)
 26.02) $JV | $H2 × $JV | $JT
 26.03) $JT | $H3 × $JT
 # LB 27 Treat a Korean Syllable Block the same as ID.
-27.01) $JL | $JV | $JT | $H2 | $H3 × $IN
-27.02) $JL | $JV | $JT | $H2 | $H3  × $PO
-27.03) $PR × $JL | $JV | $JT | $H2 | $H3
+27.01) $JL | $JV | $JT | $H2 | $H3  × $PO
+27.02) $PR × $JL | $JV | $JT | $H2 | $H3
 # LB 28  Do not break between alphabetics (\"at\").
 28) ($AL | $HL) × ($AL | $HL)
 # LB 29  Do not break between numeric punctuation and alphabetics (\"e.g.\").
@@ -287,7 +288,9 @@ $AL=($AL | ^ $CM | (?<=$Spec1_) $CM)
 30.11) ^ ($RI $RI)* $RI × $RI
 30.12) [^$RI] ($RI $RI)* $RI × $RI
 30.13) $RI ÷ $RI
-30.2) $EB × $EM
+# LB 30b Do not break between an emoji base (or potential emoji) and an emoji modifier.
+30.21) $EB × $EM
+30.22) $ExtPictUnassigned × $EM
 
 @SentenceBreak
 


### PR DESCRIPTION
- remove the redundant first of three LB27 rules
- add a future-proofing LB30b rule for code points reserved for emoji (unassigned ExtPict)