### PR TITLE
Fix Markdown formatting in the help pages for the JSPs

### DIFF
--- a/docs/help/bidi.md
+++ b/docs/help/bidi.md
@@ -1,10 +1,12 @@
 # bidi - Unicode Bidi Algorithm (UBA) Demo
 
-[Demo](http://unicode.org/cldr/utility/bidi.jsp)
+[Demo](https://util.unicode.org/UnicodeJsps/bidi.jsp)
+
 Type in the sample text, and hit "Show Bidi". Below, you'll see how the rules in
 the UBA are applied to the characters. Clicking on any character class (like
 "EN") will show the Unicode characters with that property value. Clicking on a
 rule (like "W5") will take you to the rule in the UBA spec.
+
 If you turn on "ASCII Hack", then ASCII characters in the sample will be
 interpreted as if they were Arabic, Hebrew, etc. for the purpose of
 illustration.

--- a/docs/help/breaks.md
+++ b/docs/help/breaks.md
@@ -1,6 +1,6 @@
 # breaks - Unicode Segmentation
 
-[Demo](http://unicode.org/cldr/utility/breaks.jsp)
+[Demo](https://util.unicode.org/UnicodeJsps/breaks.jsp)
 
 Demonstrates different boundaries within text.
 

--- a/docs/help/changes.md
+++ b/docs/help/changes.md
@@ -7,7 +7,7 @@ To get the beta version of the property, insert β *after* the property name.
 Examples:
 
 | `\p{Word_Break=ALetter}` | Released version of Unicode |
-| `p{Word_Breakβ=ALetter}` | Beta version of Unicode     |
+| `\p{Word_Breakβ=ALetter}` | Beta version of Unicode     |
 
 
 For example, to see additions to that property value in the beta version, use:
@@ -24,7 +24,7 @@ For example, to see additions to that property value in the beta version, use:
 The support is not complete done, and there are some known problems.
 
 1.  Some properties are not supported in beta versions. See
-    <https://util.unicode.org/UnicodeJsps/character.jsp>
+    <https://util.unicode.org/UnicodeJsps/properties.jsp>
     for the list.
 2.  When characters are listed, the new blocks and subheads don't show up.
 3.  If you use a property that has a β version but no ICU version, you get no

--- a/docs/help/changes.md
+++ b/docs/help/changes.md
@@ -6,19 +6,25 @@ released version of Unicode (via ICU) and from the new Unicode beta.
 To get the beta version of the property, insert β *after* the property name.
 Examples:
 
-\\p{Word_Break=ALetter} Released version of Unicode \\p{Word_Breakβ=ALetter}
-Beta version of Unicode
+| `\p{Word_Break=ALetter}` | Released version of Unicode |
+| `p{Word_Breakβ=ALetter}` | Beta version of Unicode     |
+
 
 For example, to see additions to that property value in the beta version, use:
 
-[\\p{Word_Breakβ=ALetter}-\\p{Word_Break=ALetter}](https://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5Cp%7BWord_Break%CE%B2%3DALetter%7D-%5Cp%7BWord_Break%3DALetter%7D&g=&i=)
+<center>
+
+[`\p{Word_Breakβ=ALetter}-\\p{Word_Break=ALetter}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7BWord_Break%CE%B2%3DALetter%7D-%5Cp%7BWord_Break%3DALetter%7D&g=&i=)
+
+</center>
+
 
 ## Caveats
 
 The support is not complete done, and there are some known problems.
 
 1.  Some properties are not supported in beta versions. See
-    [unicode.org/cldr/utility/properties.jsp](https://unicode.org/cldr/utility/properties.jsp)
+    <https://util.unicode.org/UnicodeJsps/character.jsp>
     for the list.
 2.  When characters are listed, the new blocks and subheads don't show up.
 3.  If you use a property that has a β version but no ICU version, you get no
@@ -26,11 +32,11 @@ The support is not complete done, and there are some known problems.
 4.  The beta properties don't yet have the "shorthands" for cases like \\p{Lu}.
     So make sure the property is listed, eg \\p{gcβ=Lu}
     1.  Example:
-        [\\p{gcβ=Lu}-\\p{gc=Lu}](https://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5Cp%7Bgc%CE%B2%3DLu%7D-%5Cp%7Bgc%3DLu%7D&g=&i=)
+        [`\p{gcβ=Lu}-\\p{gc=Lu}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7Bgc%CE%B2%3DLu%7D-%5Cp%7Bgc%3DLu%7D&g=&i=)
 5.  Tools for segmentation, etc. use the release properties; there isn't a way
     to have them use the beta properties.
 6.  There are probably others...
 
 If you find a problem, please file a ticket at
-<http://unicode.org/cldr/trac/newticket>: make sure to start the summary with
+<https://cldr.unicode.org/index/bug-reports>: make sure to start the summary with
 "Unicode Utilities: "

--- a/docs/help/character.md
+++ b/docs/help/character.md
@@ -1,6 +1,6 @@
 # character - Unicode Character Properties
 
-[Demo](http://unicode.org/cldr/utility/character.jsp)
+[Demo](https://util.unicode.org/UnicodeJsps/character.jsp)
 
 This demo shows Unicode character properties for a given character, plus some
-useful extended properties. For more information, see [UnicodeSet](index.md).
+useful extended properties. For more information, see [UnicodeSet](unicodeset.md).

--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -4,6 +4,20 @@ The Unicode Utilities provide a number of different utilities that use and
 demonstrate features of the Unicode encoding and locale data. These include the
 following:
 
+* [bidi - Unicode Bidi Algorithm (UBA) Demo ](bidi)
+* [bnf-regex - Simplified regex generation ](bnf)
+* [breaks - Unicode Segmentation ](breaks)
+* [Changes](changes)
+* [character - Unicode Character Properties ](character)
+* [confusables - Visually Similar Characters ](confusables)
+* [idna - Internationalized Domain Names (IDN) ](idna)
+* [languageid - BCP47 Language Tags ](languageid)
+* [list-unicodeset - Manipulate sets of Unicode characters ](list-unicodeset)
+* [properties - Unicode Properties and Values ](properties)
+* [regex - Generate corrected regex ](regex)
+* [transform - Transform strings using CLDR ](transform)
+* [unicodeset - Compare sets of characters ](unicodeset)
+
 Common to many of the utilities is the use of UnicodeSet. For more information,
 see [list-unicodeset - Manipulate sets of Unicode
 characters](list-unicodeset.md)

--- a/docs/help/list-unicodeset.md
+++ b/docs/help/list-unicodeset.md
@@ -8,7 +8,9 @@ can be specified explicitly, such as `[a-m w-z]`, or using a combinations of
 Unicode Properties such as the following, for **the Arabic script characters
 that have a canonical decomposition:**
 
-\[\[:script=arabic:\]&\[:decompositiontype=canonical:\]\]
+```
+[[:script=arabic:]&[:decompositiontype=canonical:]]
+```
 
 ## Operation
 
@@ -17,68 +19,68 @@ choose certain combinations of options for display, such as abbreviated or not.
 
 The values you use are encapsulated into a URL for reference, such as
 
-<http://unicode.org/cldr/utility/list-unicodeset.jsp?a=\\p{sc:Greek}>
+<https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=\\p{sc:Greek}>
 
 If you add properties to the **Group By** box, you can sort the results by
-property values. For example, if you set it to "General_Category Numeric_Value"
-(or the short form "gc nv"), you'll see the results sorted first by the general
+property values. For example, if you set it to `General_Category Numeric_Value`
+(or the short form `gc nv`), you'll see the results sorted first by the general
 category of the characters, and then by the numeric value.
 
-## **Syntax**
+## Syntax
 
-**UnicodeSets are defined according to the description on [UTS #35: Locale Data
+UnicodeSets are defined according to the description on [UTS #35: Locale Data
 Markup Language (LDML)](http://www.unicode.org/reports/tr35/), but has some
-useful extensions in these online demos.**
+useful extensions in these online demos.
 
-**Properties can be specified either with Perl-style notation
+Properties can be specified either with Perl-style notation
 (`\p{script=arabic}`) or with POSIX-style notation (`[:script=arabic:]`).
-Properties and values can either use a long form (like "script") or a short form
-(like "sc").**
+Properties and values can either use a long form (like `script`) or a short form
+(like `sc`).
 
-**No argument is equivalent to "Yes"; mostly useful with binary properties, like
-\\p{isLowercase}!**
+No argument is equivalent to "Yes"; mostly useful with binary properties, like
+`\p{isLowercase}`.
 
-### **Convenience**
+### Convenience
 
 The following examples illustrate the syntax with a particular property, value
-pair: the property *age* and the value *3.2:*
+pair: the property `age` and the value `3.2`:
 
-The : can be used in the place of =. (Mostly because : doesn't require
+The `:` can be used in the place of `=`. (Mostly because `:` doesn't require
 percent-encoding in URLs.)
 
-*   \\p{age:3.2} and \[:age:3.2:\]
+*   `\p{age:3.2}` and `[:age:3.2:]`
 
-The Perl and Posix syntax for negations are \\P{...} and \[:^...:\],
-respectively. The characters ≠ and ! are added for convenience:
+The Perl and Posix syntax for negations are `\P{...}` and `[:^...:]`,
+respectively. The characters `≠` and `!` are added for convenience:
 
-*   \\p{age≠3.2} and \[:age≠3.2:\]
-*   \\p{age!=3.2} and \[:age!=3.2:\]
-*   \\p{age!:3.2} and \[:age!=3.2:\]
+*   `\p{age≠3.2}` and `\:age≠3.2:]`
+*   `\p{age!=3.2}` and `\:age!=3.2:]`
+*   `\p{age!:3.2}` and `\:age!=3.2:]`
 
-### **Regular Expressions**
+### Regular Expressions
 
-For the *name* property, regular expressions can be used for the value, enclosed
-in /.../. For example in the following expression, the first term will select
+For the `name` property, regular expressions can be used for the value, enclosed
+in `/.../`. For example in the following expression, the first term will select
 all those Unicode characters whose names contain "CJK". The rest of the
 expression will then subtract the ideographic characters, showing that these can
 be used in arbitrary combinations.
 
-*   `[[[:name=/CJK/:]-[:ideographic:]]](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B%5B:name=/CJK/:%5D-%5B:ideographic:%5D%5D)`
+*   `[[[:name=/CJK/:]-[:ideographic:]]](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%5B:name=/CJK/:%5D-%5B:ideographic:%5D%5D)`
     - the set of all characters with names that contain CJK that are not
     Ideographic
-*   `[[:name=/\bDOT$/:]](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B:name=/%5CbDOT$/:%5D)`
+*   `[[:name=/\bDOT$/:]](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B:name=/%5CbDOT$/:%5D)`
     - the set of all characters with names that end with the word DOT
-*   `[[:block=/(?i)arab/:]](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B:block=/(?i)arab/:%5D)`
+*   `[[:block=/(?i)arab/:]](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B:block=/(?i)arab/:%5D)`
     - the set of all characters in blocks that contain the sequence of letters
     "arab" (case-insensitive)
-*   `[[:toNFKC=/\./:]](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B:toNFKC=/%5C./:%5D)`
+*   `[[:toNFKC=/\./:]](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B:toNFKC=/%5C./:%5D)`
     - the set of all characters with toNFKC values that contain a literal period
 
 Some particularly useful regex features are:
 
-*   \\b means a word break, ^ means front of the string, and $ means end. So
-    /^DOT\\b/ means the word DOT at the start.
-*   (?i) means case-insensitive matching.
+*   `\b` means a word break, `^` means front of the string, and `$` means end. So
+    `/^DOT\\b/` means the word DOT at the start.
+*   `(?i)` means case-insensitive matching.
 
 ***Caveats:***
 
@@ -86,40 +88,40 @@ Some particularly useful regex features are:
     Pattern](http://download.oracle.com/javase/6/docs/api/java/util/regex/Pattern.html).
     In particular, it does not have the extended functions in UnicodeSet, nor is
     it up-to-date with the latest Unicode. So be aware that you shouldn't depend
-    on properties inside of the /.../ pattern.
-2.  If you do use properties, then use \[:...:\] syntax on the outside, such as:
-    *   [\[:block=/\\p{Digit}/:\]](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B:block:/%5Cp%7BDigit%7D/:%5D&g=)
+    on properties inside of the `/.../` pattern.
+2.  If you do use properties, then use `[:...:]` syntax on the outside, such as:
+    *   [`[:block=/\\p{Digit}/:]`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B:block:/%5Cp%7BDigit%7D/:%5D&g=)
 3.  The Unassigned, Surrogate, and Private Use code points are skipped in the
-    Regex comparison, so \[:Block=/Aegean_Numbers/:\] returns a different number
-    of characters than \[:Block=Aegean_Numbers:\], because it skips Unassigned
+    Regex comparison, so `[:Block=/Aegean_Numbers/:]` returns a different number
+    of characters than `[:Block=Aegean_Numbers:]`, because it skips Unassigned
     code points.
-4.  None of the normal "loose matching" is enabled. So \[:Block=aegeannumbers:\]
-    works, but \[:Block=/aegeannumbers/:\] fails -- you have to use
-    \[:Block=/Aegean_Numbers/:\] or \[:Block=/(?i)aegean_numbers/:\].
+4.  None of the normal "loose matching" is enabled. So `[:Block=aegeannumbers:]`
+    works, but `[:Block=/aegeannumbers/:]` fails -- you have to use
+    `[:Block=/Aegean_Numbers/:]` or `[:Block=/(?i)aegean_numbers/:]`.
 
 ### Property Comparison
 
 Property values can be compared to those for other properties, using the syntax
-@...@. For example:
+`@...@`. For example:
 
 *   Find the characters for which IDNA2003 is not the same as UTS46:
-    [\\p{idna2003!=@uts46@}](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5Cp%7Bidna2003!%3D@uts46@%7D)
+    [`\p{idna2003!=@uts46@}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7Bidna2003!%3D@uts46@%7D)
 *   The same thing, but limited to Unicode 3.2:
-    [\\p{idna2003!=@uts46@}&\\p{age=3.2}](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5Cp%7Bidna2003!%3D@uts46@%7D%26%5Cp%7Bage%3D3.2%7D&g=)
+    [`\p{idna2003!=@uts46@}&\\p{age=3.2}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7Bidna2003!%3D@uts46@%7D%26%5Cp%7Bage%3D3.2%7D&g=)
 
 There is a special property "cp" that returns the code point itself. For
 example:
 
 *   Find the characters whose lowercase is different:
-    [\\p{toLowercase!=@cp@}](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5Cp%7BtoLowercase!%3D%40cp%40%7D&g=)
+    [`\p{toLowercase!=@cp@}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7BtoLowercase!%3D%40cp%40%7D&g=)
 
 ## **Available Properties**
 
 You can see a full listing of the possible properties on
-<http://unicode.org/cldr/utility/properties.jsp>. The standard Unicode
+<https://util.unicode.org/UnicodeJsps/properties.jsp>. The standard Unicode
 properties are supported, plus the extra ICU properties. There are some
 additional properties just in this demo. The easiest way to see the properties
-for a range of characters is to use a set like \[:Greek:\] in the Input, and
+for a range of characters is to use a set like `[:Greek:]` in the Input, and
 then set the Group By box to the property name.
 
 ### List
@@ -155,7 +157,7 @@ then set the Group By box to the property name.
     1.  uca (the primary UCA weight -- after the CLDR transforms),
     2.  uca2 (the primary and secondary weights)
 
-Normally, \\p{isX} is equivalent to \\p{toX=@cp@}. There are some exceptions and
+Normally, \\p{isX} is equivalent to `\p{toX=@cp@}`. There are some exceptions and
 missing cases.
 
 Note: The Unassigned, Surrogate, and Private Use code points are skipped in the
@@ -171,21 +173,21 @@ characters.***Warning:*** the first three sets may be somewhat misleading:
 isLowercase means that the character is the same as its lowercase version, which
 includes *all uncased* characters. To get those characters that are *cased*
 characters and lowercase, use
-[`[[:isLowercase:]&[:isCased:]]`](http://cldr.unicode.org/unicode-utilities)
+[`[[:isLowercase:]&[:isCased:]]`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%5B%3AisLowercase%3A%5D%26%5B%3AisCased%3A%5D%5D&g=&i=)
 
 1.  The binary testing operations take no argument:
-    *   `[[:isLowercase:]](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B:isLowercase:%5D)`
-    *   [`[:isUppercase:]`](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B:isUppercase:%5D)
-    *   [`[:isTitlecase:]`](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B:isTitlecase:%5D)
-    *   [`[:isCaseFolded:]`](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B:isCaseFolded:%5D)
-    *   `[[:isCased:]](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B:isCased:%5D).`
+    *   [`[:isLowercase:]`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B:isLowercase:%5D)
+    *   [`[:isUppercase:]`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B:isUppercase:%5D)
+    *   [`[:isTitlecase:]`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B:isTitlecase:%5D)
+    *   [`[:isCaseFolded:]`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B:isCaseFolded:%5D)
+    *   [`[:isCased:]`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B:isCased:%5D).
 2.  The string functions are also provided, and require an argument. For
     example:
-    *   `[[:toLowercase=a:]](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B:toLowercase=a:%5D)
-        `- the set of all characters X such that toLowercase(X) = a
-    *   `[[:toCaseFold=a:]](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B:toCaseFold=a:%5D)`
-    *   `[[:toUppercase=A:]](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B:toUppercase=A:%5D)`
-    *   `[[:toTitlecase=A:]](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B:toTitlecase=A:%5D)`
+    *   [`[:toLowercase=a:]`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B:toLowercase=a:%5D)
+        - the set of all characters X such that toLowercase(X) = a
+    *   [`[:toCaseFold=a:]`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B:toCaseFold=a:%5D)
+    *   [`[:toUppercase=A:]`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B:toUppercase=A:%5D)
+    *   [`[:toTitlecase=A:]`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B:toTitlecase=A:%5D)
 
     Note: The Unassigned, Surrogate, and Private Use code points are skipped in
     generation of the sets.
@@ -195,8 +197,8 @@ characters and lowercase, use
 Unicode defines a number of string normalization functions UAX #15. These string
 functions can also be applied to single characters.
 
-*   [\[:toNFC=a:\]](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B:toNFC=a:%5D)
+*   [`[:toNFC=a:]`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B:toNFC=a:%5D)
     - the set of all characters X such that toNFC(X) = a
-*   [\[:toNFD=A\\u0300:\]](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B:toNFD=A%5Cu0300:%5D)
-*   [\[:toNFKC=A:\]](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B:toNFKC=A:%5D)
-*   [\[:toNFKD=A\\u0300:\]](http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B:toNFKD=A%5Cu0300:%5D)
+*   [`[:toNFD=A\u0300:]`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B:toNFD=A%5Cu0300:%5D)
+*   [`[:toNFKC=A:]`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B:toNFKC=A:%5D)
+*   [`[:toNFKD=A\u0300:]`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B:toNFKD=A%5Cu0300:%5D)

--- a/docs/help/properties.md
+++ b/docs/help/properties.md
@@ -9,5 +9,5 @@ properties. It also lets you see the values of a given property.
 *   Clicking Show Values will show the values (or a selection, if there are too
     many).
 *   Clicking on a value will show the
-    [unicode-set](http://unicode.org/cldr/utility/list-unicodeset.jsp) of
+    [unicode-set](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp) of
     characters with that value.


### PR DESCRIPTION
Fixes #138 

This is based on top of @macchiati 's PR #141 to land the initial auto-converted Markdown files of the original help site pages.

I configured my personal to serve pages out of this PR's branch from the `/docs` directory, so https://echeran.github.io/unicodetools/help should be a preview.  Reminder: https://cldr.unicode.org/unicode-utilities/ is the original site we're migrating from.