### PR TITLE
remove MakeUnicodeFiles.DeltaVersion

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -262,9 +262,8 @@ to set up the inputs correctly. For some updates you may need to pull in other
 
 Unicode 15:
 
-We no longer generate files with version suffixes, but for now we still
-generate files into an output folder with the DeltaVersion that is set in MakeUnicodeFiles.txt.
-We might revisit this.
+We no longer generate files with version suffixes.
+We now generate files into an output folder with the Unicode version number.
 
 Unicode 14:
 
@@ -274,7 +273,6 @@ Now, update the following files:
 
 ```
 Generate: .*
-DeltaVersion: 1 (this will generate files suffixed with -d1, figure out what the latest delta is)
 CopyrightYear: 2021 (or whatever)
 ....
 File: DerivedAge
@@ -448,7 +446,6 @@ If there are new break rules (or changes), see
             modify at some times:
             ```
             Generate: .*script.* // this is a regular expression. Use .* for all files
-            DeltaVersion: 10     // This gets appended to the file name. Pick 1+ the highest value in Public
             CopyrightYear: 2010  // Pick the current year
             ```
 3.  Open in Package Explorer

--- a/unicodetools/src/main/java/org/unicode/text/UCD/CompareProperties.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/CompareProperties.java
@@ -246,7 +246,7 @@ public class CompareProperties implements UCD_Types {
     public void printPartition() throws IOException {
         System.out.println("Set Size: " + map.size());
         final PrintWriter output = Utility.openPrintWriterGenDir("Partition"
-                + FileInfix.fromFlags(Settings.BUILD_FOR_COMPARE, true).getFileInfix() + ".txt", Utility.LATIN1_WINDOWS);
+                + FileInfix.getDefault().getFileSuffix(".txt"), Utility.LATIN1_WINDOWS);
 
         final Iterator it = map.keySet().iterator();
         while (it.hasNext()) {
@@ -272,7 +272,7 @@ public class CompareProperties implements UCD_Types {
     public void printStatistics() throws IOException {
         System.out.println("Set Size: " + map.size());
         final PrintWriter output = Utility.openPrintWriterGenDir("Statistics"
-                + FileInfix.fromFlags(Settings.BUILD_FOR_COMPARE, true).getFileInfix() + ".txt", Utility.LATIN1_WINDOWS);
+                + FileInfix.getDefault().getFileSuffix(".txt"), Utility.LATIN1_WINDOWS);
 
         System.out.println("Finding disjoints/contains");
         for (int i = 0; i < count; ++i) {
@@ -433,7 +433,10 @@ public class CompareProperties implements UCD_Types {
 
     public static void listDifferences() throws IOException {
 
-        final PrintWriter output = Utility.openPrintWriterGenDir("PropertyDifferences" + FileInfix.fromFlags(Settings.BUILD_FOR_COMPARE, true).getFileInfix() + ".txt", Utility.LATIN1_UNIX);
+        final PrintWriter output =
+                Utility.openPrintWriterGenDir(
+                        "PropertyDifferences" + FileInfix.getDefault().getFileSuffix(".txt"),
+                        Utility.LATIN1_UNIX);
         output.println("# Listing of relationships among properties, suitable for analysis by spreadsheet");
         output.println("# Generated for " + Default.ucd().getVersion());
         output.println(Utility.generateDateLine());

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateBreakTest.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateBreakTest.java
@@ -390,8 +390,7 @@ abstract public class GenerateBreakTest implements UCD_Types {
 	//printLine(out, samples[LB_ZW], " ", samples[LB_CL]);
 
         boolean forCLDR = seg.target == Segmenter.Target.FOR_CLDR;
-        String path = MakeUnicodeFiles.MAIN_OUTPUT_DIRECTORY +
-	        (forCLDR ? "cldr/" : "auxiliary/");
+        String path = "UCD/" + ucd.getVersion() + '/' + (forCLDR ? "cldr/" : "auxiliary/");
 	String outFilename = fileName + "BreakTest";
 	if (forCLDR) {
 	    outFilename = outFilename + "-cldr";

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateCaseFolding.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateCaseFolding.java
@@ -49,8 +49,12 @@ public class GenerateCaseFolding implements UCD_Types {
     public static void makeCaseFold(boolean normalized) throws java.io.IOException {
         PICK_SHORT = NF_CLOSURE = normalized;
 
-        log = Utility.openPrintWriter(Settings.Output.GEN_DIR + "/log", "CaseFoldingLog" + FileInfix.fromFlags(Settings.BUILD_FOR_COMPARE, true).getFileInfix() + ".txt", Utility.LATIN1_UNIX);
-        System.out.println("Writing Log: " + "CaseFoldingLog" + FileInfix.fromFlags(Settings.BUILD_FOR_COMPARE, true).getFileInfix() + ".txt");
+        String suffix = FileInfix.getDefault().getFileSuffix(".txt");
+        log = Utility.openPrintWriter(
+                Settings.Output.GEN_DIR + "/log",
+                "CaseFoldingLog" + suffix,
+                Utility.LATIN1_UNIX);
+        System.out.println("Writing Log: " + "CaseFoldingLog" + suffix);
 
         System.out.println("Making Full Data");
         final Map<String, String> fullData = getCaseFolding(true, NF_CLOSURE, "");
@@ -74,8 +78,9 @@ public class GenerateCaseFolding implements UCD_Types {
         if (normalized) {
             filename += "-Normalized";
         }
-        final String directory = MakeUnicodeFiles.MAIN_OUTPUT_DIRECTORY;
-        final UnicodeDataFile fc = UnicodeDataFile.openAndWriteHeader(directory, filename)
+        final String directory = "UCD/" + Default.ucd().getVersion() + '/';
+        final UnicodeDataFile fc =
+                UnicodeDataFile.openAndWriteHeader(directory, filename)
                 .setSkipCopyright(Settings.SKIP_COPYRIGHT);
         final PrintWriter out = fc.out;
 
@@ -548,9 +553,12 @@ public class GenerateCaseFolding implements UCD_Types {
         if (normalize) {
             suffix2 = "-Normalized";
         }
-
-        final PrintWriter log = Utility.openPrintWriter(Settings.Output.GEN_DIR, "log/SpecialCasingExceptions"
-        + suffix2 + FileInfix.fromFlags(Settings.BUILD_FOR_COMPARE, true).getFileInfix() + ".txt", Utility.LATIN1_UNIX);
+        String suffix = FileInfix.getDefault().getFileSuffix(".txt");
+        final PrintWriter log =
+                Utility.openPrintWriter(
+                        Settings.Output.GEN_DIR,
+                        "log/SpecialCasingExceptions" + suffix2 + suffix,
+                        Utility.LATIN1_UNIX);
 
         for (int ch = 0; ch <= 0x10FFFF; ++ch) {
             Utility.dot(ch);
@@ -687,7 +695,11 @@ public class GenerateCaseFolding implements UCD_Types {
         //String newFile = "DerivedData/SpecialCasing" + suffix2 + UnicodeDataFile.getFileSuffix(true);
         //PrintWriter out = Utility.openPrintWriter(newFile, Utility.LATIN1_UNIX);
 
-        final UnicodeDataFile udf = UnicodeDataFile.openAndWriteHeader(MakeUnicodeFiles.MAIN_OUTPUT_DIRECTORY, "SpecialCasing" + suffix2).setSkipCopyright(Settings.SKIP_COPYRIGHT);
+        final UnicodeDataFile udf =
+                UnicodeDataFile.openAndWriteHeader(
+                        "UCD/" + Default.ucd().getVersion() + '/',
+                        "SpecialCasing" + suffix2).
+                setSkipCopyright(Settings.SKIP_COPYRIGHT);
         final PrintWriter out = udf.out;
 
         /*       String[] batName = {""};

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateData.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateData.java
@@ -753,7 +753,8 @@ public class GenerateData implements UCD_Types {
         final UnicodeDataFile fc = UnicodeDataFile.openAndWriteHeader(directory, fileName).setSkipCopyright(Settings.SKIP_COPYRIGHT);
         final PrintWriter log = fc.out;
 
-        final String newFile = directory + fileName + FileInfix.fromFlags(Settings.BUILD_FOR_COMPARE, true).getFileInfix() + ".txt";
+        //final String suffix = FileInfix.getDefault().getFileSuffix(".txt");
+        //final String newFile = directory + fileName + suffix;
         //PrintWriter log = Utility.openPrintWriter(newFile, Utility.UTF8_UNIX);
         //String[] batName = {""};
         //String mostRecent = org.unicode.cldr.util.Utility.generateBat(directory, fileName, UnicodeDataFile.getFileSuffix(true), batName);

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateNamedSequences.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateNamedSequences.java
@@ -111,8 +111,7 @@ public final class GenerateNamedSequences implements UCD_Types {
 
         // now write out the results
 
-        final String directory = MakeUnicodeFiles.MAIN_OUTPUT_DIRECTORY + "extra/";
-        final String filename = directory + filename2 + FileInfix.fromFlags(Settings.BUILD_FOR_COMPARE, true).getFileInfix() + ".html";
+        final String directory = "UCD/" + Default.ucd().getVersion() + "/extra/";
         final UnicodeDataFile outfile = UnicodeDataFile.openHTMLAndWriteHeader(directory, filename2)
                 .setSkipCopyright(Settings.SKIP_COPYRIGHT);
 

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateStandardizedVariants.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateStandardizedVariants.java
@@ -128,13 +128,16 @@ public final class GenerateStandardizedVariants implements UCD_Types {
 
         // now write out the results
 
-        final UnicodeDataFile outfile = UnicodeDataFile.openHTMLAndWriteHeader(MakeUnicodeFiles.MAIN_OUTPUT_DIRECTORY, "StandardizedVariants")
+        final UCD ucd = Default.ucd();
+        final String version = ucd.getVersion();
+        final UnicodeDataFile outfile =
+                UnicodeDataFile.openHTMLAndWriteHeader(
+                        "UCD/" + version + '/',
+                        "StandardizedVariants")
                 .setSkipCopyright(Settings.SKIP_COPYRIGHT);
 
         final PrintWriter out = outfile.out;
 
-        final UCD ucd = Default.ucd();
-        final String version = Default.ucd().getVersion();
         final String lastVersion = Utility.getPreviousUcdVersion(version);
         final int lastDot = version.lastIndexOf('.');
         String updateDirectory;

--- a/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
@@ -43,10 +43,6 @@ import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ULocale;
 
 public class MakeUnicodeFiles {
-    public static String MAIN_OUTPUT_DIRECTORY = "UCD/";
-
-    public static int dVersion = -1; // change to fix the generated file D version. If less than zero, no "d"
-
     static boolean DEBUG = false;
 
     public static void main(String[] args) throws IOException {
@@ -294,9 +290,6 @@ public class MakeUnicodeFiles {
                                     || (filesToDo.length == 1 && filesToDo[0].length() == 0)) {
                                 filesToDo = new String[] {".*"};
                             }
-                        } else if (line.startsWith("DeltaVersion:")) {
-                            dVersion = Integer.parseInt(lineValue);
-                            MAIN_OUTPUT_DIRECTORY = "UCD/" + (Settings.BUILD_FOR_COMPARE ? "" : "d" + dVersion + "/");
                         } else if (line.startsWith("CopyrightYear:")) {
                             Default.setYear(lineValue);
                         } else if (line.startsWith("File:")) {
@@ -420,6 +413,7 @@ public class MakeUnicodeFiles {
     }
 
     public static void generateFile(String filename) throws IOException {
+        String outputDir = "UCD/" + Default.ucdVersion() + '/';
         if (filename.endsWith("Aliases")) {
             if (filename.endsWith("ValueAliases")) {
                 generateValueAliasFile(filename);
@@ -433,10 +427,10 @@ public class MakeUnicodeFiles {
         } else {
             switch(filename) {
             case "unihan":
-                writeUnihan(MAIN_OUTPUT_DIRECTORY + "unihan/");
+                writeUnihan(outputDir + "unihan/");
                 break;
             case "NormalizationTest":
-                GenerateData.writeNormalizerTestSuite(MAIN_OUTPUT_DIRECTORY, "NormalizationTest");
+                GenerateData.writeNormalizerTestSuite(outputDir, "NormalizationTest");
                 break;
             case "BidiTest":
                 doBidiTest(filename);
@@ -484,7 +478,10 @@ public class MakeUnicodeFiles {
     private static void generateDerivedName(String filename) throws IOException {
         boolean isLabel = filename.contains("Label");
         final String dir = Format.theFormat.fileToDirectory.get(filename);
-        final UnicodeDataFile udf = UnicodeDataFile.openAndWriteHeader(MAIN_OUTPUT_DIRECTORY + dir, filename);
+        final UnicodeDataFile udf =
+                UnicodeDataFile.openAndWriteHeader(
+                        "UCD/" + Default.ucdVersion() + '/' + dir,
+                        filename);
         final PrintWriter pw = udf.out;
         Format.theFormat.printFileComments(pw, filename);
         final UCD ucd = Default.ucd();
@@ -530,7 +527,9 @@ public class MakeUnicodeFiles {
     private static void generateScriptNfkc(String filename) throws IOException {
         final String dir = Format.theFormat.fileToDirectory.get(filename);
         final UnicodeDataFile udf =
-                UnicodeDataFile.openAndWriteHeader(MAIN_OUTPUT_DIRECTORY + dir, filename);
+                UnicodeDataFile.openAndWriteHeader(
+                        "UCD/" + Default.ucdVersion() + '/' + dir,
+                        filename);
         final PrintWriter pw = udf.out;
         Format.theFormat.printFileComments(pw, filename);
         final UCD ucd = Default.ucd();
@@ -568,7 +567,9 @@ public class MakeUnicodeFiles {
 
     private static void doBidiTest(String filename) throws IOException {
         final UnicodeDataFile udf =
-                UnicodeDataFile.openAndWriteHeader(MAIN_OUTPUT_DIRECTORY, filename);
+                UnicodeDataFile.openAndWriteHeader(
+                        "UCD/" + Default.ucdVersion() + '/',
+                        filename);
         final PrintWriter pw = udf.out;
         Format.theFormat.printFileComments(pw, filename);
         org.unicode.bidi.BidiConformanceTestBuilder.write(pw);
@@ -662,7 +663,11 @@ public class MakeUnicodeFiles {
     static final String SEPARATOR = "# ================================================";
 
     public static void generateAliasFile(String filename) throws IOException {
-        final UnicodeDataFile udf = UnicodeDataFile.openAndWriteHeader(MAIN_OUTPUT_DIRECTORY, filename).setSkipCopyright(Settings.SKIP_COPYRIGHT);
+        final UnicodeDataFile udf =
+                UnicodeDataFile.openAndWriteHeader(
+                        "UCD/" + Default.ucdVersion() + '/',
+                        filename).
+                setSkipCopyright(Settings.SKIP_COPYRIGHT);
         final PrintWriter pw = udf.out;
         final UnicodeProperty.Factory ups
         = ToolUnicodePropertySource.make(Default.ucdVersion());
@@ -769,8 +774,9 @@ public class MakeUnicodeFiles {
     }
 
     public static void generateValueAliasFile(String filename) throws IOException {
-        final UnicodeDataFile udf = UnicodeDataFile.openAndWriteHeader(MAIN_OUTPUT_DIRECTORY, filename).setSkipCopyright(Settings.SKIP_COPYRIGHT);
-        final UnicodeDataFile diff = UnicodeDataFile.openAndWriteHeader(MAIN_OUTPUT_DIRECTORY + "extra/", "diff");
+        String outputDir = "UCD/" + Default.ucdVersion() + '/';
+        final UnicodeDataFile udf = UnicodeDataFile.openAndWriteHeader(outputDir, filename).setSkipCopyright(Settings.SKIP_COPYRIGHT);
+        final UnicodeDataFile diff = UnicodeDataFile.openAndWriteHeader(outputDir + "extra/", "diff");
         final PrintWriter pw = udf.out;
         final PrintWriter diffOut = diff.out;
         Format.theFormat.printFileComments(pw, filename);
@@ -976,7 +982,10 @@ public class MakeUnicodeFiles {
             dir = "";
         }
         final UnicodeDataFile udf =
-                UnicodeDataFile.openAndWriteHeader(MAIN_OUTPUT_DIRECTORY + dir, filename).setSkipCopyright(Settings.SKIP_COPYRIGHT);
+                UnicodeDataFile.openAndWriteHeader(
+                        "UCD/" + Default.ucdVersion() + '/' + dir,
+                        filename).
+                setSkipCopyright(Settings.SKIP_COPYRIGHT);
         final PrintWriter pwFile = udf.out;
         // bf2.openUTF8Writer(UCD_Types.GEN_DIR, "Test" + filename + ".txt");
         Format.theFormat.printFileComments(pwFile, filename);

--- a/unicodetools/src/main/java/org/unicode/text/utility/Settings.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/Settings.java
@@ -263,7 +263,7 @@ public class Settings {
                 getRequiredPathAndFix("UNICODETOOLS_OUTPUT_DIR");
         public static final String GEN_DIR = UNICODETOOLS_OUTPUT_DIR + "Generated/";
         public static final String BIN_DIR = GEN_DIR + "BIN/";
-        public static final String GEN_UCD_DIR = GEN_DIR + "ucd/";
+        public static final String GEN_UCD_DIR = GEN_DIR + "UCD/";
         public static final String GEN_UCA_DIR = GEN_DIR + "UCA/";
         /**
          * Make sure the output dirs exist

--- a/unicodetools/src/main/java/org/unicode/text/utility/UnicodeDataFile.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/UnicodeDataFile.java
@@ -82,34 +82,26 @@ public class UnicodeDataFile {
     }
 
     /**
-     * There are three cases:<br>
-     * no version (ArabicShaping.txt)<br>
-     * plain version (ArabicShaping-11.0.0.txt)<br>
-     * d version (ArabicShaping-11.0.0-d31.txt)<br>
+     * There are two cases:<br>
+     * no infix (ArabicShaping.txt)<br>
+     * plain version infix (ArabicShaping-11.0.0.txt)<br>
      */
     public enum FileInfix {
-        none, 
-        plain, 
-        d;
-        // TODO: Switch call sites to getFileSuffix(): Faster for none because it avoids concatenation.
-        public String getFileInfix() {
-            if (this == none) {
-                return "";
-            }
-            String infix = "-" + Default.ucd().getVersion();
-            if (this == d && MakeUnicodeFiles.dVersion >= 0) {
-                infix = infix + "d" + MakeUnicodeFiles.dVersion;
-            }
-            return infix;
-        }
+        none, plain;
+
         public String getFileSuffix(String fileType) {
             if (this == none) {
                 return fileType;  // avoid string concatenation
             }
-            return getFileInfix() + fileType;
+            return "-" + Default.ucd().getVersion() + fileType;
         }
-        public static FileInfix fromFlags(boolean suppress, boolean withDVersion) {
-            return suppress ? FileInfix.none : !withDVersion ? FileInfix.plain : FileInfix.d;
+
+        public static FileInfix getDefault() {
+            return suppressVersion(Settings.BUILD_FOR_COMPARE);
+        }
+
+        private static FileInfix suppressVersion(boolean suppress) {
+            return suppress ? FileInfix.none : FileInfix.plain;
         }
     }
 

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/MakeUnicodeFiles.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/MakeUnicodeFiles.txt
@@ -1,6 +1,5 @@
 Generate: .
 CopyrightYear: 2021
-DeltaVersion: 24
 
 File: extra/ScriptNfkc
 Property: SPECIAL


### PR DESCRIPTION
Now that we no longer generate files with versioned suffixes,
- delete the `DeltaVersion` line in MakeUnicodeFiles.txt
- remove the `dVersion` field in MakeUnicodeFiles.java
- write UCD output files into Generated/UCD/15.0.0 instead of Generated/UCD/d24
- simplify UnicodeDataFile.FileInfix and its call sites

Fixes issue #161