### PR TITLE
Update to CLDR version that includes jar sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 		<!--
 			 For CLDR versions, see https://github.com/orgs/unicode-org/packages?repo_name=cldr
 		  -->
-		<cldr.version>0.0.0-SNAPSHOT-bfa39570be</cldr.version>
+		<cldr.version>0.0.0-SNAPSHOT-e995b07a7e</cldr.version>
 
 
 		<!-- these two set the JDK version for source and target -->

--- a/unicodetools/src/main/java/org/unicode/text/tools/CLDRCharacterUtility.java
+++ b/unicodetools/src/main/java/org/unicode/text/tools/CLDRCharacterUtility.java
@@ -18,7 +18,7 @@ import org.unicode.cldr.util.CLDRFile.WinningChoice;
 public class CLDRCharacterUtility {
     public static UnicodeMap<Set<String>> getCLDRCharacters() {
         UnicodeMap<Set<String>> result = new UnicodeMap<>();
-        org.unicode.cldr.util.Factory factory = CLDRConfig.getInstance().getCldrFactory();
+        org.unicode.cldr.util.Factory factory = CLDRConfig.getInstance().getFullCldrFactory();
         //        File[] paths = { new File(CLDRPaths.MAIN_DIRECTORY)
         //        //, new File(CLDRPaths.SEED_DIRECTORY), new File(CLDRPaths.EXEMPLARS_DIRECTORY)
         //        };


### PR DESCRIPTION
- per CLDR-15195
- Now updates to CLDR version 0.0.0-SNAPSHOT-472af8d773
- CLDR release: snapshot/2022-01-10
- https://github.com/unicode-org/cldr/releases/tag/snapshot%2F2022-01-10