### PR TITLE
fixes for new Egyptian controls not default ignorable

### DIFF
--- a/unicodetools/data/ucd/dev/DerivedNormalizationProps.txt
+++ b/unicodetools/data/ucd/dev/DerivedNormalizationProps.txt
@@ -1,5 +1,5 @@
 # DerivedNormalizationProps-15.0.0.txt
-# Date: 2022-02-02, 00:57:00 GMT
+# Date: 2022-03-03, 22:03:13 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -7041,7 +7041,6 @@ FFF0..FFF8    ; NFKC_CF;                # Cn   [9] <reserved-FFF0>..<reserved-FF
 118BD         ; NFKC_CF; 118DD          # L&       WARANG CITI CAPITAL LETTER SSUU
 118BE         ; NFKC_CF; 118DE          # L&       WARANG CITI CAPITAL LETTER SII
 118BF         ; NFKC_CF; 118DF          # L&       WARANG CITI CAPITAL LETTER VIYO
-13439..13440  ; NFKC_CF;                # Cf   [8] EGYPTIAN HIEROGLYPH INSERT AT MIDDLE..EGYPTIAN HIEROGLYPH MIRROR HORIZONTALLY
 16E40         ; NFKC_CF; 16E60          # L&       MEDEFAIDRIN CAPITAL LETTER M
 16E41         ; NFKC_CF; 16E61          # L&       MEDEFAIDRIN CAPITAL LETTER S
 16E42         ; NFKC_CF; 16E62          # L&       MEDEFAIDRIN CAPITAL LETTER V
@@ -9002,7 +9001,7 @@ E0080..E00FF  ; NFKC_CF;                # Cn [128] <reserved-E0080>..<reserved-E
 E0100..E01EF  ; NFKC_CF;                # Mn [240] VARIATION SELECTOR-17..VARIATION SELECTOR-256
 E01F0..E0FFF  ; NFKC_CF;                # Cn [3600] <reserved-E01F0>..<reserved-E0FFF>
 
-# Total code points: 10499
+# Total code points: 10491
 
 # ================================================
 
@@ -9914,7 +9913,6 @@ FFF0..FFF8    ; Changes_When_NFKC_Casefolded # Cn   [9] <reserved-FFF0>..<reserv
 107B2..107BA  ; Changes_When_NFKC_Casefolded # Lm   [9] MODIFIER LETTER SMALL CAPITAL Y..MODIFIER LETTER SMALL S WITH CURL
 10C80..10CB2  ; Changes_When_NFKC_Casefolded # L&  [51] OLD HUNGARIAN CAPITAL LETTER A..OLD HUNGARIAN CAPITAL LETTER US
 118A0..118BF  ; Changes_When_NFKC_Casefolded # L&  [32] WARANG CITI CAPITAL LETTER NGAA..WARANG CITI CAPITAL LETTER VIYO
-13439..13440  ; Changes_When_NFKC_Casefolded # Cf   [8] EGYPTIAN HIEROGLYPH INSERT AT MIDDLE..EGYPTIAN HIEROGLYPH MIRROR HORIZONTALLY
 16E40..16E5F  ; Changes_When_NFKC_Casefolded # L&  [32] MEDEFAIDRIN CAPITAL LETTER M..MEDEFAIDRIN CAPITAL LETTER Y
 1BCA0..1BCA3  ; Changes_When_NFKC_Casefolded # Cf   [4] SHORTHAND FORMAT LETTER OVERLAP..SHORTHAND FORMAT UP STEP
 1D15E..1D164  ; Changes_When_NFKC_Casefolded # So   [7] MUSICAL SYMBOL HALF NOTE..MUSICAL SYMBOL ONE HUNDRED TWENTY-EIGHTH NOTE
@@ -10015,6 +10013,6 @@ E0080..E00FF  ; Changes_When_NFKC_Casefolded # Cn [128] <reserved-E0080>..<reser
 E0100..E01EF  ; Changes_When_NFKC_Casefolded # Mn [240] VARIATION SELECTOR-17..VARIATION SELECTOR-256
 E01F0..E0FFF  ; Changes_When_NFKC_Casefolded # Cn [3600] <reserved-E01F0>..<reserved-E0FFF>
 
-# Total code points: 10499
+# Total code points: 10491
 
 # EOF

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
@@ -533,7 +533,7 @@ Let $Uax31Removals = [\-\u058A\u0F0B\u2010\u30A0\u30FB\u2E2F\u17B4-\u17B5]
 
 # See derivation of Default_Ignorable_Code_Point in DerivedCoreProperties.txt
 Let $Annotations = [\uFFF9-\uFFFB]
-Let $EgyptianControls = [\U00013430-\U00013438]
+Let $EgyptianControls = [\U00013430-\U00013440]
 \p{Default_Ignorable_Code_Point} = [\p{Other_Default_Ignorable_Code_Point} \p{GC=Cf} \p{Variation_Selector} - [\p{White_Space} $Annotations $EgyptianControls \p{PCM}]]
 
 \p{Grapheme_Extend} = [\p{Other_Grapheme_Extend} \p{GC=Me} \p{GC=Mn}]


### PR DESCRIPTION
The new Egyptian format controls are not default ignorable.
Fix derived NFKC_CF data for them, and adjust an invariant test case.

These fixes should have been part of PR #203 but I had tooling problems last week :-/