### PR TITLE
Add tab check

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,4 +32,4 @@ jobs:
         flake8
     - name: Check .java files for tabs
       run: |
-        python py/tabcheck.py --exit-zero
+        python py/tabcheck.py

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,7 @@
-# This workflow will install and run the flake8 linter on the project's Python files.
+# This workflow will install and run the flake8 linter on the project's Python files,
+# then run the tabcheck script (checks Java files for tab characters).
 
-name: Lint Python Files
+name: Python-based Checks
 
 on:
   push:
@@ -26,6 +27,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8
-    - name: Lint with flake8
+    - name: Lint Python files with flake8
       run: |
         flake8
+    - name: Check .java files for tabs
+      run: |
+        python py/tabcheck.py --exit-zero

--- a/py/tabcheck.py
+++ b/py/tabcheck.py
@@ -30,7 +30,7 @@ def main() -> bool:
         return False
 
     error_count = 0
-    for p in Path(root).rglob("*.java"):
+    for p in root.rglob("*.java"):
         with open(p, 'r') as f:
             s = f.read()
             if '\t' in s:

--- a/py/tabcheck.py
+++ b/py/tabcheck.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python3 -B
+# © 2021 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+
+# This script checks .java source files for the presence of tab characters. If a tab is encountered,
+# the script will print the name (path) of the file. If any file(s) had tabs, the script will exit
+# with a non-zero status code (unless the --exit-zero option is specified, which forces a
+# zero/success status code return).
+
+import argparse
+from pathlib import Path
+import sys
+
+def main() -> bool:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("ROOT_DIR",
+                    nargs='?',
+                    default=Path.cwd(),
+                    help="Top-level directory which will be recursively searched "
+                         "for .java files to be checked.")
+    ap.add_argument('--exit-zero',
+                    action='store_true',
+                    help="Force exit with status code 0 even if there are errors.")
+
+    args = ap.parse_args()
+    root = Path(args.ROOT_DIR)
+
+    if not root.exists():
+        print(f'{root.absolute()}: directory not found; aborting.')
+        return False
+
+    error_count = 0
+    for p in Path(root).rglob("*.java"):
+        with open(p, 'r') as f:
+            s = f.read()
+            if '\t' in s:
+                print(f"tabs found in {p.relative_to(root)}")
+                error_count += 1
+
+    return args.exit_zero or not(bool(error_count))
+
+
+if __name__ == '__main__':
+    ok = main()
+    if not ok:
+        sys.exit("Errors encountered.")

--- a/py/tabcheck.py
+++ b/py/tabcheck.py
@@ -34,7 +34,7 @@ def main() -> bool:
         with open(p, 'r') as f:
             s = f.read()
             if '\t' in s:
-                print(f"tabs found in {p.relative_to(root)}")
+                print(f"tabs found in {p.relative_to(root)}", flush=True)
                 error_count += 1
 
     return args.exit_zero or not(bool(error_count))

--- a/py/tabcheck.py
+++ b/py/tabcheck.py
@@ -29,15 +29,15 @@ def main() -> bool:
         print(f'{root.absolute()}: directory not found; aborting.')
         return False
 
-    error_count = 0
+    errors_found = False
     for p in root.rglob("*.java"):
         with open(p, 'r') as f:
             s = f.read()
             if '\t' in s:
                 print(f"tabs found in {p.relative_to(root)}", flush=True)
-                error_count += 1
+                errors_found = True
 
-    return args.exit_zero or not(bool(error_count))
+    return args.exit_zero or not errors_found
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- add a simple Python script that checks all .java files in the project for tab characters. The script prints the full path of each file found containing tabs and fails if any are found. The script can be run independently of CI.
- minor modifications to the Python workflow to link up the tab check script
