### PR TITLE
Address JavaScript-related LGTM.com alerts

### DIFF
--- a/unicodetools/data/ucd/10.0.0-Update/NamesList.html
+++ b/unicodetools/data/ucd/10.0.0-Update/NamesList.html
@@ -622,7 +622,7 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
         <img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-<script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+<script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>
@@ -631,4 +631,3 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
 </body>
 
 </html>
-

--- a/unicodetools/data/ucd/10.0.0-Update/auxiliary/GraphemeBreakTest.html
+++ b/unicodetools/data/ucd/10.0.0-Update/auxiliary/GraphemeBreakTest.html
@@ -134,7 +134,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/10.0.0-Update/auxiliary/LineBreakTest.html
+++ b/unicodetools/data/ucd/10.0.0-Update/auxiliary/LineBreakTest.html
@@ -911,7 +911,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/10.0.0-Update/auxiliary/SentenceBreakTest.html
+++ b/unicodetools/data/ucd/10.0.0-Update/auxiliary/SentenceBreakTest.html
@@ -216,7 +216,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/10.0.0-Update/auxiliary/WordBreakTest.html
+++ b/unicodetools/data/ucd/10.0.0-Update/auxiliary/WordBreakTest.html
@@ -169,7 +169,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/11.0.0-Update/NamesList.html
+++ b/unicodetools/data/ucd/11.0.0-Update/NamesList.html
@@ -638,7 +638,7 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
         <img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-<script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+<script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>
@@ -647,4 +647,3 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
 </body>
 
 </html>
-

--- a/unicodetools/data/ucd/11.0.0-Update/auxiliary/GraphemeBreakTest.html
+++ b/unicodetools/data/ucd/11.0.0-Update/auxiliary/GraphemeBreakTest.html
@@ -137,7 +137,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/11.0.0-Update/auxiliary/LineBreakTest.html
+++ b/unicodetools/data/ucd/11.0.0-Update/auxiliary/LineBreakTest.html
@@ -911,7 +911,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/11.0.0-Update/auxiliary/SentenceBreakTest.html
+++ b/unicodetools/data/ucd/11.0.0-Update/auxiliary/SentenceBreakTest.html
@@ -216,7 +216,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/11.0.0-Update/auxiliary/WordBreakTest.html
+++ b/unicodetools/data/ucd/11.0.0-Update/auxiliary/WordBreakTest.html
@@ -185,7 +185,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/12.0.0-Update/NamesList.html
+++ b/unicodetools/data/ucd/12.0.0-Update/NamesList.html
@@ -648,7 +648,7 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
         <img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-<script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+<script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>
@@ -657,4 +657,3 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
 </body>
 
 </html>
-

--- a/unicodetools/data/ucd/12.0.0-Update/auxiliary/GraphemeBreakTest.html
+++ b/unicodetools/data/ucd/12.0.0-Update/auxiliary/GraphemeBreakTest.html
@@ -136,7 +136,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/12.0.0-Update/auxiliary/LineBreakTest.html
+++ b/unicodetools/data/ucd/12.0.0-Update/auxiliary/LineBreakTest.html
@@ -911,7 +911,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/12.0.0-Update/auxiliary/SentenceBreakTest.html
+++ b/unicodetools/data/ucd/12.0.0-Update/auxiliary/SentenceBreakTest.html
@@ -216,7 +216,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/12.0.0-Update/auxiliary/WordBreakTest.html
+++ b/unicodetools/data/ucd/12.0.0-Update/auxiliary/WordBreakTest.html
@@ -185,7 +185,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/12.1.0-Update/NamesList.html
+++ b/unicodetools/data/ucd/12.1.0-Update/NamesList.html
@@ -653,7 +653,7 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
         <img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-<script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+<script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>
@@ -662,4 +662,3 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
 </body>
 
 </html>
-

--- a/unicodetools/data/ucd/12.1.0-Update/auxiliary/GraphemeBreakTest.html
+++ b/unicodetools/data/ucd/12.1.0-Update/auxiliary/GraphemeBreakTest.html
@@ -136,7 +136,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/12.1.0-Update/auxiliary/LineBreakTest.html
+++ b/unicodetools/data/ucd/12.1.0-Update/auxiliary/LineBreakTest.html
@@ -911,7 +911,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/12.1.0-Update/auxiliary/SentenceBreakTest.html
+++ b/unicodetools/data/ucd/12.1.0-Update/auxiliary/SentenceBreakTest.html
@@ -216,7 +216,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/12.1.0-Update/auxiliary/WordBreakTest.html
+++ b/unicodetools/data/ucd/12.1.0-Update/auxiliary/WordBreakTest.html
@@ -185,7 +185,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/13.0.0-Update/auxiliary/GraphemeBreakTest.html
+++ b/unicodetools/data/ucd/13.0.0-Update/auxiliary/GraphemeBreakTest.html
@@ -136,7 +136,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/13.0.0-Update/auxiliary/LineBreakTest.html
+++ b/unicodetools/data/ucd/13.0.0-Update/auxiliary/LineBreakTest.html
@@ -908,7 +908,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/13.0.0-Update/auxiliary/SentenceBreakTest.html
+++ b/unicodetools/data/ucd/13.0.0-Update/auxiliary/SentenceBreakTest.html
@@ -216,7 +216,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/13.0.0-Update/auxiliary/WordBreakTest.html
+++ b/unicodetools/data/ucd/13.0.0-Update/auxiliary/WordBreakTest.html
@@ -185,7 +185,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/14.0.0-Update/auxiliary/GraphemeBreakTest.html
+++ b/unicodetools/data/ucd/14.0.0-Update/auxiliary/GraphemeBreakTest.html
@@ -136,7 +136,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/14.0.0-Update/auxiliary/LineBreakTest.html
+++ b/unicodetools/data/ucd/14.0.0-Update/auxiliary/LineBreakTest.html
@@ -914,7 +914,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/14.0.0-Update/auxiliary/SentenceBreakTest.html
+++ b/unicodetools/data/ucd/14.0.0-Update/auxiliary/SentenceBreakTest.html
@@ -216,7 +216,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/14.0.0-Update/auxiliary/WordBreakTest.html
+++ b/unicodetools/data/ucd/14.0.0-Update/auxiliary/WordBreakTest.html
@@ -185,7 +185,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/3.1.0-Update/NamesList.html
+++ b/unicodetools/data/ucd/3.1.0-Update/NamesList.html
@@ -362,7 +362,7 @@ UCD <a name="Terms of Use">Terms of Use</a></h2>
                   alt="E-mail" width="46" height="49"></a></td>  
               </tr>  
             </table>  
-            <script language="Javascript" src="http://www.unicode.org/webscripts/lastModified.js"></script>                
+            <script language="Javascript" src="https://www.unicode.org/webscripts/lastModified.js"></script>                
             </center>  
           </div>  
 </form>  

--- a/unicodetools/data/ucd/3.1.1-Update/NamesList.html
+++ b/unicodetools/data/ucd/3.1.1-Update/NamesList.html
@@ -362,7 +362,7 @@ UCD <a name="Terms of Use">Terms of Use</a></h2>
                   alt="E-mail" width="46" height="49"></a></td>  
               </tr>  
             </table>  
-            <script language="Javascript" src="http://www.unicode.org/webscripts/lastModified.js"></script>                
+            <script language="Javascript" src="https://www.unicode.org/webscripts/lastModified.js"></script>                
             </center>  
           </div>  
 </form>  

--- a/unicodetools/data/ucd/3.2.0-Update/StandardizedVariants.html
+++ b/unicodetools/data/ucd/3.2.0-Update/StandardizedVariants.html
@@ -829,7 +829,7 @@
     <img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
     </tr>
     </table>
-    <script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js"></script>
+    <script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js"></script>
     </center>
     </div>
 

--- a/unicodetools/data/ucd/4.0.0-Update/StandardizedVariants.html
+++ b/unicodetools/data/ucd/4.0.0-Update/StandardizedVariants.html
@@ -562,7 +562,7 @@
         <td><a href="http://www.unicode.org/unicode/copyright.html"><img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-    <script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js"></script>
+    <script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js"></script>
     </center>
   </div>
 </blockquote>

--- a/unicodetools/data/ucd/4.0.1-Update/StandardizedVariants.html
+++ b/unicodetools/data/ucd/4.0.1-Update/StandardizedVariants.html
@@ -562,7 +562,7 @@
         <td><a href="http://www.unicode.org/unicode/copyright.html"><img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-    <script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js"></script>
+    <script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js"></script>
     </center>
   </div>
 </blockquote>

--- a/unicodetools/data/ucd/4.0.1-Update/UCD.html
+++ b/unicodetools/data/ucd/4.0.1-Update/UCD.html
@@ -2562,7 +2562,7 @@ widening to ints in Java. </li>
         <td><a href="http://www.unicode.org/copyright.html"><img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-              <script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+              <script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script></center>
   </div>
 </div>

--- a/unicodetools/data/ucd/4.1.0-Update/StandardizedVariants.html
+++ b/unicodetools/data/ucd/4.1.0-Update/StandardizedVariants.html
@@ -546,7 +546,7 @@
         <td><a href="http://www.unicode.org/unicode/copyright.html"><img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-    <script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js"></script>
+    <script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js"></script>
     </center>
   </div>
 </blockquote>

--- a/unicodetools/data/ucd/4.1.0-Update/UCD.html
+++ b/unicodetools/data/ucd/4.1.0-Update/UCD.html
@@ -2526,7 +2526,7 @@ extensively revised, and now appears in Unihan.html.</p>
         <img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-    <script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+    <script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>

--- a/unicodetools/data/ucd/4.1.0-Update/Unihan.html
+++ b/unicodetools/data/ucd/4.1.0-Update/Unihan.html
@@ -3357,7 +3357,7 @@ th           { background-color: #CCFFCC }
         <img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-    <script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+    <script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>

--- a/unicodetools/data/ucd/5.0.0-Update/NamesList.html
+++ b/unicodetools/data/ucd/5.0.0-Update/NamesList.html
@@ -361,7 +361,7 @@ COMMENT:		&quot;(&quot; LABEL &quot;)&quot;
       </tr>
     </table>
 
-<script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+<script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>
@@ -370,4 +370,3 @@ COMMENT:		&quot;(&quot; LABEL &quot;)&quot;
 </body>
 
 </html>
-

--- a/unicodetools/data/ucd/5.0.0-Update/StandardizedVariants.html
+++ b/unicodetools/data/ucd/5.0.0-Update/StandardizedVariants.html
@@ -562,7 +562,7 @@
         <img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-    <script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+    <script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
     </script>
     </center>
   </div>

--- a/unicodetools/data/ucd/5.0.0-Update/UCD.html
+++ b/unicodetools/data/ucd/5.0.0-Update/UCD.html
@@ -2753,7 +2753,7 @@ window.open = SymWinOpen;
 //-->
 </script>
 
-<script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+<script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>
@@ -2762,4 +2762,3 @@ window.open = SymWinOpen;
 </body>
 
 </html>
-

--- a/unicodetools/data/ucd/5.0.0-Update/Unihan.html
+++ b/unicodetools/data/ucd/5.0.0-Update/Unihan.html
@@ -3488,7 +3488,7 @@ th           { background-color: #CCFFCC }
         <img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-    <script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+    <script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>

--- a/unicodetools/data/ucd/5.1.0-Update/NamesList.html
+++ b/unicodetools/data/ucd/5.1.0-Update/NamesList.html
@@ -439,7 +439,7 @@ COMMENT:	           &quot;(&quot; LABEL &quot;)&quot;
         <img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-<script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+<script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>
@@ -448,4 +448,3 @@ COMMENT:	           &quot;(&quot; LABEL &quot;)&quot;
 </body>
 
 </html>
-

--- a/unicodetools/data/ucd/5.1.0-Update/StandardizedVariants.html
+++ b/unicodetools/data/ucd/5.1.0-Update/StandardizedVariants.html
@@ -564,7 +564,7 @@ the variation selector.</p><p>The mathematical variants are all produced with th
         <img src="http://www.unicode.org/img/hb_notice.gif" alt="Access to Copyright and terms of use" border="0" height="50" width="216"></a></td>
       </tr>
     </tbody></table>
-    <script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+    <script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
     </script>
     </center>
   </div>

--- a/unicodetools/data/ucd/5.1.0-Update/UCD.html
+++ b/unicodetools/data/ucd/5.1.0-Update/UCD.html
@@ -3148,7 +3148,7 @@ window.open = SymWinOpen;
 //-->
 </script>
 
-<script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+<script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>
@@ -3157,4 +3157,3 @@ window.open = SymWinOpen;
 </body>
 
 </html>
-

--- a/unicodetools/data/ucd/5.1.0-Update/Unihan.html
+++ b/unicodetools/data/ucd/5.1.0-Update/Unihan.html
@@ -109,7 +109,7 @@ th           { background-color: #CCFFCC }
         <img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-    <script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+    <script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>

--- a/unicodetools/data/ucd/5.1.0-Update/auxiliary/GraphemeBreakTest.html
+++ b/unicodetools/data/ucd/5.1.0-Update/auxiliary/GraphemeBreakTest.html
@@ -49,7 +49,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/5.1.0-Update/auxiliary/LineBreakTest.html
+++ b/unicodetools/data/ucd/5.1.0-Update/auxiliary/LineBreakTest.html
@@ -165,7 +165,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/5.1.0-Update/auxiliary/SentenceBreakTest.html
+++ b/unicodetools/data/ucd/5.1.0-Update/auxiliary/SentenceBreakTest.html
@@ -166,7 +166,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/5.1.0-Update/auxiliary/WordBreakTest.html
+++ b/unicodetools/data/ucd/5.1.0-Update/auxiliary/WordBreakTest.html
@@ -100,7 +100,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/5.2.0-Update/NamesList.html
+++ b/unicodetools/data/ucd/5.2.0-Update/NamesList.html
@@ -480,7 +480,7 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
         <img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-<script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+<script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>
@@ -489,4 +489,3 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
 </body>
 
 </html>
-

--- a/unicodetools/data/ucd/5.2.0-Update/StandardizedVariants.html
+++ b/unicodetools/data/ucd/5.2.0-Update/StandardizedVariants.html
@@ -566,7 +566,7 @@ the variation selector.</p><p>The mathematical variants are all produced with th
         <img src="http://www.unicode.org/img/hb_notice.gif" alt="Access to Copyright and terms of use" border="0" height="50" width="216"></a></td>
       </tr>
     </tbody></table>
-    <script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+    <script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
     </script>
     </center>
   </div>

--- a/unicodetools/data/ucd/5.2.0-Update/auxiliary/GraphemeBreakTest.html
+++ b/unicodetools/data/ucd/5.2.0-Update/auxiliary/GraphemeBreakTest.html
@@ -49,7 +49,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/5.2.0-Update/auxiliary/LineBreakTest.html
+++ b/unicodetools/data/ucd/5.2.0-Update/auxiliary/LineBreakTest.html
@@ -181,7 +181,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/5.2.0-Update/auxiliary/SentenceBreakTest.html
+++ b/unicodetools/data/ucd/5.2.0-Update/auxiliary/SentenceBreakTest.html
@@ -178,7 +178,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/5.2.0-Update/auxiliary/WordBreakTest.html
+++ b/unicodetools/data/ucd/5.2.0-Update/auxiliary/WordBreakTest.html
@@ -100,7 +100,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/6.0.0-Update/NamesList.html
+++ b/unicodetools/data/ucd/6.0.0-Update/NamesList.html
@@ -495,7 +495,7 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
         <img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-<script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+<script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>
@@ -504,4 +504,3 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
 </body>
 
 </html>
-

--- a/unicodetools/data/ucd/6.0.0-Update/StandardizedVariants.html
+++ b/unicodetools/data/ucd/6.0.0-Update/StandardizedVariants.html
@@ -565,7 +565,7 @@ the variation selector.</p><p>The mathematical variants are all produced with th
         <img src="http://www.unicode.org/img/hb_notice.gif" alt="Access to Copyright and terms of use" border="0" height="50" width="216"></a></td>
       </tr>
     </tbody></table>
-    <script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+    <script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
     </script>
     </center>
   </div>

--- a/unicodetools/data/ucd/6.0.0-Update/auxiliary/GraphemeBreakTest.html
+++ b/unicodetools/data/ucd/6.0.0-Update/auxiliary/GraphemeBreakTest.html
@@ -49,7 +49,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/6.0.0-Update/auxiliary/LineBreakTest.html
+++ b/unicodetools/data/ucd/6.0.0-Update/auxiliary/LineBreakTest.html
@@ -778,7 +778,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/6.0.0-Update/auxiliary/SentenceBreakTest.html
+++ b/unicodetools/data/ucd/6.0.0-Update/auxiliary/SentenceBreakTest.html
@@ -178,7 +178,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/6.0.0-Update/auxiliary/WordBreakTest.html
+++ b/unicodetools/data/ucd/6.0.0-Update/auxiliary/WordBreakTest.html
@@ -100,7 +100,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/6.1.0-Update/NamesList.html
+++ b/unicodetools/data/ucd/6.1.0-Update/NamesList.html
@@ -500,7 +500,7 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
         <img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-<script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+<script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>
@@ -509,4 +509,3 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
 </body>
 
 </html>
-

--- a/unicodetools/data/ucd/6.1.0-Update/StandardizedVariants.html
+++ b/unicodetools/data/ucd/6.1.0-Update/StandardizedVariants.html
@@ -1634,7 +1634,7 @@ the variation selector.</p><p>The mathematical variants are all produced with th
         <img src="http://www.unicode.org/img/hb_notice.gif" alt="Access to Copyright and terms of use" border="0" height="50" width="216"></a></td>
       </tr>
     </tbody></table>
-    <script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+    <script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
     </script>
     </center>
   </div>

--- a/unicodetools/data/ucd/6.1.0-Update/auxiliary/GraphemeBreakTest.html
+++ b/unicodetools/data/ucd/6.1.0-Update/auxiliary/GraphemeBreakTest.html
@@ -52,7 +52,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/6.1.0-Update/auxiliary/LineBreakTest.html
+++ b/unicodetools/data/ucd/6.1.0-Update/auxiliary/LineBreakTest.html
@@ -782,7 +782,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/6.1.0-Update/auxiliary/SentenceBreakTest.html
+++ b/unicodetools/data/ucd/6.1.0-Update/auxiliary/SentenceBreakTest.html
@@ -179,7 +179,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/6.1.0-Update/auxiliary/WordBreakTest.html
+++ b/unicodetools/data/ucd/6.1.0-Update/auxiliary/WordBreakTest.html
@@ -101,7 +101,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/6.2.0-Update/NamesList.html
+++ b/unicodetools/data/ucd/6.2.0-Update/NamesList.html
@@ -575,7 +575,7 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
         <img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-<script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+<script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>
@@ -584,4 +584,3 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
 </body>
 
 </html>
-

--- a/unicodetools/data/ucd/6.2.0-Update/StandardizedVariants.html
+++ b/unicodetools/data/ucd/6.2.0-Update/StandardizedVariants.html
@@ -1634,7 +1634,7 @@ the variation selector.</p><p>The mathematical variants are all produced with th
         <img src="http://www.unicode.org/img/hb_notice.gif" alt="Access to Copyright and terms of use" border="0" height="50" width="216"></a></td>
       </tr>
     </tbody></table>
-    <script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+    <script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
     </script>
     </center>
   </div>

--- a/unicodetools/data/ucd/6.2.0-Update/auxiliary/GraphemeBreakTest.html
+++ b/unicodetools/data/ucd/6.2.0-Update/auxiliary/GraphemeBreakTest.html
@@ -89,7 +89,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/6.2.0-Update/auxiliary/LineBreakTest.html
+++ b/unicodetools/data/ucd/6.2.0-Update/auxiliary/LineBreakTest.html
@@ -812,7 +812,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/6.2.0-Update/auxiliary/SentenceBreakTest.html
+++ b/unicodetools/data/ucd/6.2.0-Update/auxiliary/SentenceBreakTest.html
@@ -195,7 +195,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/6.2.0-Update/auxiliary/WordBreakTest.html
+++ b/unicodetools/data/ucd/6.2.0-Update/auxiliary/WordBreakTest.html
@@ -134,7 +134,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/6.3.0-Update/NamesList.html
+++ b/unicodetools/data/ucd/6.3.0-Update/NamesList.html
@@ -579,7 +579,7 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
         <img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-<script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+<script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>
@@ -588,4 +588,3 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
 </body>
 
 </html>
-

--- a/unicodetools/data/ucd/6.3.0-Update/StandardizedVariants.html
+++ b/unicodetools/data/ucd/6.3.0-Update/StandardizedVariants.html
@@ -1637,7 +1637,7 @@ the variation selector.</p><p>The mathematical variants are all produced with th
         <img src="http://www.unicode.org/img/hb_notice.gif" alt="Access to Copyright and terms of use" border="0" height="50" width="216"></a></td>
       </tr>
     </tbody></table>
-    <script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+    <script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
     </script>
     </center>
   </div>

--- a/unicodetools/data/ucd/6.3.0-Update/auxiliary/GraphemeBreakTest.html
+++ b/unicodetools/data/ucd/6.3.0-Update/auxiliary/GraphemeBreakTest.html
@@ -89,7 +89,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/6.3.0-Update/auxiliary/LineBreakTest.html
+++ b/unicodetools/data/ucd/6.3.0-Update/auxiliary/LineBreakTest.html
@@ -812,7 +812,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/6.3.0-Update/auxiliary/SentenceBreakTest.html
+++ b/unicodetools/data/ucd/6.3.0-Update/auxiliary/SentenceBreakTest.html
@@ -195,7 +195,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/6.3.0-Update/auxiliary/WordBreakTest.html
+++ b/unicodetools/data/ucd/6.3.0-Update/auxiliary/WordBreakTest.html
@@ -140,7 +140,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/7.0.0-Update/NamesList.html
+++ b/unicodetools/data/ucd/7.0.0-Update/NamesList.html
@@ -583,7 +583,7 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
         <img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-<script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+<script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>
@@ -592,4 +592,3 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
 </body>
 
 </html>
-

--- a/unicodetools/data/ucd/7.0.0-Update/StandardizedVariants.html
+++ b/unicodetools/data/ucd/7.0.0-Update/StandardizedVariants.html
@@ -1637,7 +1637,7 @@ the variation selector.</p><p>The mathematical variants are all produced with th
         <img src="http://www.unicode.org/img/hb_notice.gif" alt="Access to Copyright and terms of use" border="0" height="50" width="216"></a></td>
       </tr>
     </tbody></table>
-    <script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+    <script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
     </script>
     </center>
   </div>

--- a/unicodetools/data/ucd/7.0.0-Update/auxiliary/GraphemeBreakTest.html
+++ b/unicodetools/data/ucd/7.0.0-Update/auxiliary/GraphemeBreakTest.html
@@ -89,7 +89,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/7.0.0-Update/auxiliary/LineBreakTest.html
+++ b/unicodetools/data/ucd/7.0.0-Update/auxiliary/LineBreakTest.html
@@ -812,7 +812,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/7.0.0-Update/auxiliary/SentenceBreakTest.html
+++ b/unicodetools/data/ucd/7.0.0-Update/auxiliary/SentenceBreakTest.html
@@ -195,7 +195,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/7.0.0-Update/auxiliary/WordBreakTest.html
+++ b/unicodetools/data/ucd/7.0.0-Update/auxiliary/WordBreakTest.html
@@ -140,7 +140,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/8.0.0-Update/NamesList.html
+++ b/unicodetools/data/ucd/8.0.0-Update/NamesList.html
@@ -613,7 +613,7 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
         <img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-<script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+<script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>
@@ -622,4 +622,3 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
 </body>
 
 </html>
-

--- a/unicodetools/data/ucd/8.0.0-Update/StandardizedVariants.html
+++ b/unicodetools/data/ucd/8.0.0-Update/StandardizedVariants.html
@@ -1754,7 +1754,7 @@ in <em><a href='http://www.unicode.org/reports/tr37/'>UTS #37: Unicode Ideograph
         <img src="http://www.unicode.org/img/hb_notice.gif" alt="Access to Copyright and terms of use" border="0" height="50" width="216"></a></td>
       </tr>
     </tbody></table>
-    <script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+    <script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
     </script>
     </center>
   </div>

--- a/unicodetools/data/ucd/8.0.0-Update/auxiliary/GraphemeBreakTest.html
+++ b/unicodetools/data/ucd/8.0.0-Update/auxiliary/GraphemeBreakTest.html
@@ -89,7 +89,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/8.0.0-Update/auxiliary/LineBreakTest.html
+++ b/unicodetools/data/ucd/8.0.0-Update/auxiliary/LineBreakTest.html
@@ -817,7 +817,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/8.0.0-Update/auxiliary/SentenceBreakTest.html
+++ b/unicodetools/data/ucd/8.0.0-Update/auxiliary/SentenceBreakTest.html
@@ -219,7 +219,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/8.0.0-Update/auxiliary/WordBreakTest.html
+++ b/unicodetools/data/ucd/8.0.0-Update/auxiliary/WordBreakTest.html
@@ -167,7 +167,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/9.0.0-Update/NamesList.html
+++ b/unicodetools/data/ucd/9.0.0-Update/NamesList.html
@@ -617,7 +617,7 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
         <img src="http://www.unicode.org/img/hb_notice.gif" border="0" alt="Access to Copyright and terms of use" width="216" height="50"></a></td>
       </tr>
     </table>
-<script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+<script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
                 </script>
     </center>
   </div>
@@ -626,4 +626,3 @@ COMMENT:	&quot;(&quot; LABEL &quot;)&quot;
 </body>
 
 </html>
-

--- a/unicodetools/data/ucd/9.0.0-Update/StandardizedVariants.html
+++ b/unicodetools/data/ucd/9.0.0-Update/StandardizedVariants.html
@@ -91,7 +91,7 @@ sequences are defined according to the registration process specified in
         <img src="http://www.unicode.org/img/hb_notice.gif" alt="Access to Copyright and terms of use" border="0" height="50" width="216"></a></td>
       </tr>
     </tbody></table>
-    <script language="Javascript" type="text/javascript" src="http://www.unicode.org/webscripts/lastModified.js">
+    <script language="Javascript" type="text/javascript" src="https://www.unicode.org/webscripts/lastModified.js">
     </script>
     </center>
   </div>

--- a/unicodetools/data/ucd/9.0.0-Update/auxiliary/GraphemeBreakTest.html
+++ b/unicodetools/data/ucd/9.0.0-Update/auxiliary/GraphemeBreakTest.html
@@ -134,7 +134,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/9.0.0-Update/auxiliary/LineBreakTest.html
+++ b/unicodetools/data/ucd/9.0.0-Update/auxiliary/LineBreakTest.html
@@ -911,7 +911,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/9.0.0-Update/auxiliary/SentenceBreakTest.html
+++ b/unicodetools/data/ucd/9.0.0-Update/auxiliary/SentenceBreakTest.html
@@ -216,7 +216,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/data/ucd/9.0.0-Update/auxiliary/WordBreakTest.html
+++ b/unicodetools/data/ucd/9.0.0-Update/auxiliary/WordBreakTest.html
@@ -169,7 +169,7 @@ td, th { vertical-align: top }
 <img src='http://www.unicode.org/img/hb_notice.gif' border='0' alt='Access to Copyright and terms of use' width='216' height='50'></a></td>
 </tr>
 </table>
-<script language='Javascript' type='text/javascript' src='http://www.unicode.org/webscripts/lastModified.js'>
+<script language='Javascript' type='text/javascript' src='https://www.unicode.org/webscripts/lastModified.js'>
 </script>
 </center>
 </div>

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/UCD-in-XML-Notes.htm
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/UCD-in-XML-Notes.htm
@@ -15,7 +15,7 @@ td           { padding: 4 }
 
 <body>
 
-<span class="cb" id style="DISPLAY: block">
+<span class="cb" style="DISPLAY: block">
 <h1 align="center">Unicode Character Database (UCD) in XML Format</h1>
 <h1 align="center"><b><font color="#FF0000">WARNING: FORMAT IS DRAFT!</font></b></h1>
 <p align="center">MD 2000.10.16</p>
@@ -105,7 +105,7 @@ Since the PropList values are so long, they will probably also be abbreviated in
 the future.</p>
 <table border="1" width="100%">
   <tr>
-    <td width="50%" valign="top"><span class="cb" id style="DISPLAY: block">
+    <td width="50%" valign="top"><span class="cb" style="DISPLAY: block">
       <h4>UnicodeData</h4>
       <p>&nbsp; c: code point<br>
       &nbsp; n: name<br>
@@ -127,7 +127,7 @@ the future.</p>
       &nbsp; sc: special case condition</p>
       <h4>CaseFolding:</h4>
       <p>&nbsp; fc: foldcase (=sl)</span></td>
-    <td width="50%" valign="top"><span class="cb" id style="DISPLAY: block">
+    <td width="50%" valign="top"><span class="cb" style="DISPLAY: block">
       <h4>CompositionExclusions:</h4>
       <p>&nbsp; ce: composition exclusion (N)</p>
       <h4>EastAsianWidth:</h4>
@@ -176,7 +176,7 @@ changes, detailed below.</p>
       <p>The fields are based on the proposed PropList.alpha, which changes the
       fields considerably.</p>
       </font>
-      <p><span class="cb" id style="display: block"><b><i>WARNING: other values
+      <p><span class="cb" style="display: block"><b><i>WARNING: other values
       are also likely to change!</i></b></span></p>
     </td>
   </tr>


### PR DESCRIPTION
As mentioned in #208 and discussed in email with @macchiati 

Notes for reviewers:
 - the vast majority of the changes are simply "http" --> "https"
 - there are a few fixes for empty `id` attributes
 - this should close most of the current (March, 2022) LGTM.com alerts, but be advised that as of this writing that analysis is limited to JavaScript and Python code. Once we're able to get LGTM.com to build the Java code, there will likely be many more to address.
 