### PR TITLE
add Eclipse .settings/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ perf-*.xml
 test-*.xml
 
 # Directories
+.settings/
 .vs/
 .vscode/
 ARM/


### PR DESCRIPTION
After importing the new Maven project into Eclipse, git status reported that there was a new folder `unicodetools-testutils/.settings/`. AFAIU we don't want to check in IDE-specific settings.