### PR TITLE
switch from ICU ObjectMatcher to Java Predicate

### DIFF
--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeProperty.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeProperty.java
@@ -19,13 +19,12 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import org.unicode.cldr.util.props.UnicodeLabel;
 
 import com.ibm.icu.dev.util.CollectionUtilities;
-import com.ibm.icu.dev.util.CollectionUtilities.InverseMatcher;
-import com.ibm.icu.dev.util.CollectionUtilities.ObjectMatcher;
 import com.ibm.icu.dev.util.UnicodeMap;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.text.SymbolTable;
@@ -307,7 +306,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             for (UnicodeSetIterator usi = getStuffToTest(uniformUnassigned); usi.next();) { // int i = 0; i <= 0x10FFFF; ++i
                 int i = usi.codepoint;
                 String value = getValue(i);
-                if (value != null && matcher.matches(value)) {
+                if (value != null && matcher.test(value)) {
                     result.add(i);
                 }
             }
@@ -323,8 +322,8 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             while (it2.hasNext()) {
                 String value2 = (String) it2.next();
                 // System.out.println("Values:" + value2);
-                if (matcher.matches(value2)
-                        || matcher.matches(toSkeleton(value2))) {
+                if (matcher.test(value2)
+                        || matcher.test(toSkeleton(value2))) {
                     um.keySet(value, result);
                     continue main;
                 }
@@ -1087,12 +1086,11 @@ public abstract class UnicodeProperty extends UnicodeLabel {
         }
     }
 
-    public interface PatternMatcher extends ObjectMatcher {
+    public interface PatternMatcher extends Predicate<String> {
         public PatternMatcher set(String pattern);
     }
 
-    public static class InversePatternMatcher extends InverseMatcher implements
-    PatternMatcher {
+    public static class InversePatternMatcher implements PatternMatcher {
         PatternMatcher other;
 
         public PatternMatcher set(PatternMatcher toInverse) {
@@ -1100,8 +1098,8 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             return this;
         }
 
-        public boolean matches(Object value) {
-            return !other.matches(value);
+        public boolean test(String value) {
+            return !other.test(value);
         }
 
         public PatternMatcher set(String pattern) {
@@ -1120,7 +1118,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             this.pattern = pattern;
         }
 
-        public boolean matches(Object value) {
+        public boolean test(String value) {
             if (comparator == null)
                 return pattern.equals(value);
             return comparator.compare(pattern, value) == 0;
@@ -1140,7 +1138,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             return this;
         }
         UFormat foo;
-        public boolean matches(Object value) {
+        public boolean test(String value) {
             matcher.reset(value.toString());
             return matcher.find();
         }

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeSetUtilities.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeSetUtilities.java
@@ -156,7 +156,7 @@ public class UnicodeSetUtilities {
             if (propertyValue.length() != 0) {
                 if (prop == null) {
                     propertyValue = propertyValue.trim();
-                } else if (prop.isTrimable()) {
+                } else if (prop.isTrimmable()) {
                     propertyValue = propertyValue.trim();
                 } else {
                     int debug = 0;

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeSetUtilities.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeSetUtilities.java
@@ -237,7 +237,7 @@ public class UnicodeSetUtilities {
                     set = new UnicodeSet();
                     List<String> values = prop.getAvailableValues();
                     for (String value : values) {
-                        if (patternMatcher.matches(value)) {
+                        if (patternMatcher.test(value)) {
                             for (String other : values) {
                                 if (other.compareTo(value) <= 0) {
                                     set.addAll(prop.getSet(other));
@@ -284,7 +284,7 @@ public class UnicodeSetUtilities {
             this.pattern = pattern;
         }
 
-        public boolean matches(Object value) {
+        public boolean test(String value) {
             int comp = comparator.compare(pattern, value.toString());
             switch (relation) {
             case less: return comp < 0;

--- a/unicodetools/src/main/java/org/unicode/jsp/ICUPropertyFactory.java
+++ b/unicodetools/src/main/java/org/unicode/jsp/ICUPropertyFactory.java
@@ -241,7 +241,7 @@ public class ICUPropertyFactory extends UnicodeProperty.Factory {
       if (propEnum == UProperty.GENERAL_CATEGORY) {
         for (String multiprop : SPECIAL_GC.keySet()) {
           R2<String, UnicodeSet> value = SPECIAL_GC.get(multiprop);
-          if (matcher.matches(multiprop) || matcher.matches(value.get0())) {
+          if (matcher.test(multiprop) || matcher.test(value.get0())) {
             result.addAll(value.get1());
           }
         }

--- a/unicodetools/src/main/java/org/unicode/jsp/MySymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/jsp/MySymbolTable.java
@@ -132,7 +132,7 @@ public class MySymbolTable extends UnicodeSet.XSymbolTable {
                 set = new UnicodeSet();
                 List<String> values = prop.getAvailableValues();
                 for (String value : values) {
-                    if (patternMatcher.matches(value)) {
+                    if (patternMatcher.test(value)) {
                         for (String other : values) {
                             if (other.compareTo(value) <= 0) {
                                 set.addAll(prop.getSet(other));
@@ -171,7 +171,7 @@ public class MySymbolTable extends UnicodeSet.XSymbolTable {
         }
 
         @Override
-        public boolean matches(Object value) {
+        public boolean test(String value) {
             int comp = comparator.compare(pattern, value.toString());
             switch (relation) {
             case less: return comp < 0;

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -25,7 +25,6 @@ import java.util.regex.Pattern;
 import com.ibm.icu.dev.util.UnicodeMap;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.text.SymbolTable;
-import com.ibm.icu.text.UFormat;
 import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeMatcher;
 import com.ibm.icu.text.UnicodeSet;
@@ -137,7 +136,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
 
     private int type;
 
-    private Map valueToFirstValueAlias = null;
+    private Map<String, String> valueToFirstValueAlias = null;
 
     private boolean hasUniformUnassigned = true;
 
@@ -216,13 +215,13 @@ public abstract class UnicodeProperty extends UnicodeLabel {
 
     public List<String> getNameAliases(List<String> result) {
         if (result == null)
-            result = new ArrayList(1);
+            result = new ArrayList<>(1);
         return _getNameAliases(result);
     }
 
     public List<String> getValueAliases(String valueAlias, List<String> result) {
         if (result == null)
-            result = new ArrayList(1);
+            result = new ArrayList<>(1);
         result = _getValueAliases(valueAlias, result);
         if (!result.contains(valueAlias)) { // FIX && type < NUMERIC
             result = _getValueAliases(valueAlias, result); // for debugging
@@ -235,7 +234,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
 
     public List<String> getAvailableValues(List<String> result) {
         if (result == null)
-            result = new ArrayList(1);
+            result = new ArrayList<>(1);
         return _getAvailableValues(result);
     }
 
@@ -262,6 +261,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
         return getAvailableValues(null);
     }
 
+    @Override
     public final String getValue(int codepoint, boolean getShortest) {
         String result = getValue(codepoint);
         if (type >= MISC || result == null || !getShortest)
@@ -285,11 +285,11 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     private void _getFirstValueAliasCache() {
         maxValueWidth = 0;
         maxFirstValueAliasWidth = 0;
-        valueToFirstValueAlias = new HashMap(1);
-        Iterator it = getAvailableValues().iterator();
+        valueToFirstValueAlias = new HashMap<>(1);
+        Iterator<String> it = getAvailableValues().iterator();
         while (it.hasNext()) {
-            String value = (String) it.next();
-            String first = (String) getValueAliases(value).get(0);
+            String value = it.next();
+            String first = getValueAliases(value).get(0);
             if (first == null) { // internal error
                 throw new IllegalArgumentException(
                         "Value not in value aliases: " + value);
@@ -313,6 +313,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
 
     private int maxFirstValueAliasWidth = -1;
 
+    @Override
     public int getMaxWidth(boolean getShortest) {
         if (maxValueWidth < 0)
             _getFirstValueAliasCache();
@@ -337,7 +338,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
                 result);
     }
 
-    private UnicodeMap unicodeMap = null;
+    private UnicodeMap<String> unicodeMap = null;
 
     public static final String UNUSED = "??";
 
@@ -355,13 +356,13 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             }
             return addUntested(result, uniformUnassigned);
         }
-        List temp = new ArrayList(1); // to avoid reallocating...
-        UnicodeMap um = getUnicodeMap_internal();
-        Iterator it = um.getAvailableValues(null).iterator();
+        List<String> temp = new ArrayList<>(1); // to avoid reallocating...
+        UnicodeMap<String> um = getUnicodeMap_internal();
+        Iterator<String> it = um.getAvailableValues(null).iterator();
         main: while (it.hasNext()) {
             String value = (String) it.next();
             temp.clear();
-            Iterator it2 = getValueAliases(value, temp).iterator();
+            Iterator<String> it2 = getValueAliases(value, temp).iterator();
             while (it2.hasNext()) {
                 String value2 = (String) it2.next();
                 // System.out.println("Values:" + value2);
@@ -396,7 +397,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     }
 
     // TODO use this instead of plain strings
-    public static class Name implements Comparable {
+    public static class Name implements Comparable<Name> {
         private String skeleton;
 
         private String pretty;
@@ -414,18 +415,22 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             }
         }
 
-        public int compareTo(Object o) {
-            return skeleton.compareTo(((Name) o).skeleton);
+        @Override
+        public int compareTo(Name o) {
+            return skeleton.compareTo(o.skeleton);
         }
 
+        @Override
         public boolean equals(Object o) {
             return skeleton.equals(((Name) o).skeleton);
         }
 
+        @Override
         public int hashCode() {
             return skeleton.hashCode();
         }
 
+        @Override
         public String toString() {
             return pretty;
         }
@@ -434,17 +439,17 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     /**
      * @return the unicode map
      */
-    public UnicodeMap getUnicodeMap() {
+    public UnicodeMap<String> getUnicodeMap() {
         return getUnicodeMap(false);
     }
 
     /**
      * @return the unicode map
      */
-    public UnicodeMap getUnicodeMap(boolean getShortest) {
+    public UnicodeMap<String> getUnicodeMap(boolean getShortest) {
         if (!getShortest)
-            return (UnicodeMap) getUnicodeMap_internal().cloneAsThawed();
-        UnicodeMap result = new UnicodeMap();
+            return getUnicodeMap_internal().cloneAsThawed();
+        UnicodeMap<String> result = new UnicodeMap<>();
         boolean uniformUnassigned = hasUniformUnassigned();
 
         for (UnicodeSetIterator usi = getStuffToTest(uniformUnassigned); usi.next();) { // int i = 0; i <= 0x10FFFF; ++i
@@ -460,15 +465,15 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     /**
      * @return the unicode map
      */
-    public UnicodeMap getUnicodeMap_internal() {
+    public UnicodeMap<String> getUnicodeMap_internal() {
         if (unicodeMap == null)
             unicodeMap = _getUnicodeMap();
         return unicodeMap;
     }
 
-    protected UnicodeMap _getUnicodeMap() {
-        UnicodeMap result = new UnicodeMap();
-        HashMap myIntern = new HashMap();
+    protected UnicodeMap<String> _getUnicodeMap() {
+        UnicodeMap<String> result = new UnicodeMap<>();
+        HashMap<String, String> myIntern = new HashMap<>();
         boolean uniformUnassigned = hasUniformUnassigned();
 
         for (UnicodeSetIterator usi = getStuffToTest(uniformUnassigned); usi.next();) { // int i = 0; i <= 0x10FFFF; ++i
@@ -476,7 +481,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             // if (DEBUG && i == 0x41) System.out.println(i + "\t" +
             // getValue(i));
             String value = getValue(i);
-            String iValue = (String) myIntern.get(value);
+            String iValue = myIntern.get(value);
             if (iValue == null)
                 myIntern.put(value, iValue = value);
             result.put(i, iValue);
@@ -522,9 +527,10 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     /**
      * Utility for managing property & non-string value aliases
      */
-    public static final Comparator PROPERTY_COMPARATOR = new Comparator() {
-        public int compare(Object o1, Object o2) {
-            return compareNames((String) o1, (String) o2);
+    public static final Comparator<String> PROPERTY_COMPARATOR = new Comparator<String>() {
+        @Override
+        public int compare(String o1, String o2) {
+            return compareNames(o1, o2);
         }
     };
 
@@ -731,11 +737,11 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     static public class Factory {
         static boolean DEBUG = false;
 
-        Map<String, UnicodeProperty> canonicalNames = new TreeMap<String, UnicodeProperty>();
+        Map<String, UnicodeProperty> canonicalNames = new TreeMap<>();
 
-        Map skeletonNames = new TreeMap();
+        Map<String, UnicodeProperty> skeletonNames = new TreeMap<>();
 
-        Map propertyCache = new HashMap(1);
+        Map<String, UnicodeProperty> propertyCache = new HashMap<>(1);
 
         public final Factory add(UnicodeProperty sp) {
             String name2 = sp.getName();
@@ -744,8 +750,8 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             }
             canonicalNames.put(name2, sp);
             skeletonNames.put(toSkeleton(name2), sp);
-            List c = sp.getNameAliases(new ArrayList(1));
-            Iterator it = c.iterator();
+            List<String> c = sp.getNameAliases(new ArrayList<>(1));
+            Iterator<String> it = c.iterator();
             while (it.hasNext()) {
                 skeletonNames.put(toSkeleton((String) it.next()), sp);
             }
@@ -763,22 +769,22 @@ public abstract class UnicodeProperty extends UnicodeLabel {
 
         public final List<String> getAvailableNames(List<String> result) {
             if (result == null)
-                result = new ArrayList(1);
-            Iterator it = canonicalNames.keySet().iterator();
+                result = new ArrayList<String>(1);
+            Iterator<String> it = canonicalNames.keySet().iterator();
             while (it.hasNext()) {
                 addUnique(it.next(), result);
             }
             return result;
         }
 
-        public final List getAvailableNames(int propertyTypeMask) {
+        public final List<String> getAvailableNames(int propertyTypeMask) {
             return getAvailableNames(propertyTypeMask, null);
         }
 
-        public final List getAvailableNames(int propertyTypeMask, List result) {
+        public final List<String> getAvailableNames(int propertyTypeMask, List<String> result) {
             if (result == null)
-                result = new ArrayList(1);
-            Iterator it = canonicalNames.keySet().iterator();
+                result = new ArrayList<>(1);
+            Iterator<String> it = canonicalNames.keySet().iterator();
             while (it.hasNext()) {
                 String item = (String) it.next();
                 UnicodeProperty property = getProperty(item);
@@ -838,6 +844,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
         }
 
         private class MyXSymbolTable extends UnicodeSet.XSymbolTable {
+            @Override
             public boolean applyPropertyAlias(String propertyName,
                     String propertyValue, UnicodeSet result) {
                 if (false)
@@ -866,6 +873,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
                 this.prefix = prefix;
             }
 
+            @Override
             public char[] lookup(String s) {
                 if (DEBUG)
                     System.out.println("\t(" + prefix + ")Looking up " + s);
@@ -903,10 +911,10 @@ public abstract class UnicodeProperty extends UnicodeLabel {
                 return set.toPattern(true).toCharArray(); // really ugly
             }
 
-            private String showSet(List list) {
-                StringBuffer result = new StringBuffer("[");
+            private String showSet(List<String> list) {
+                StringBuilder result = new StringBuilder("[");
                 boolean first = true;
-                for (Iterator it = list.iterator(); it.hasNext();) {
+                for (Iterator<String> it = list.iterator(); it.hasNext();) {
                     if (!first)
                         result.append(", ");
                     else
@@ -917,10 +925,12 @@ public abstract class UnicodeProperty extends UnicodeLabel {
                 return result.toString();
             }
 
+            @Override
             public UnicodeMatcher lookupMatcher(int ch) {
                 return null;
             }
 
+            @Override
             public String parseReference(String text, ParsePosition pos,
                     int limit) {
                 if (DEBUG)
@@ -992,7 +1002,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
         protected UnicodeSetIterator matchIterator = new UnicodeSetIterator(
                 new UnicodeSet(0, 0x10FFFF));
 
-        protected HashMap backmap;
+        protected HashMap<String, String> backmap;
 
         boolean allowValueAliasCollisions = false;
 
@@ -1010,27 +1020,28 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             return this;
         }
 
-        List temp = new ArrayList(1);
+        List<String> temp = new ArrayList<>(1);
 
-        public List _getAvailableValues(List result) {
+        public List<String> _getAvailableValues(List<String> result) {
             temp.clear();
             return filter.addUnique(property.getAvailableValues(temp), result);
         }
 
-        public List _getNameAliases(List result) {
+        public List<String> _getNameAliases(List<String> result) {
             temp.clear();
             return filter.addUnique(property.getNameAliases(temp), result);
         }
 
+        @Override
         public String _getValue(int codepoint) {
             return filter.remap(property.getValue(codepoint));
         }
 
-        public List _getValueAliases(String valueAlias, List result) {
+        public List<String> _getValueAliases(String valueAlias, List<String> result) {
             if (backmap == null) {
-                backmap = new HashMap(1);
+                backmap = new HashMap<>(1);
                 temp.clear();
-                Iterator it = property.getAvailableValues(temp).iterator();
+                Iterator<String> it = property.getAvailableValues(temp).iterator();
                 while (it.hasNext()) {
                     String item = (String) it.next();
                     String mappedItem = filter.remap(item);
@@ -1049,6 +1060,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
                     result);
         }
 
+        @Override
         public String _getVersion() {
             return property.getVersion();
         }
@@ -1067,10 +1079,10 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     public static abstract class StringFilter implements Cloneable {
         public abstract String remap(String original);
 
-        public final List addUnique(Collection source, List result) {
+        public final List<String> addUnique(Collection<String> source, List<String> result) {
             if (result == null)
-                result = new ArrayList(1);
-            Iterator it = source.iterator();
+                result = new ArrayList<>(1);
+            Iterator<String> it = source.iterator();
             while (it.hasNext()) {
                 UnicodeProperty.addUnique(remap((String) it.next()), result);
             }
@@ -1084,18 +1096,19 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     }
 
     public static class MapFilter extends StringFilter {
-        private Map valueMap;
+        private Map<String, String> valueMap;
 
-        public MapFilter(Map valueMap) {
+        public MapFilter(Map<String, String> valueMap) {
             this.valueMap = valueMap;
         }
 
+        @Override
         public String remap(String original) {
             Object changed = valueMap.get(original);
             return changed == null ? original : (String) changed;
         }
 
-        public Map getMap() {
+        public Map<String, String> getMap() {
             return valueMap;
         }
     }
@@ -1112,10 +1125,12 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             return this;
         }
 
+        @Override
         public boolean test(String value) {
             return !other.test(value);
         }
 
+        @Override
         public PatternMatcher set(String pattern) {
             other.set(pattern);
             return this;
@@ -1123,21 +1138,23 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     }
 
     public static class SimpleMatcher implements PatternMatcher {
-        Comparator comparator;
+        Comparator<String> comparator;
 
         String pattern;
 
-        public SimpleMatcher(String pattern, Comparator comparator) {
+        public SimpleMatcher(String pattern, Comparator<String> comparator) {
             this.comparator = comparator;
             this.pattern = pattern;
         }
 
+        @Override
         public boolean test(String value) {
             if (comparator == null)
                 return pattern.equals(value);
             return comparator.compare(pattern, value) == 0;
         }
 
+        @Override
         public PatternMatcher set(String pattern) {
             this.pattern = pattern;
             return this;
@@ -1147,11 +1164,13 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     public static class RegexMatcher implements UnicodeProperty.PatternMatcher {
         private java.util.regex.Matcher matcher;
 
+        @Override
         public UnicodeProperty.PatternMatcher set(String pattern) {
             matcher = Pattern.compile(pattern).matcher("");
             return this;
         }
-        UFormat foo;
+
+        @Override
         public boolean test(String value) {
             matcher.reset(value.toString());
             return matcher.find();
@@ -1170,9 +1189,9 @@ public abstract class UnicodeProperty extends UnicodeLabel {
          */
         private static final String[][] YES_NO_ALIASES = new String[][] {YES_VALUES, NO_VALUES};
 
-        protected List propertyAliases = new ArrayList(1);
+        protected List<String> propertyAliases = new ArrayList<>(1);
 
-        protected Map toValueAliases;
+        protected Map<String, List<String>> toValueAliases;
 
         protected String version;
 
@@ -1189,11 +1208,13 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             return this;
         }
 
+        @Override
         public String _getVersion() {
             return version;
         }
 
-        public List _getNameAliases(List result) {
+        @Override
+        public List<String> _getNameAliases(List<String> result) {
             addAllUnique(propertyAliases, result);
             return result;
         }
@@ -1213,13 +1234,13 @@ public abstract class UnicodeProperty extends UnicodeLabel {
 
         public void addValueAlias(String value, String valueAlias,
                 AliasAddAction aliasAddAction) {
-            List result = (List) toValueAliases.get(value);
+            List<String> result = toValueAliases.get(value);
             if (result == null) {
                 switch(aliasAddAction) {
                 case IGNORE_IF_MISSING: return;
                 case REQUIRE_MAIN_ALIAS: throw new IllegalArgumentException("Can't add alias for mising value: " + value);
                 case ADD_MAIN_ALIAS:
-                    toValueAliases.put(value, result = new ArrayList(0));
+                    toValueAliases.put(value, result = new ArrayList<>(0));
                     break;
                 }
             }
@@ -1227,10 +1248,11 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             addUnique(valueAlias, result);
         }
 
-        protected List _getValueAliases(String valueAlias, List result) {
+        @Override
+        protected List<String> _getValueAliases(String valueAlias, List<String> result) {
             if (toValueAliases == null)
                 _fixValueAliases();
-            List a = (List) toValueAliases.get(valueAlias);
+            List<String> a = toValueAliases.get(valueAlias);
             if (a != null)
                 addAllUnique(a, result);
             return result;
@@ -1238,26 +1260,26 @@ public abstract class UnicodeProperty extends UnicodeLabel {
 
         protected void _fixValueAliases() {
             if (toValueAliases == null)
-                toValueAliases = new HashMap(1);
-            for (Iterator it = getAvailableValues().iterator(); it.hasNext();) {
-                Object value = it.next();
+                toValueAliases = new HashMap<>(1);
+            for (Iterator<String> it = getAvailableValues().iterator(); it.hasNext();) {
+                String value = it.next();
                 _ensureValueInAliases(value);
             }
         }
 
-        protected void _ensureValueInAliases(Object value) {
-            List result = (List) toValueAliases.get(value);
+        protected void _ensureValueInAliases(String value) {
+            List<String> result = toValueAliases.get(value);
             if (result == null)
-                toValueAliases.put(value, result = new ArrayList(1));
+                toValueAliases.put(value, result = new ArrayList<String>(1));
             addUnique(value, result);
         }
 
         public BaseProperty swapFirst2ValueAliases() {
-            for (Iterator it = toValueAliases.keySet().iterator(); it.hasNext();) {
-                List list = (List) toValueAliases.get(it.next());
+            for (Iterator<String> it = toValueAliases.keySet().iterator(); it.hasNext();) {
+                List<String> list = toValueAliases.get(it.next());
                 if (list.size() < 2)
                     continue;
-                Object first = list.get(0);
+                String first = list.get(0);
                 list.set(0, list.get(1));
                 list.set(1, first);
             }
@@ -1275,8 +1297,9 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     }
 
     public static abstract class SimpleProperty extends BaseProperty {
-        LinkedHashSet values;
+        LinkedHashSet<String> values;
 
+        @Override
         public UnicodeProperty addName(String alias) {
             propertyAliases.add(alias);
             return this;
@@ -1305,15 +1328,16 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             return this;
         }
 
-        public SimpleProperty setValues(List valueAliases) {
-            this.values = new LinkedHashSet(valueAliases);
-            for (Iterator it = this.values.iterator(); it.hasNext();) {
+        public SimpleProperty setValues(List<String> valueAliases) {
+            this.values = new LinkedHashSet<>(valueAliases);
+            for (Iterator<String> it = this.values.iterator(); it.hasNext();) {
                 _addToValues((String) it.next(), null);
             }
             return this;
         }
 
-        public List _getAvailableValues(List result) {
+        @Override
+        public List<String> _getAvailableValues(List<String> result) {
             if (values == null)
                 _fillValues();
             result.addAll(values);
@@ -1321,16 +1345,16 @@ public abstract class UnicodeProperty extends UnicodeLabel {
         }
 
         protected void _fillValues() {
-            List newvalues = (List) getUnicodeMap_internal()
-            .getAvailableValues(new ArrayList());
-            for (Iterator it = newvalues.iterator(); it.hasNext();) {
+            List<String> newvalues = getUnicodeMap_internal()
+                    .getAvailableValues(new ArrayList<String>());
+            for (Iterator<String> it = newvalues.iterator(); it.hasNext();) {
                 _addToValues((String) it.next(), null);
             }
         }
 
         private void _addToValues(String item, String alias) {
             if (values == null)
-                values = new LinkedHashSet();
+                values = new LinkedHashSet<>();
             if (toValueAliases == null)
                 _fixValueAliases();
             addUnique(item, values);
@@ -1371,17 +1395,19 @@ public abstract class UnicodeProperty extends UnicodeLabel {
          }
          }.setMain("Grapheme_Cluster_Break", "GCB", UnicodeProperty.ENUMERATED, version)
          */
-        protected UnicodeMap unicodeMap;
+        protected UnicodeMap<String> unicodeMap;
 
-        protected UnicodeMap _getUnicodeMap() {
+        @Override
+        protected UnicodeMap<String> _getUnicodeMap() {
             return unicodeMap;
         }
 
-        public UnicodeMapProperty set(UnicodeMap map) {
+        public UnicodeMapProperty set(UnicodeMap<String> map) {
             unicodeMap = map.freeze();
             return this;
         }
 
+        @Override
         protected String _getValue(int codepoint) {
             return (String) unicodeMap.getValue(codepoint);
         }
@@ -1391,10 +1417,12 @@ public abstract class UnicodeProperty extends UnicodeLabel {
          result.add(valueAlias);
          return result; // no other aliases
          }
-         */protected List _getAvailableValues(List result) {
+         */
+        @Override
+        protected List<String> _getAvailableValues(List<String> result) {
              unicodeMap.getAvailableValues(result);
              if (toValueAliases != null) {
-                 for (Object s : toValueAliases.keySet()) {
+                 for (String s : toValueAliases.keySet()) {
                      if (!result.contains(s)) {
                          result.add(s);
                      }
@@ -1423,7 +1451,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     }
 
     public List<String> getValueAliases() {
-        List<String> result = new ArrayList();
+        List<String> result = new ArrayList<>();
         if (isType(STRING_OR_MISC_MASK)) {
             return result;
         }
@@ -1464,8 +1492,8 @@ public abstract class UnicodeProperty extends UnicodeLabel {
         return result;
     }
 
-    public static UnicodeMap addUntested(UnicodeMap result, boolean uniformUnassigned) {
-        Object temp;
+    public static UnicodeMap<String> addUntested(UnicodeMap<String> result, boolean uniformUnassigned) {
+        String temp;
         if (uniformUnassigned && null != (temp = result.get(UnicodeProperty.getSAMPLE_UNASSIGNED()))) {
             result.putAll(UnicodeProperty.getUNASSIGNED(), temp);
         }
@@ -1512,7 +1540,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     public static class UnicodeSetProperty extends BaseProperty {
         protected UnicodeSet unicodeSet;
         private static final String[] YESNO_ARRAY = new String[]{"Yes", "No"};
-        private static final List YESNO = Arrays.asList(YESNO_ARRAY);
+        private static final List<String> YESNO = Arrays.asList(YESNO_ARRAY);
 
         public UnicodeSetProperty set(UnicodeSet set) {
             unicodeSet = set.freeze();
@@ -1524,11 +1552,13 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             return set(new UnicodeSet(string).freeze());
         }
 
+        @Override
         protected String _getValue(int codepoint) {
             return YESNO_ARRAY[unicodeSet.contains(codepoint) ? 0 : 1];
         }
 
-        protected List _getAvailableValues(List result) {
+        @Override
+        protected List<String> _getAvailableValues(List<String> result) {
             return YESNO;
         }
     }
@@ -1558,8 +1588,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     //    }
 
     // from the jsp version
-    public boolean isTrimable() {
+    public boolean isTrimmable() {
         return !isType(STRING_OR_MISC_MASK);
     }
 }
-

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -19,10 +19,9 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
-import com.ibm.icu.dev.util.CollectionUtilities.InverseMatcher;
-import com.ibm.icu.dev.util.CollectionUtilities.ObjectMatcher;
 import com.ibm.icu.dev.util.UnicodeMap;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.text.SymbolTable;
@@ -32,7 +31,6 @@ import com.ibm.icu.text.UnicodeMatcher;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 
-import org.unicode.props.BagFormatter;
 import org.unicode.cldr.util.props.UnicodeLabel;
 
 public abstract class UnicodeProperty extends UnicodeLabel {
@@ -351,7 +349,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             for (UnicodeSetIterator usi = getStuffToTest(uniformUnassigned); usi.next();) { // int i = 0; i <= 0x10FFFF; ++i
                 int i = usi.codepoint;
                 String value = getValue(i);
-                if (value != null && matcher.matches(value)) {
+                if (value != null && matcher.test(value)) {
                     result.add(i);
                 }
             }
@@ -367,8 +365,8 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             while (it2.hasNext()) {
                 String value2 = (String) it2.next();
                 // System.out.println("Values:" + value2);
-                if (matcher.matches(value2)
-                        || matcher.matches(toSkeleton(value2))) {
+                if (matcher.test(value2)
+                        || matcher.test(toSkeleton(value2))) {
                     um.keySet(value, result);
                     continue main;
                 }
@@ -1102,12 +1100,11 @@ public abstract class UnicodeProperty extends UnicodeLabel {
         }
     }
 
-    public interface PatternMatcher extends ObjectMatcher {
+    public interface PatternMatcher extends Predicate<String> {
         public PatternMatcher set(String pattern);
     }
 
-    public static class InversePatternMatcher extends InverseMatcher implements
-    PatternMatcher {
+    public static class InversePatternMatcher implements PatternMatcher {
         PatternMatcher other;
 
         public PatternMatcher set(PatternMatcher toInverse) {
@@ -1115,8 +1112,8 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             return this;
         }
 
-        public boolean matches(Object value) {
-            return !other.matches(value);
+        public boolean test(String value) {
+            return !other.test(value);
         }
 
         public PatternMatcher set(String pattern) {
@@ -1135,7 +1132,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             this.pattern = pattern;
         }
 
-        public boolean matches(Object value) {
+        public boolean test(String value) {
             if (comparator == null)
                 return pattern.equals(value);
             return comparator.compare(pattern, value) == 0;
@@ -1155,7 +1152,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             return this;
         }
         UFormat foo;
-        public boolean matches(Object value) {
+        public boolean test(String value) {
             matcher.reset(value.toString());
             return matcher.find();
         }

--- a/unicodetools/src/main/java/org/unicode/props/UnicodePropertySymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodePropertySymbolTable.java
@@ -192,7 +192,7 @@ public class UnicodePropertySymbolTable extends UnicodeSet.XSymbolTable {
           set = new UnicodeSet();
           List<String> values = prop.getAvailableValues();
           for (String value : values) {
-            if (patternMatcher.matches(value)) {
+            if (patternMatcher.test(value)) {
               for (String other : values) {
                 if (other.compareTo(value) <= 0) {
                   set.addAll(prop.getSet(other));
@@ -236,7 +236,7 @@ public class UnicodePropertySymbolTable extends UnicodeSet.XSymbolTable {
           }
 
         @Override
-        public boolean matches(Object value) {
+        public boolean test(String value) {
           int comp = comparator.compare(pattern, value.toString());
           switch (relation) {
           case less: return comp < 0;

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java
@@ -32,6 +32,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -1576,12 +1577,11 @@ public class GenerateConfusables {
         //            }
         //        }
 
-        private static class MyCollectionFilter implements CollectionUtilities.ObjectMatcher {
+        private static class MyCollectionFilter implements Predicate<String> {
             UnicodeSet outputAllowed;
             int minLength;
             @Override
-            public boolean matches(Object o) {
-                final String item = (String)o;
+            public boolean test(String item) {
                 if (!outputAllowed.containsAll(item)) {
                     return false;
                 }
@@ -1631,7 +1631,7 @@ public class GenerateConfusables {
                 itemsSeen.addAll(equivalents);
                 if (outputOnly) { // remove non-output
                     myFilter.minLength = 1000;
-                    CollectionUtilities.retainAll(equivalents, myFilter);
+                    retainAll(equivalents, myFilter);
                     if (equivalents.size() <= 1) {
                         continue;
                     }
@@ -2493,4 +2493,20 @@ public class GenerateConfusables {
 
     };
 
+    // Copied from ICU CollectionUtilities.
+    /**
+     * Retain matching items
+     * @param <T>
+     * @param <U>
+     * @param c
+     * @param f
+     * @return
+     */
+    static <T, U extends Collection<T>> U retainAll(U c, Predicate<T> f) {
+        for (Iterator<T> it = c.iterator(); it.hasNext();) {
+            T item = it.next();
+            if (!f.test(item)) it.remove();
+        }
+        return c;
+    }
 }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusablesCopy.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusablesCopy.java
@@ -34,6 +34,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -2253,12 +2254,11 @@ public class GenerateConfusablesCopy {
         //            }
         //        }
 
-        private static class MyCollectionFilter implements CollectionUtilities.ObjectMatcher {
+        private static class MyCollectionFilter implements Predicate<String> {
             UnicodeSet outputAllowed;
             int minLength;
             @Override
-            public boolean matches(Object o) {
-                final String item = (String)o;
+            public boolean test(String item) {
                 if (!outputAllowed.containsAll(item)) {
                     return false;
                 }
@@ -2308,7 +2308,7 @@ public class GenerateConfusablesCopy {
                 itemsSeen.addAll(equivalents);
                 if (outputOnly) { // remove non-output
                     myFilter.minLength = 1000;
-                    CollectionUtilities.retainAll(equivalents, myFilter);
+                    GenerateConfusables.retainAll(equivalents, myFilter);
                     if (equivalents.size() <= 1) {
                         continue;
                     }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/TestData.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/TestData.java
@@ -687,7 +687,7 @@ public class TestData implements UCD_Types {
             return this;
         }
         @Override
-        public boolean matches(Object value) {
+        public boolean test(String value) {
             matcher.reset((String)value);
             return matcher.matches();
         }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/TestUnicodeInvariants.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/TestUnicodeInvariants.java
@@ -960,7 +960,7 @@ public class TestUnicodeInvariants {
 
     static final UnicodeProperty.PatternMatcher NULL_MATCHER = new UnicodeProperty.PatternMatcher() {
         @Override
-        public boolean matches(Object o) {
+        public boolean test(String o) {
             return o == null || "".equals(o);
         }
         @Override


### PR DESCRIPTION
and then clean up most warnings in UnicodeProperty

For issue #66: This makes unicodetools UnicodeProperty more like CLDR UnicodeProperty. The CLDR version switched to Java Predicate in https://github.com/unicode-org/cldr/pull/460. The warnings cleanup here goes farther than the earlier one in CLDR.

Best to review one commit at a time.