### PR TITLE
deps: use prerelease CLDR 42 dev tag

### DIFF
--- a/UnicodeJsps/.settings/org.eclipse.core.resources.prefs
+++ b/UnicodeJsps/.settings/org.eclipse.core.resources.prefs
@@ -3,4 +3,5 @@ encoding//src/main/java=UTF-8
 encoding//src/main/resources=UTF-8
 encoding//src/main/webapp=UTF-8
 encoding//src/test/java=UTF-8
+encoding//src/test/resources=UTF-8
 encoding/<project>=UTF-8

--- a/UnicodeJsps/.settings/org.eclipse.wst.common.component
+++ b/UnicodeJsps/.settings/org.eclipse.wst.common.component
@@ -1,9 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?><project-modules id="moduleCoreId" project-version="1.5.0">
+        
     <wb-module deploy-name="UnicodeJsps">
+                
         <wb-resource deploy-path="/" source-path="/target/m2e-wtp/web-resources"/>
+                
         <wb-resource deploy-path="/" source-path="/src/main/webapp" tag="defaultRootSource"/>
+                
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src/main/java"/>
+        <dependent-module archiveName="unicodetools-1.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/unicodetools/unicodetools">
+            <dependency-type>uses</dependency-type>
+        </dependent-module>
+                
         <property name="context-root" value="UnicodeJsps"/>
+                
         <property name="java-output-path" value="/UnicodeJsps/target/classes"/>
+            
     </wb-module>
+    
 </project-modules>

--- a/UnicodeJsps/.settings/org.eclipse.wst.common.project.facet.core.xml
+++ b/UnicodeJsps/.settings/org.eclipse.wst.common.project.facet.core.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <faceted-project>
   <fixed facet="wst.jsdt.web"/>
-  <installed facet="java" version="1.8"/>
   <installed facet="jst.web" version="3.0"/>
   <installed facet="wst.jsdt.web" version="1.0"/>
+  <installed facet="java" version="11"/>
 </faceted-project>

--- a/UnicodeJsps/pom.xml
+++ b/UnicodeJsps/pom.xml
@@ -6,7 +6,6 @@
 	<artifactId>UnicodeJsps</artifactId>
 	<packaging>war</packaging>
 	<name>Unicode JSPs</name>
-	<groupId>org.unicode.unicodetools</groupId>
 
 	<parent>
 		<groupId>org.unicode.unicodetools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 		<!--
 			 For CLDR versions, see https://github.com/orgs/unicode-org/packages?repo_name=cldr
 		  -->
-		<cldr.version>0.0.0-SNAPSHOT-1e28c0fbb4</cldr.version>
+		<cldr.version>0.0.0-SNAPSHOT-e849e51d51</cldr.version>
 
 
 		<!-- these two set the JDK version for source and target -->

--- a/unicodetools-testutils/.settings/org.eclipse.core.resources.prefs
+++ b/unicodetools-testutils/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,3 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding/<project>=UTF-8

--- a/unicodetools-testutils/.settings/org.eclipse.jdt.core.prefs
+++ b/unicodetools-testutils/.settings/org.eclipse.jdt.core.prefs
@@ -1,12 +1,8 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.compliance=11
-org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
-org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
-org.eclipse.jdt.core.compiler.processAnnotations=disabled
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
 org.eclipse.jdt.core.compiler.release=disabled
 org.eclipse.jdt.core.compiler.source=11

--- a/unicodetools-testutils/.settings/org.eclipse.m2e.core.prefs
+++ b/unicodetools-testutils/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/unicodetools-testutils/pom.xml
+++ b/unicodetools-testutils/pom.xml
@@ -4,10 +4,8 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>unicodetools-testutils</artifactId>
-	<groupId>org.unicode.unicodetools</groupId>
 	<name>Unicode Test Utilities</name>
 
-	<version>1.0.0</version>
 	<packaging>jar</packaging>
 
 

--- a/unicodetools/.project
+++ b/unicodetools/.project
@@ -6,7 +6,17 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.wst.common.project.facet.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.wst.validation.validationbuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
@@ -17,8 +27,11 @@
 		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.jem.workbench.JavaEMFNature</nature>
+		<nature>org.eclipse.wst.common.modulecore.ModuleCoreNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
 	</natures>
 	<filteredResources>
 		<filter>

--- a/unicodetools/.settings/org.eclipse.jdt.core.prefs
+++ b/unicodetools/.settings/org.eclipse.jdt.core.prefs
@@ -1,9 +1,12 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.processAnnotations=disabled
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11

--- a/unicodetools/.settings/org.eclipse.wst.common.component
+++ b/unicodetools/.settings/org.eclipse.wst.common.component
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?><project-modules id="moduleCoreId" project-version="1.5.0">
+    <wb-module deploy-name="unicodetools">
+        <wb-resource deploy-path="/" source-path="/src/main/java"/>
+        <wb-resource deploy-path="/" source-path="/src/main/resources"/>
+    </wb-module>
+</project-modules>

--- a/unicodetools/.settings/org.eclipse.wst.common.project.facet.core.xml
+++ b/unicodetools/.settings/org.eclipse.wst.common.project.facet.core.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<faceted-project>
+  <installed facet="jst.utility" version="1.0"/>
+  <installed facet="java" version="11"/>
+</faceted-project>

--- a/unicodetools/.settings/org.eclipse.wst.validation.prefs
+++ b/unicodetools/.settings/org.eclipse.wst.validation.prefs
@@ -1,0 +1,2 @@
+disabled=06target
+eclipse.preferences.version=1

--- a/unicodetools/pom.xml
+++ b/unicodetools/pom.xml
@@ -4,10 +4,8 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>unicodetools</artifactId>
-	<groupId>org.unicode.unicodetools</groupId>
 	<name>Unicode Tools</name>
 
-	<version>1.0.0</version>
 
 	<packaging>jar</packaging>
 


### PR DESCRIPTION
For: #218
Followon to: #224

- to pickup JDK11 fixes
- Also, dropped some unneeded lines from pom.xml (duplicate version and groupId fields) to fix warnings
- This is CLDR `0.0.0-SNAPSHOT-e849e51d51` corresponding to [`snapshot/2022-04-25`](https://github.com/unicode-org/cldr/releases/tag/snapshot%2F2022-04-25)

- Also checkin some .settings files that eclipse seems to want to modify