### PR TITLE
include Kawi postbase (gc=Mc, InPC=Right) characters in GCB=SpacingMark

### DIFF
--- a/unicodetools/data/ucd/dev/auxiliary/GraphemeBreakProperty.txt
+++ b/unicodetools/data/ucd/dev/auxiliary/GraphemeBreakProperty.txt
@@ -1,5 +1,5 @@
 # GraphemeBreakProperty-15.0.0.txt
-# Date: 2022-04-26, 23:14:40 GMT
+# Date: 2022-04-27, 17:07:38 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -626,13 +626,16 @@ ABEC          ; SpacingMark # Mc       MEETEI MAYEK LUM IYEK
 11D93..11D94  ; SpacingMark # Mc   [2] GUNJALA GONDI VOWEL SIGN OO..GUNJALA GONDI VOWEL SIGN AU
 11D96         ; SpacingMark # Mc       GUNJALA GONDI SIGN VISARGA
 11EF5..11EF6  ; SpacingMark # Mc   [2] MAKASAR VOWEL SIGN E..MAKASAR VOWEL SIGN O
+11F03         ; SpacingMark # Mc       KAWI SIGN VISARGA
+11F34..11F35  ; SpacingMark # Mc   [2] KAWI VOWEL SIGN AA..KAWI VOWEL SIGN ALTERNATE AA
 11F3E..11F3F  ; SpacingMark # Mc   [2] KAWI VOWEL SIGN E..KAWI VOWEL SIGN AI
+11F41         ; SpacingMark # Mc       KAWI SIGN KILLER
 16F51..16F87  ; SpacingMark # Mc  [55] MIAO SIGN ASPIRATION..MIAO VOWEL SIGN UI
 16FF0..16FF1  ; SpacingMark # Mc   [2] VIETNAMESE ALTERNATE READING MARK CA..VIETNAMESE ALTERNATE READING MARK NHAY
 1D166         ; SpacingMark # Mc       MUSICAL SYMBOL COMBINING SPRECHGESANG STEM
 1D16D         ; SpacingMark # Mc       MUSICAL SYMBOL COMBINING AUGMENTATION DOT
 
-# Total code points: 391
+# Total code points: 395
 
 # ================================================
 

--- a/unicodetools/src/main/java/org/unicode/text/UCD/ToolUnicodePropertySource.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/ToolUnicodePropertySource.java
@@ -828,8 +828,7 @@ extend -and not GCB = Virama
                             // They may have been gc=Spacing_Mark in an earlier version.
                             "\u19B0-\u19B4\u19B8\u19B9\u19BB-\u19C0\u19C8\u19C9" + // New Tai Lue
                             "\u1A61\u1A63\u1A64" + // Tai Tham
-                            "\uAA7B\uAA7D" + // Myanmar
-                            "\\U00011F03\\U00011F34\\U00011F35\\U00011F41]")) // Kawi Unicode 15
+                            "\uAA7B\uAA7D]")) // Myanmar
                     .removeAll(unicodeMap.keySet("Extend"));
             if (compositeVersion >= (14 << 16)) {
                 gcbSpacingMarkSet.remove(0x11720).remove(0x11721); // AHOM VOWEL SIGN A & AA


### PR DESCRIPTION
= partial reverse of pull request #181

Fixes UTC action item [171-A69](https://www.unicode.org/cgi-bin/GetL2Ref.pl?171-A69).
After bug reports, and discussion in UTC 171, it was decided for Kawi line breaking to follow Western style for now, and try to default to orthographic syllables in the future, rather than using East Asian style (with the whole script in lb=SA).