### PR TITLE
ZWJ/ZWNJ not Identifier_Status=Allowed

### DIFF
--- a/unicodetools/data/security/dev/IdentifierStatus.txt
+++ b/unicodetools/data/security/dev/IdentifierStatus.txt
@@ -1,5 +1,5 @@
 ﻿# IdentifierStatus.txt
-# Date: 2022-05-10, 17:59:54 GMT
+# Date: 2022-05-18, 21:51:57 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -485,7 +485,6 @@
 1FF6..1FF8    ; Allowed    # 1.1    [3] GREEK SMALL LETTER OMEGA WITH PERISPOMENI..GREEK CAPITAL LETTER OMICRON WITH VARIA
 1FFA          ; Allowed    # 1.1        GREEK CAPITAL LETTER OMEGA WITH VARIA
 1FFC          ; Allowed    # 1.1        GREEK CAPITAL LETTER OMEGA WITH PROSGEGRAMMENI
-200C..200D    ; Allowed    # 1.1    [2] ZERO WIDTH NON-JOINER..ZERO WIDTH JOINER
 2010          ; Allowed    # 1.1        HYPHEN
 2019          ; Allowed    # 1.1        RIGHT SINGLE QUOTATION MARK
 2027          ; Allowed    # 1.1        HYPHENATION POINT
@@ -587,4 +586,4 @@ FA27..FA29    ; Allowed    # 1.1    [3] CJK COMPATIBILITY IDEOGRAPH-FA27..CJK CO
 30000..3134A  ; Allowed    # 13.0 [4939] CJK UNIFIED IDEOGRAPH-30000..CJK UNIFIED IDEOGRAPH-3134A
 31350..323AF  ; Allowed    # 15.0 [4192] CJK UNIFIED IDEOGRAPH-31350..CJK UNIFIED IDEOGRAPH-323AF
 
-# Total code points: 112161
+# Total code points: 112159

--- a/unicodetools/data/security/dev/IdentifierType.txt
+++ b/unicodetools/data/security/dev/IdentifierType.txt
@@ -1,5 +1,5 @@
 ﻿# IdentifierType.txt
-# Date: 2022-05-10, 17:59:54 GMT
+# Date: 2022-05-18, 21:51:56 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -592,14 +592,13 @@ FA27..FA29    ; Recommended                    # 1.1    [3] CJK COMPATIBILITY ID
 05F3..05F4    ; Inclusion                      # 1.1    [2] HEBREW PUNCTUATION GERESH..HEBREW PUNCTUATION GERSHAYIM
 06FD..06FE    ; Inclusion                      # 3.0    [2] ARABIC SIGN SINDHI AMPERSAND..ARABIC SIGN SINDHI POSTPOSITION MEN
 0F0B          ; Inclusion                      # 2.0        TIBETAN MARK INTERSYLLABIC TSHEG
-200C..200D    ; Inclusion                      # 1.1    [2] ZERO WIDTH NON-JOINER..ZERO WIDTH JOINER
 2010          ; Inclusion                      # 1.1        HYPHEN
 2019          ; Inclusion                      # 1.1        RIGHT SINGLE QUOTATION MARK
 2027          ; Inclusion                      # 1.1        HYPHENATION POINT
 30A0          ; Inclusion                      # 3.2        KATAKANA-HIRAGANA DOUBLE HYPHEN
 30FB          ; Inclusion                      # 1.1        KATAKANA MIDDLE DOT
 
-# Total code points: 19
+# Total code points: 17
 
 #	Identifier_Type:	Limited_Use
 
@@ -1322,7 +1321,7 @@ A930..A953    ; Exclusion                      # 5.1   [36] REJANG LETTER KA..RE
 12F90..12FF0  ; Exclusion                      # 14.0  [97] CYPRO-MINOAN SIGN CM001..CYPRO-MINOAN SIGN CM114
 13000..1342E  ; Exclusion                      # 5.2 [1071] EGYPTIAN HIEROGLYPH A001..EGYPTIAN HIEROGLYPH AA032
 1342F         ; Exclusion                      # 15.0       EGYPTIAN HIEROGLYPH V011D
-13441..13455  ; Exclusion                      # 15.0  [21] EGYPTIAN HIEROGLYPH FULL BLANK..EGYPTIAN HIEROGLYPH MODIFIER DAMAGED
+13440..13455  ; Exclusion                      # 15.0  [22] EGYPTIAN HIEROGLYPH MIRROR HORIZONTALLY..EGYPTIAN HIEROGLYPH MODIFIER DAMAGED
 14400..14646  ; Exclusion                      # 8.0  [583] ANATOLIAN HIEROGLYPH A001..ANATOLIAN HIEROGLYPH A530
 16A70..16ABE  ; Exclusion                      # 14.0  [79] TANGSA LETTER OZ..TANGSA LETTER ZA
 16AC0..16AC9  ; Exclusion                      # 14.0  [10] TANGSA DIGIT ZERO..TANGSA DIGIT NINE
@@ -1365,7 +1364,7 @@ A930..A953    ; Exclusion                      # 5.1   [36] REJANG LETTER KA..RE
 1E800..1E8C4  ; Exclusion                      # 7.0  [197] MENDE KIKAKUI SYLLABLE M001 KI..MENDE KIKAKUI SYLLABLE M060 NYON
 1E8D0..1E8D6  ; Exclusion                      # 7.0    [7] MENDE KIKAKUI COMBINING NUMBER TEENS..MENDE KIKAKUI COMBINING NUMBER MILLIONS
 
-# Total code points: 16070
+# Total code points: 16071
 
 #	Identifier_Type:	Exclusion Not_XID
 
@@ -1451,7 +1450,7 @@ A95F          ; Exclusion Not_XID              # 5.1        REJANG SECTION MARK
 12474         ; Exclusion Not_XID              # 7.0        CUNEIFORM PUNCTUATION SIGN DIAGONAL QUADCOLON
 12FF1..12FF2  ; Exclusion Not_XID              # 14.0   [2] CYPRO-MINOAN SIGN CM301..CYPRO-MINOAN SIGN CM302
 13430..13438  ; Exclusion Not_XID              # 12.0   [9] EGYPTIAN HIEROGLYPH VERTICAL JOINER..EGYPTIAN HIEROGLYPH END SEGMENT
-13439..13440  ; Exclusion Not_XID              # 15.0   [8] EGYPTIAN HIEROGLYPH INSERT AT MIDDLE..EGYPTIAN HIEROGLYPH MIRROR HORIZONTALLY
+13439..1343F  ; Exclusion Not_XID              # 15.0   [7] EGYPTIAN HIEROGLYPH INSERT AT MIDDLE..EGYPTIAN HIEROGLYPH END WALLED ENCLOSURE
 16A6E..16A6F  ; Exclusion Not_XID              # 7.0    [2] MRO DANDA..MRO DOUBLE DANDA
 16AF5         ; Exclusion Not_XID              # 7.0        BASSA VAH FULL STOP
 16B37..16B3F  ; Exclusion Not_XID              # 7.0    [9] PAHAWH HMONG SIGN VOS THOM..PAHAWH HMONG SIGN XYEEM FAIB
@@ -1467,7 +1466,7 @@ A95F          ; Exclusion Not_XID              # 5.1        REJANG SECTION MARK
 1DA85..1DA8B  ; Exclusion Not_XID              # 8.0    [7] SIGNWRITING LOCATION TORSO..SIGNWRITING PARENTHESIS
 1E8C7..1E8CF  ; Exclusion Not_XID              # 7.0    [9] MENDE KIKAKUI DIGIT ONE..MENDE KIKAKUI DIGIT NINE
 
-# Total code points: 1126
+# Total code points: 1125
 
 #	Identifier_Type:	Obsolete
 
@@ -2460,8 +2459,7 @@ FFE8..FFEE    ; Not_NFKC                       # 1.1    [7] HALFWIDTH FORMS LIGH
 180B..180D    ; Default_Ignorable              # 3.0    [3] MONGOLIAN FREE VARIATION SELECTOR ONE..MONGOLIAN FREE VARIATION SELECTOR THREE
 180E          ; Default_Ignorable              # 3.0        MONGOLIAN VOWEL SEPARATOR
 180F          ; Default_Ignorable              # 14.0       MONGOLIAN FREE VARIATION SELECTOR FOUR
-200B          ; Default_Ignorable              # 1.1        ZERO WIDTH SPACE
-200E..200F    ; Default_Ignorable              # 1.1    [2] LEFT-TO-RIGHT MARK..RIGHT-TO-LEFT MARK
+200B..200F    ; Default_Ignorable              # 1.1    [5] ZERO WIDTH SPACE..RIGHT-TO-LEFT MARK
 202A..202E    ; Default_Ignorable              # 1.1    [5] LEFT-TO-RIGHT EMBEDDING..RIGHT-TO-LEFT OVERRIDE
 2060..2063    ; Default_Ignorable              # 3.2    [4] WORD JOINER..INVISIBLE SEPARATOR
 2064          ; Default_Ignorable              # 5.1        INVISIBLE PLUS
@@ -2475,7 +2473,7 @@ FFA0          ; Default_Ignorable              # 1.1        HALFWIDTH HANGUL FIL
 E0020..E007F  ; Default_Ignorable              # 3.1   [96] TAG SPACE..CANCEL TAG
 E0100..E01EF  ; Default_Ignorable              # 4.0  [240] VARIATION SELECTOR-17..VARIATION SELECTOR-256
 
-# Total code points: 396
+# Total code points: 398
 
 #	Identifier_Type:	Deprecated
 

--- a/unicodetools/data/security/dev/confusables.txt
+++ b/unicodetools/data/security/dev/confusables.txt
@@ -1,5 +1,5 @@
 ﻿# confusables.txt
-# Date: 2022-05-10, 17:59:53 GMT
+# Date: 2022-05-18, 21:51:56 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -1071,7 +1071,7 @@ A714 ;	02EB ;	MA	#* ( ꜔ → ˫ ) MODIFIER LETTER MID LEFT-STEM TONE BAR → MO
 25CB ;	00B0 ;	MA	#* ( ○ → ° ) WHITE CIRCLE → DEGREE SIGN	# →◦→→∘→
 25E6 ;	00B0 ;	MA	#* ( ◦ → ° ) WHITE BULLET → DEGREE SIGN	# →∘→
 
-235C ;	00B0 0332 ;	MA	#* ( ⍜ → °̲ ) APL FUNCTIONAL SYMBOL CIRCLE UNDERBAR → DEGREE SIGN, COMBINING LOW LINE	# →○̲→
+235C ;	00B0 0332 ;	MA	#* ( ⍜ → °̲ ) APL FUNCTIONAL SYMBOL CIRCLE UNDERBAR → DEGREE SIGN, COMBINING LOW LINE	# →○̲→→∘̲→
 
 2364 ;	00B0 0308 ;	MA	#* ( ⍤ → °̈ ) APL FUNCTIONAL SYMBOL JOT DIAERESIS → DEGREE SIGN, COMBINING DIAERESIS	# →◦̈→→∘̈→
 

--- a/unicodetools/data/security/dev/confusablesSummary.txt
+++ b/unicodetools/data/security/dev/confusablesSummary.txt
@@ -1,5 +1,5 @@
 ﻿# confusablesSummary.txt
-# Date: 2022-05-10, 17:59:53 GMT
+# Date: 2022-05-18, 21:51:56 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -4353,10 +4353,11 @@
 ←	(‎ ◦̈ ‎)	25E6 0308	 WHITE BULLET, COMBINING DIAERESIS	# →∘̈→
 ←	(‎ ⍤ ‎)	2364	 APL FUNCTIONAL SYMBOL JOT DIAERESIS	# →◦̈→→∘̈→
 
-#	°̲	○̲	⍜
+#	°̲	∘̲	○̲	⍜
 	(‎ °̲ ‎)	00B0 0332	 DEGREE SIGN, COMBINING LOW LINE
-←	(‎ ○̲ ‎)	25CB 0332	 WHITE CIRCLE, COMBINING LOW LINE
-←	(‎ ⍜ ‎)	235C	 APL FUNCTIONAL SYMBOL CIRCLE UNDERBAR	# →○̲→
+←	(‎ ∘̲ ‎)	2218 0332	 RING OPERATOR, COMBINING LOW LINE
+←	(‎ ○̲ ‎)	25CB 0332	 WHITE CIRCLE, COMBINING LOW LINE	# →∘̲→
+←	(‎ ⍜ ‎)	235C	 APL FUNCTIONAL SYMBOL CIRCLE UNDERBAR	# →○̲→→∘̲→
 
 #	μ	µ	𝛍	𝜇	𝝁	𝝻	𝞵
 	(‎ µ ‎)	00B5	 MICRO SIGN
@@ -17202,5 +17203,5 @@
 	(‎ 𪘀 ‎)	2A600	 CJK UNIFIED IDEOGRAPH-2A600
 ←	(‎ 𪘀 ‎)	2FA1D	 CJK COMPATIBILITY IDEOGRAPH-2FA1D
 
-# total : 7247
+# total : 7248
 

--- a/unicodetools/data/security/dev/data/draft-restrictions.txt
+++ b/unicodetools/data/security/dev/data/draft-restrictions.txt
@@ -1,6 +1,4 @@
 # Characters restricted in domain names
-# $Revision: 1.32 $
-# $Date: 2010-06-19 00:29:21 $
 #
 # This file contains a draft list of characters for use in
 #     UTR #36: Unicode Security Considerations
@@ -25,8 +23,6 @@
 # - Characters listed as ~IICore are restricted because they are Ideographic,
 #   but not part of the IICore set defined by the IRG as the minimal set
 #   of required ideographs for East Asian use.
-# - The files in this directory are 'live', and may change at any time.
-#   Please include the above Revision number in your feedback.
 
 0673          ;  ; Deprecated #      (ٳ)  ARABIC LETTER ALEF WITH WAVY HAMZA BELOW
 17A3          ;  ; Deprecated #      (ឣ)  KHMER INDEPENDENT VOWEL QAQ
@@ -5733,6 +5729,7 @@ A9CF          ;  ; Exclusion #      (ꧏ)  JAVANESE PANGRANGKEP
 1342D         ;  ; Exclusion #      (𓐭)  EGYPTIAN HIEROGLYPH AA031
 1342E         ;  ; Exclusion #      (𓐮)  EGYPTIAN HIEROGLYPH AA032
 1342F         ;  ; Exclusion #      (𓐯)  EGYPTIAN HIEROGLYPH V011D
+13440         ;  ; Exclusion #      (𓑀)  EGYPTIAN HIEROGLYPH MIRROR HORIZONTALLY
 13441         ;  ; Exclusion #      (𓑁)  EGYPTIAN HIEROGLYPH FULL BLANK
 13442         ;  ; Exclusion #      (𓑂)  EGYPTIAN HIEROGLYPH HALF BLANK
 13443         ;  ; Exclusion #      (𓑃)  EGYPTIAN HIEROGLYPH LOST SIGN
@@ -14977,7 +14974,7 @@ A9CF          ;  ; Exclusion #      (ꧏ)  JAVANESE PANGRANGKEP
 1E8D5         ;  ; Exclusion #      (𞣕)  MENDE KIKAKUI COMBINING NUMBER HUNDRED THOUSANDS
 1E8D6         ;  ; Exclusion #      (𞣖)  MENDE KIKAKUI COMBINING NUMBER MILLIONS
 
-# Total code points: 15833
+# Total code points: 15834
 
 0710..073F    ;  ; Limited_Use # [48] (ܐ..ܿ)  SYRIAC LETTER ALAPH..SYRIAC RWAHA
 074D..074F    ;  ; Limited_Use #  [3] (ݍ..ݏ)  SYRIAC LETTER SOGDIAN ZHAIN..SYRIAC LETTER SOGDIAN FE
@@ -50169,7 +50166,7 @@ FFF9..FFFD    ; ~Unicode Identifier #  [5] (U+FFF9..�)  INTERLINEAR ANNOTATION
 11FFF         ; ~Unicode Identifier #      (𑿿)  TAMIL PUNCTUATION END OF TEXT
 12470..12474  ; ~Unicode Identifier #  [5] (𒑰..𒑴)  CUNEIFORM PUNCTUATION SIGN OLD ASSYRIAN WORD DIVIDER..CUNEIFORM PUNCTUATION SIGN DIAGONAL QUADCOLON
 12FF1..12FF2  ; ~Unicode Identifier #  [2] (𒿱..𒿲)  CYPRO-MINOAN SIGN CM301..CYPRO-MINOAN SIGN CM302
-13430..13440  ; ~Unicode Identifier # [17] (U+13430..𓑀)  EGYPTIAN HIEROGLYPH VERTICAL JOINER..EGYPTIAN HIEROGLYPH MIRROR HORIZONTALLY
+13430..1343F  ; ~Unicode Identifier # [16] (U+13430..𓐿)  EGYPTIAN HIEROGLYPH VERTICAL JOINER..EGYPTIAN HIEROGLYPH END WALLED ENCLOSURE
 16A6E..16A6F  ; ~Unicode Identifier #  [2] (𖩮..𖩯)  MRO DANDA..MRO DOUBLE DANDA
 16AF5         ; ~Unicode Identifier #      (𖫵)  BASSA VAH FULL STOP
 16B37..16B3F  ; ~Unicode Identifier #  [9] (𖬷..𖬿)  PAHAWH HMONG SIGN VOS THOM..PAHAWH HMONG SIGN XYEEM FAIB
@@ -50301,4 +50298,4 @@ FFF9..FFFD    ; ~Unicode Identifier #  [5] (U+FFF9..�)  INTERLINEAR ANNOTATION
 E0001         ; ~Unicode Identifier #      (U+E0001)  LANGUAGE TAG
 E0020..E007F  ; ~Unicode Identifier # [96] (U+E0020..U+E007F)  TAG SPACE..CANCEL TAG
 
-# Total code points: 13419
+# Total code points: 13418

--- a/unicodetools/data/security/dev/data/idnchars.txt
+++ b/unicodetools/data/security/dev/data/idnchars.txt
@@ -1,5 +1,5 @@
 ﻿# idnchars.txt
-# Date: 2022-05-10, 17:59:55 GMT
+# Date: 2022-05-18, 21:51:57 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -583,7 +583,6 @@
 1FE0..1FE2    ; output #  [3] (ῠ..ῢ)  GREEK SMALL LETTER UPSILON WITH VRACHY..GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND VARIA
 1FE4..1FE7    ; output #  [4] (ῤ..ῧ)  GREEK SMALL LETTER RHO WITH PSILI..GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND PERISPOMENI
 1FF6          ; output #      (ῶ)  GREEK SMALL LETTER OMEGA WITH PERISPOMENI
-200C..200D    ; output #  [2] (U+200C..U+200D)  ZERO WIDTH NON-JOINER..ZERO WIDTH JOINER
 2010          ; output #      (‐)  HYPHEN
 2019          ; output #      (’)  RIGHT SINGLE QUOTATION MARK
 2027          ; output #      (‧)  HYPHENATION POINT
@@ -663,7 +662,7 @@ FA27..FA29    ; output #  [3] (﨧..﨩)  CJK COMPATIBILITY IDEOGRAPH-FA27..CJK 
 30000..3134A  ; output # [4939] (𰀀..𱍊)  CJK UNIFIED IDEOGRAPH-30000..CJK UNIFIED IDEOGRAPH-3134A
 31350..323AF  ; output # [4192] (𱍐..𲎯)  CJK UNIFIED IDEOGRAPH-31350..CJK UNIFIED IDEOGRAPH-323AF
 
-# Total code points: 111486
+# Total code points: 111484
 
 # Not allowed at start of identifier
 

--- a/unicodetools/data/security/dev/data/source/removals.txt
+++ b/unicodetools/data/security/dev/data/source/removals.txt
@@ -570,7 +570,7 @@ A673  ; historic  # [*035B.0020.0002.A673] # SLAVONIC ASTERISK
 2E35 ; historic # 122A022
 2E39 ; historic # 122A022
 
-# Updated to UAX31, Table 3. Candidate Characters for Inclusion in Identifiers
+# Updated to UAX31, Tables 3/3a/3b, Optional Characters for Start/Medial/Continue
 
 0027 ; inclusion # (') APOSTROPHE
 002D ; inclusion # (-) HYPHEN-MINUS
@@ -581,8 +581,12 @@ A673  ; historic  # [*035B.0020.0002.A673] # SLAVONIC ASTERISK
 05F3 ; inclusion # (׳) HEBREW PUNCTUATION GERESH
 05F4 ; inclusion # (״) HEBREW PUNCTUATION GERSHAYIM
 0F0B ; inclusion # ( ་ ) TIBETAN MARK INTERSYLLABIC TSHEG
-200C ; inclusion # () ZERO WIDTH NON-JOINER*
-200D ; inclusion # () ZERO WIDTH JOINER*
+
+# UTC AI 171-A128: ... remove the Joiner_Control characters ZWJ and ZWNJ from Identifier_Type=Inclusion and Identifier_Status=Allowed.
+# Without an override, they get Identifier_Type=Default_Ignorable
+# 200C ; inclusion # () ZERO WIDTH NON-JOINER*
+# 200D ; inclusion # () ZERO WIDTH JOINER*
+
 2010 ; inclusion # (‐) HYPHEN
 2019 ; inclusion # (’) RIGHT SINGLE QUOTATION MARK
 2027 ; inclusion # (‧) HYPHENATION POINT

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusablesCopy.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusablesCopy.java
@@ -1117,8 +1117,6 @@ public class GenerateConfusablesCopy {
             //someRemovals = removals;
             out = FileUtilities.openUTF8Writer(outdir, "draft-restrictions.txt");
             out.println("# Characters restricted in domain names");
-            out.println("# $Revision: 1.32 $");
-            out.println("# $Date: 2010-06-19 00:29:21 $");
             out.println("#");
             out.println("# This file contains a draft list of characters for use in");
             out.println("#     UTR #36: Unicode Security Considerations");
@@ -1143,8 +1141,6 @@ public class GenerateConfusablesCopy {
             out.println("# - Characters listed as ~IICore are restricted because they are Ideographic,");
             out.println("#   but not part of the IICore set defined by the IRG as the minimal set");
             out.println("#   of required ideographs for East Asian use.");
-            out.println("# - The files in this directory are 'live', and may change at any time.");
-            out.println("#   Please include the above Revision number in your feedback.");
 
             bf.setRangeBreakSource(new FakeBreak2());
             if (true) {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/IdentifierInfo.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/IdentifierInfo.java
@@ -880,8 +880,6 @@ public class IdentifierInfo {
         //someRemovals = removals;
         out = FileUtilities.openUTF8Writer(GenerateConfusables.reformatedInternal, "draft-restrictions.txt");
         out.println("# Characters restricted in domain names");
-        out.println("# $Revision: 1.32 $");
-        out.println("# $Date: 2010-06-19 00:29:21 $");
         out.println("#");
         out.println("# This file contains a draft list of characters for use in");
         out.println("#     UTR #36: Unicode Security Considerations");
@@ -906,8 +904,6 @@ public class IdentifierInfo {
         out.println("# - Characters listed as ~IICore are restricted because they are Ideographic,");
         out.println("#   but not part of the IICore set defined by the IRG as the minimal set");
         out.println("#   of required ideographs for East Asian use.");
-        out.println("# - The files in this directory are 'live', and may change at any time.");
-        out.println("#   Please include the above Revision number in your feedback.");
 
         bf.setRangeBreakSource(new GenerateConfusables.FakeBreak2());
         if (MAIN_CODE) {

--- a/unicodetools/src/test/java/org/unicode/propstest/TestInvariants.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/TestInvariants.java
@@ -249,12 +249,23 @@ public class TestInvariants extends TestFmwkMinusMinus {
             same &= oldSet.equals(newSet);
             if (!newSet.containsAll(oldSet)) {
                 UnicodeSet missing = new UnicodeSet(oldSet).removeAll(newSet);
-                msg(ucdProperty + " new «" + value + "» does’t contain " + missing.toPattern(false),
-                        skips.contains(value) ? LOG : ERR, true, true);
+                int level = skips.contains(value) ? LOG : ERR;
+                if (ucdProperty == UcdProperty.Identifier_Type && value.equals("Inclusion") &&
+                        Settings.latestVersion.equals("15.0.0") &&
+                        missing.size() == 2 && missing.containsAll("\u200C\u200D")) {
+                    // Intentional removal of characters from Identifier_Type=Inclusion:
+                    // UTC AI 171-A128: ... remove the Joiner_Control characters ZWJ and ZWNJ
+                    // from Identifier_Type=Inclusion and Identifier_Status=Allowed.
+                    level = LOG;
+                }
+                msg("Unicode " + Settings.latestVersion + " [:" +
+                        ucdProperty + "=" + value + ":] does’t contain " + missing.toPattern(true),
+                        level, true, true);
             }
             if (!oldSet.containsAll(newSet)) {
                 UnicodeSet newOnes = new UnicodeSet(newSet).removeAll(oldSet);
-                logln(ucdProperty + " old «" + value + "» doesn't contain " + newOnes.toPattern(false));
+                logln("Unicode " + Settings.lastVersion + " [:" +
+                        ucdProperty + "=" + value + ":] does’t contain " + newOnes.toPattern(true));
             }
             //assertRelation(status.toString(), true, newSet, CONTAINS_US, oldSet);
         }


### PR DESCRIPTION
For
[[171-A128](https://www.unicode.org/cgi-bin/GetL2Ref.pl?171-A128)] Action Item for Mark Davis: In the property files IdentifierStatus.txt and IdentifierType.txt, remove the Joiner_Control characters ZWJ and ZWNJ from Identifier_Type=Inclusion and Identifier_Status=Allowed. For Unicode version 15.0.

removals.txt has overrides for ZWJ & ZWNJ, setting them to Identifier_Type=Inclusion.
By removing them, they default to Identifier_Type=Default_Ignorable.

All data files other than removals.txt are modified by the tool.

There are also changes for U+13440 EGYPTIAN HIEROGLYPH MIRROR HORIZONTALLY (still Exclusion but no longer Not_XID). I assume that they are due to changes in other properties.

The confusables changes are only in comments. I think I have seen some of these flip-flopping but didn't check the history.

Drive-by removal of some obsolete version lines that I noticed.

I regenerated the IDNA (UTS 46) files; they did not show any data changes.

I had to add an exception into TestInvariants for the intentional removals from Identifier_Type=Inclusion.