### PR TITLE
UCA 15 sifter code changes

### DIFF
--- a/c/uca/sifter/cttfooter.txt
+++ b/c/uca/sifter/cttfooter.txt
@@ -13,19 +13,20 @@
 % Weights for unified Han characters follow the Unified Repertoire and
 %   Ordering, which is a language-neutral, traditional radical-stroke order.
 
-%   The original URO and Extensions A through G, plus the 12 unified Han characters
+%   The original URO and Extensions A through H, plus the 12 unified Han characters
 %   in the CJK compatibility area are weighted implicitly as defined here.
 
 %   WEIGHT_BASE = 0xFB40 for original URO and 12 unified Han from CJK compat area.
-%      cp >= 0x04E00 && cp <= 0x09FFC % URO
-%   WEIGHT_BASE = 0xFB80 for Extension A through Extension G Han characters.
+%      cp >= 0x04E00 && cp <= 0x09FFF % URO
+%   WEIGHT_BASE = 0xFB80 for Extension A through Extension H Han characters.
 %      cp >= 0x03400 && cp <= 0x04DBF % Ext. A
-%      cp >= 0x20000 && cp <= 0x2A6DD % Ext. B
-%      cp >= 0x2A700 && cp <= 0x2B734 % Ext. C
+%      cp >= 0x20000 && cp <= 0x2A6DF % Ext. B
+%      cp >= 0x2A700 && cp <= 0x2B739 % Ext. C
 %      cp >= 0x2B740 && cp <= 0x2B81D % Ext. D
 %      cp >= 0x2B820 && cp <= 0x2CEA1 % Ext. E
 %      cp >= 0x2CEB0 && cp <= 0x2EBE0 % Ext. F
 %      cp >= 0x30000 && cp <= 0x3134A % Ext. G
+%      cp >= 0x31350 && cp <= 0x323AF % Ext. H
 %   For a given Han character at code point cp:
 %   base1 = WEIGHT_BASE + ( cp >> 15 )
 %   base2 = ( cp & 0x7FFF ) | 0x8000
@@ -35,7 +36,7 @@
 
 %   WEIGHT_BASE = 0xFB00
 %      cp >= 0x17000 && cp <= 0x187F7 % Tangut ideographs
-%      cp >= 0x18800 && cp <= 0x18AF2 % Tangut components
+%      cp >= 0x18800 && cp <= 0x18AFF % Tangut components
 %      cp >= 0x18D00 && cp <= 0x18D08 % Tangut ideograph supplement
 %   For a given Tangut character at code point cp:
 %   base1 = WEIGHT_BASE

--- a/c/uca/sifter/unisift.c
+++ b/c/uca/sifter/unisift.c
@@ -2,7 +2,7 @@
 // License & terms of use: https://www.unicode.org/copyright.html
 /*
 **      Unilib
-**      Copyright 2021
+**      Copyright 2022
 **      Ken Whistler, All rights reserved.
 */
 
@@ -43,6 +43,7 @@
  *               4 new archaic kana: U+1B11F..U+1B122.
  *   2021-Jul-06 Fix for 3 local array overflows for sprintf in getName().
  *   2021-Jul-12 Bump version number for memory leak fix in unisyms.c.
+ *   2022-May-12 Updates for Unicode 15.0.
  */
 
 /*
@@ -167,15 +168,15 @@
 #define PATHNAMELEN (256)
 #define LONGESTARG  (256)
 
-static char versionString[] = "Sifter version 14.0.0d5, 2021-07-12\n";
+static char versionString[] = "Sifter version 15.0.0d1, 2022-05-12\n";
 
-static char unidatafilename[] = "unidata-14.0.0.txt";
-static char allkeysfilename[] = "allkeys-14.0.0.txt";
-static char decompsfilename[] = "decomps-14.0.0.txt";
+static char unidatafilename[] = "unidata-15.0.0.txt";
+static char allkeysfilename[] = "allkeys-15.0.0.txt";
+static char decompsfilename[] = "decomps-15.0.0.txt";
 
-static char versionstring[] = "@version 14.0.0\n\n";
+static char versionstring[] = "@version 15.0.0\n\n";
 
-#define COPYRIGHTYEAR (2021)
+#define COPYRIGHTYEAR (2022)
 
 #define defaultInfile "unidata.col"
 
@@ -273,7 +274,7 @@ int digitsInitialized;
 #define CJK_EXTB_FIRST (0x20000)
 #define CJK_EXTB_LAST  (0x2A6DF)
 #define CJK_EXTC_FIRST (0x2A700)
-#define CJK_EXTC_LAST  (0x2B738)
+#define CJK_EXTC_LAST  (0x2B739)
 #define CJK_EXTD_FIRST (0x2B740)
 #define CJK_EXTD_LAST  (0x2B81D)
 #define CJK_EXTE_FIRST (0x2B820)
@@ -282,6 +283,8 @@ int digitsInitialized;
 #define CJK_EXTF_LAST  (0x2EBE0)
 #define CJK_EXTG_FIRST (0x30000)
 #define CJK_EXTG_LAST  (0x3134A)
+#define CJK_EXTH_FIRST (0x31350)
+#define CJK_EXTH_LAST  (0x323AF)
 
 /*
  * Constants defining other ideographic ranges for implicit weights.
@@ -537,6 +540,10 @@ WALNUTPTR getSiftDataPtr ( UInt32 i )
     {
         return ( &handata );
     }
+    else if ( i <= CJK_EXTH_LAST )
+    {
+        return ( &handata );
+    }
     else if ( ( i >= 0xE0000 ) && ( i <= 0xE01FF ) )
     {
         return ( &(plane14[i - 0xE0000]) );
@@ -596,7 +603,8 @@ char localbuf[20];
              ( ( c >= CJK_EXTD_FIRST ) && ( c <= CJK_EXTD_LAST ) ) ||
              ( ( c >= CJK_EXTE_FIRST ) && ( c <= CJK_EXTE_LAST ) ) ||
              ( ( c >= CJK_EXTF_FIRST ) && ( c <= CJK_EXTF_LAST ) ) ||
-             ( ( c >= CJK_EXTG_FIRST ) && ( c <= CJK_EXTG_LAST ) ) )
+             ( ( c >= CJK_EXTG_FIRST ) && ( c <= CJK_EXTG_LAST ) ) ||
+             ( ( c >= CJK_EXTH_FIRST ) && ( c <= CJK_EXTH_LAST ) ) )
         {
             sprintf ( localbuf, "HAN%04X", c );
             strcpy ( dp, localbuf );
@@ -1142,7 +1150,8 @@ UShort16 base;
               ( ( i >= CJK_EXTD_FIRST ) && ( i <= CJK_EXTD_LAST ) ) ||
               ( ( i >= CJK_EXTE_FIRST ) && ( i <= CJK_EXTE_LAST ) ) ||
               ( ( i >= CJK_EXTF_FIRST ) && ( i <= CJK_EXTF_LAST ) ) ||
-              ( ( i >= CJK_EXTG_FIRST ) && ( i <= CJK_EXTG_LAST ) ) )
+              ( ( i >= CJK_EXTG_FIRST ) && ( i <= CJK_EXTG_LAST ) ) || 
+              ( ( i >= CJK_EXTH_FIRST ) && ( i <= CJK_EXTH_LAST ) ) )
     {
         base = 0xFB80; /* Tangut ideographs and Tangut components */
     }
@@ -1485,6 +1494,7 @@ static int unisift_ForceToSecondary ( UInt32 c )
     case 0x0C03 :
     case 0x0C82 :
     case 0x0C83 :
+    case 0x0CF3 :
     case 0x0D02 :
     case 0x0D03 :
     case 0x0D82 :
@@ -1539,6 +1549,9 @@ static int unisift_ForceToSecondary ( UInt32 c )
     case 0x1163E :
     case 0x116AB :   /* Takri */
     case 0x116AC :
+    case 0x11F00 :   /* Kawi */
+    case 0x11F01 :
+    case 0x11F03 :
 #endif
         return ( 1 );
     default: 
@@ -1632,7 +1645,7 @@ struct tm *temptptr;
     fputs ( localbuf, fd );
     sprintf ( localbuf, "# Copyright %d Unicode, Inc.\n", COPYRIGHTYEAR );
     fputs ( localbuf, fd );
-    sprintf ( localbuf, "# For terms of use, see http://www.unicode.org/terms_of_use.html\n#\n" );
+    sprintf ( localbuf, "# For terms of use, see https://www.unicode.org/terms_of_use.html\n#\n" );
     fputs ( localbuf, fd );
     sprintf ( localbuf, "# This file defines the Default Unicode Collation Element Table\n" );
     fputs ( localbuf, fd );
@@ -1676,7 +1689,7 @@ FILE *fdi;
     fputs ( localbuf, fd );
     sprintf ( localbuf, "# Copyright %d Unicode, Inc.\n", COPYRIGHTYEAR );
     fputs ( localbuf, fd );
-    sprintf ( localbuf, "# For terms of use, see http://www.unicode.org/terms_of_use.html\n#\n" );
+    sprintf ( localbuf, "# For terms of use, see https://www.unicode.org/terms_of_use.html\n#\n" );
     fputs ( localbuf, fd );
     sprintf ( localbuf, "# This file lists decompositions used in generating the Default Unicode Collation Element Table\n" );
     fputs ( localbuf, fd );
@@ -3443,16 +3456,16 @@ static unichar kanaMap2[] =
 /*
  * Another kana map to deal with the Small Kana Extension block
  * at U+1B130..U+1B16F. The full range is defined here, even though
- * most of the characters are still unassigned as of Unicode 12.0,
+ * most of the characters are still unassigned as of Unicode 15.0,
  * to simplify the task of filling in the rest once they are added.
  */
 static unichar kanaMap3[] =
     {
-      0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, /* 3 */
+      0x0000, 0x0000, 0x30B3, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, /* 3 */
       0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
       0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, /* 4 */
       0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
-      0x30F0, 0x30F1, 0x30F2, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, /* 5 */
+      0x30F0, 0x30F1, 0x30F2, 0x0000, 0x0000, 0x30B3, 0x0000, 0x0000, /* 5 */
       0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
       0x0000, 0x0000, 0x0000, 0x0000, 0x30F0, 0x30F1, 0x30F2, 0x30F3, /* 6 */
       0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000
@@ -3502,13 +3515,13 @@ static UChar8 tertwtMap[] =
 
 static UChar8 tertwtMap3[] =
     {
+           0,      0,      HIRA_S, 0,      0,      0,      0,      0,
            0,      0,      0,      0,      0,      0,      0,      0,
            0,      0,      0,      0,      0,      0,      0,      0,
            0,      0,      0,      0,      0,      0,      0,      0,
+           HIRA_S, HIRA_S, HIRA_S, 0,      0,      KATA_S, 0,      0,
            0,      0,      0,      0,      0,      0,      0,      0,
-           HIRA_S, HIRA_S, HIRA_S, 0,      0,      0,      0,      0,
-           0,      0,      0,      0,      0,      0,      0,      0,
-           0,      0,      0,      0, KATA_S, KATA_S, KATA_S, KATA_S,
+           0,      0,      0,      0,      KATA_S, KATA_S, KATA_S, KATA_S,
            0,      0,      0,      0,      0,      0,      0,      0
     };
 

--- a/c/uca/sifter/unisyms.c
+++ b/c/uca/sifter/unisyms.c
@@ -2,7 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 /*
 **      Unilib
-**      Copyright 2021
+**      Copyright 2022
 **      Ken Whistler, All rights reserved.
 */
 
@@ -36,6 +36,7 @@
  *               Other adjustments for UCA 13.0.
  *   2021-Jul-12 Added test and free of outputstring in unisift_DropSymTreeP
  *               to fix memory leak.
+ *   2022-May-18 Add secondary ranges for UCA 15.0. Tweak some other ranges.
  */
 
 #define _CRT_SECURE_NO_WARNINGS
@@ -116,7 +117,7 @@ extern char *GetUnidataFileName ( void );
  * NUMSECONDSYMS and the following tables needs to be revisited whenever
  * any new NSM is added or reordered.
  */
-#define NUMSECONDSYMS (253)
+#define NUMSECONDSYMS (257)
 
 static const char *tertSyms[NUMTERTSYMS] =
                    { "<RES-1>",
@@ -585,6 +586,7 @@ static const char *secondSyms[NUMSECONDSYMS] = {
 "<D0E4B>", /* Thai character mai chattawa */
 "<D0E4C>", /* Thai character thanthakhat */
 "<D0E4D>", /* Thai character nikhahit */
+"<D0ECE>", /* Lao yamakkan */
 "<D0EC8>", /* Lao tone mai ek */
 "<D0EC9>", /* Lao tone mai tho */
 "<D0ECA>", /* Lao tone mai ti */
@@ -649,6 +651,10 @@ static const char *secondSyms[NUMSECONDSYMS] = {
 "<D1E2ED>", /* Wancho tone tup mang */
 "<D1E2EE>", /* Wancho tone okoi */
 "<D1E2EF>", /* Wancho tone okoi mang */
+"<D1E4EC>", /* Nag Mundari sign muhor */
+"<D1E4ED>", /* Nag Mundari sign toyor */
+"<D1E4EE>", /* Nag Mundari sign ikir */
+"<D1E4EF>", /* Nag Mundari sign sutuh */
 
 "<D302A>",  /* ideographic level tone mark */
 "<D302B>",  /* ideographic rising tone mark*/
@@ -702,7 +708,6 @@ static const char *secondSyms[NUMSECONDSYMS] = {
 "<D20EF>", /* right arrow below */
 "<D20F0>", /* asterisk above */
 #endif
-"<D101FD>", /* Phaistos disc combining oblique stroke */
 /*
  * Secondary weights for variant marks created by hack using user-defined
  * characters.
@@ -825,9 +830,9 @@ static utf32char secondSymVals[NUMSECONDSYMS] = {
     /* 0x116AB, 0x116AC, 0x116B7, */
 /* Soyombo */
     0x11A98,
-/* Thai, Lao, Tai View */
+/* Thai, Lao, Tai Viet */
     0x0E4E, 0x0E47, 0x0E48, 0x0E49, 0x0E4A, 0x0E4B, 0x0E4C, 0x0E4D, 
-    0x0EC8, 0x0EC9, 0x0ECA, 0x0ECB, 0x0ECC, 0x0ECD,
+    0x0ECE, 0x0EC8, 0x0EC9, 0x0ECA, 0x0ECB, 0x0ECC, 0x0ECD,
     0xAABF, 0xAAC1,
 /* Tibetan */
     0x0F39, /* 0x0F7E, 0x0F7F, */
@@ -850,6 +855,8 @@ static utf32char secondSymVals[NUMSECONDSYMS] = {
     0x16B30, 0x16B31, 0x16B32, 0x16B33, 0x16B34, 0x16B35, 0x16B36,
 /* Wancho */
     0x1E2EC, 0x1E2ED, 0x1E2EE, 0x1E2EF,
+/* Nag Mundari */
+    0x1E4EC, 0x1E4ED, 0x1E4EE, 0x1E4EF,
 /* CJK */
     0x302A, 0x302B, 0x302C, 0x302D, 0x302E, 0x302F, 0x16FF0, 0x16FF1,
 /* Symbols */
@@ -858,8 +865,6 @@ static utf32char secondSymVals[NUMSECONDSYMS] = {
     /* 0x20DD, 0x20DE, 0x20DF, 0x20E0,*/ 0x20E1,
     /* 0x20E2, 0x20E3, 0x20E4, 0x20E5,*/ 0x20E6, 0x20E7, 0x20E8, 0x20E9, 
     /* 0x20EA, 0x20EB, 0x20EC, 0x20ED, 0x20EE, 0x20EF, 0x20F0,*/
-/* Phaistos Disc symbol */
-    0x101FD,
 /* User-defined characters used to hack in variants for secondary weights. */
     0xF8F0, 0xF8F1, 0xF8F2, 0xF8F3, 0xF8F4
 };
@@ -2460,13 +2465,13 @@ int greatestdepth;
         return ( rc );
     }
 
-    rc = unisift_BuildSymWtTreeRange ( 0xFB00, 0x11CBF, &greatestdepth );
+    rc = unisift_BuildSymWtTreeRange ( 0xFB00, 0x11FFF, &greatestdepth );
     if ( rc < 0 )
     {
         return ( rc );
     }
 
-    rc = unisift_BuildSymWtTreeRange ( 0x12000, 0x1343F, &greatestdepth );
+    rc = unisift_BuildSymWtTreeRange ( 0x12000, 0x1345F, &greatestdepth );
     if ( rc < 0 )
     {
         return ( rc );
@@ -2484,25 +2489,25 @@ int greatestdepth;
         return ( rc );
     }
 
-    rc = unisift_BuildSymWtTreeRange ( 0x1B000, 0x1BCAF, &greatestdepth );
+    rc = unisift_BuildSymWtTreeRange ( 0x1AFF0, 0x1BCAF, &greatestdepth );
     if ( rc < 0 )
     {
         return ( rc );
     }
 
-    rc = unisift_BuildSymWtTreeRange ( 0x1D000, 0x1D37F, &greatestdepth );
+    rc = unisift_BuildSymWtTreeRange ( 0x1CF00, 0x1D37F, &greatestdepth );
     if ( rc < 0 )
     {
         return ( rc );
     }
 
-    rc = unisift_BuildSymWtTreeRange ( 0x1D800, 0x1E2FF, &greatestdepth );
+    rc = unisift_BuildSymWtTreeRange ( 0x1D800, 0x1E4FF, &greatestdepth );
     if ( rc < 0 )
     {
         return ( rc );
     }
 
-    rc = unisift_BuildSymWtTreeRange ( 0x1E800, 0x1FAFF, &greatestdepth );
+    rc = unisift_BuildSymWtTreeRange ( 0x1E7E0, 0x1FBFF, &greatestdepth );
     if ( rc < 0 )
     {
         return ( rc );


### PR DESCRIPTION
From Ken:

The only changes for 15.0 are:

unisift.c

A bunch of version and date updates;
updates for CJK ranges;
http: --> https: updates in a couple outputs for terms of use;
tweaks to the kana mapping tables for the two new small kana characters.

unisyms.c

Updates to the symbol tables for 5 new combining marks
(and for removing the explicit separate weight for the Phaistos Disc symbol mark);
updates of SMP block ranges to make sure all the appropriate
ranges of symbolic weights get output correctly.

cttfooter.txt

Updates for some CJK ranges in the static text appended at the bottom of
the CTT table output.