### PR TITLE
write multiple ea/lb @missing lines

### DIFF
--- a/unicodetools/data/ucd/dev/extracted/DerivedEastAsianWidth.txt
+++ b/unicodetools/data/ucd/dev/extracted/DerivedEastAsianWidth.txt
@@ -1,5 +1,5 @@
 # DerivedEastAsianWidth-15.0.0.txt
-# Date: 2022-05-25, 20:14:07 GMT
+# Date: 2022-07-08, 23:49:26 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -15,6 +15,27 @@
 #  have the value Neutral (N).
 
 # @missing: 0000..10FFFF; Neutral
+
+# 3400..4DBF CJK_Unified_Ideographs_Extension_A
+# @missing: 3400..4DBF; Wide
+
+# 4E00..9FFF CJK_Unified_Ideographs
+# @missing: 4E00..9FFF; Wide
+
+# F900..FAFF CJK_Compatibility_Ideographs
+# @missing: F900..FAFF; Wide
+
+# 20000..2A6DF CJK_Unified_Ideographs_Extension_B
+# 2A700..2B73F CJK_Unified_Ideographs_Extension_C
+# 2B740..2B81F CJK_Unified_Ideographs_Extension_D
+# 2B820..2CEAF CJK_Unified_Ideographs_Extension_E
+# 2CEB0..2EBEF CJK_Unified_Ideographs_Extension_F
+# 2F800..2FA1F CJK_Compatibility_Ideographs_Supplement
+# @missing: 20000..2FFFD; Wide
+
+# 30000..3134F CJK_Unified_Ideographs_Extension_G
+# 31350..323AF CJK_Unified_Ideographs_Extension_H
+# @missing: 30000..3FFFD; Wide
 
 # ================================================
 
@@ -2372,9 +2393,7 @@ A490..A4C6    ; W # So  [55] YI RADICAL QOT..YI RADICAL KE
 A960..A97C    ; W # Lo  [29] HANGUL CHOSEONG TIKEUT-MIEUM..HANGUL CHOSEONG SSANGYEORINHIEUH
 AC00..D7A3    ; W # Lo [11172] HANGUL SYLLABLE GA..HANGUL SYLLABLE HIH
 F900..FA6D    ; W # Lo [366] CJK COMPATIBILITY IDEOGRAPH-F900..CJK COMPATIBILITY IDEOGRAPH-FA6D
-FA6E..FA6F    ; W # Cn   [2] <reserved-FA6E>..<reserved-FA6F>
 FA70..FAD9    ; W # Lo [106] CJK COMPATIBILITY IDEOGRAPH-FA70..CJK COMPATIBILITY IDEOGRAPH-FAD9
-FADA..FAFF    ; W # Cn  [38] <reserved-FADA>..<reserved-FAFF>
 FE10..FE16    ; W # Po   [7] PRESENTATION FORM FOR VERTICAL COMMA..PRESENTATION FORM FOR VERTICAL QUESTION MARK
 FE17          ; W # Ps       PRESENTATION FORM FOR VERTICAL LEFT WHITE LENTICULAR BRACKET
 FE18          ; W # Pe       PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRAKCET
@@ -2485,22 +2504,15 @@ FE6A..FE6B    ; W # Po   [2] SMALL PERCENT SIGN..SMALL COMMERCIAL AT
 1FAE0..1FAE8  ; W # So   [9] MELTING FACE..SHAKING FACE
 1FAF0..1FAF8  ; W # So   [9] HAND WITH INDEX FINGER AND THUMB CROSSED..RIGHTWARDS PUSHING HAND
 20000..2A6DF  ; W # Lo [42720] CJK UNIFIED IDEOGRAPH-20000..CJK UNIFIED IDEOGRAPH-2A6DF
-2A6E0..2A6FF  ; W # Cn  [32] <reserved-2A6E0>..<reserved-2A6FF>
 2A700..2B739  ; W # Lo [4154] CJK UNIFIED IDEOGRAPH-2A700..CJK UNIFIED IDEOGRAPH-2B739
-2B73A..2B73F  ; W # Cn   [6] <reserved-2B73A>..<reserved-2B73F>
 2B740..2B81D  ; W # Lo [222] CJK UNIFIED IDEOGRAPH-2B740..CJK UNIFIED IDEOGRAPH-2B81D
-2B81E..2B81F  ; W # Cn   [2] <reserved-2B81E>..<reserved-2B81F>
 2B820..2CEA1  ; W # Lo [5762] CJK UNIFIED IDEOGRAPH-2B820..CJK UNIFIED IDEOGRAPH-2CEA1
-2CEA2..2CEAF  ; W # Cn  [14] <reserved-2CEA2>..<reserved-2CEAF>
 2CEB0..2EBE0  ; W # Lo [7473] CJK UNIFIED IDEOGRAPH-2CEB0..CJK UNIFIED IDEOGRAPH-2EBE0
-2EBE1..2F7FF  ; W # Cn [3103] <reserved-2EBE1>..<reserved-2F7FF>
 2F800..2FA1D  ; W # Lo [542] CJK COMPATIBILITY IDEOGRAPH-2F800..CJK COMPATIBILITY IDEOGRAPH-2FA1D
-2FA1E..2FFFD  ; W # Cn [1504] <reserved-2FA1E>..<reserved-2FFFD>
 30000..3134A  ; W # Lo [4939] CJK UNIFIED IDEOGRAPH-30000..CJK UNIFIED IDEOGRAPH-3134A
-3134B..3134F  ; W # Cn   [5] <reserved-3134B>..<reserved-3134F>
 31350..323AF  ; W # Lo [4192] CJK UNIFIED IDEOGRAPH-31350..CJK UNIFIED IDEOGRAPH-323AF
-323B0..3FFFD  ; W # Cn [56398] <reserved-323B0>..<reserved-3FFFD>
 
+# The above property value applies to 61104 code points not listed here.
 # Total code points: 182412
 
 # ================================================

--- a/unicodetools/data/ucd/dev/extracted/DerivedLineBreak.txt
+++ b/unicodetools/data/ucd/dev/extracted/DerivedLineBreak.txt
@@ -1,5 +1,5 @@
 # DerivedLineBreak-15.0.0.txt
-# Date: 2022-07-08, 22:07:42 GMT
+# Date: 2022-07-09, 02:00:32 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -15,6 +15,49 @@
 #  have the value Unknown (XX).
 
 # @missing: 0000..10FFFF; Unknown
+
+# 20A0..20CF Currency_Symbols
+# @missing: 20A0..20CF; Prefix_Numeric
+
+# 3400..4DBF CJK_Unified_Ideographs_Extension_A
+# @missing: 3400..4DBF; Ideographic
+
+# 4E00..9FFF CJK_Unified_Ideographs
+# @missing: 4E00..9FFF; Ideographic
+
+# F900..FAFF CJK_Compatibility_Ideographs
+# @missing: F900..FAFF; Ideographic
+
+# 1F000..1F02F Mahjong_Tiles
+# 1F030..1F09F Domino_Tiles
+# 1F0A0..1F0FF Playing_Cards
+# 1F100..1F1FF Enclosed_Alphanumeric_Supplement
+# 1F200..1F2FF Enclosed_Ideographic_Supplement
+# 1F300..1F5FF Miscellaneous_Symbols_And_Pictographs
+# 1F600..1F64F Emoticons
+# 1F650..1F67F Ornamental_Dingbats
+# 1F680..1F6FF Transport_And_Map_Symbols
+# 1F700..1F77F Alchemical_Symbols
+# 1F780..1F7FF Geometric_Shapes_Extended
+# 1F800..1F8FF Supplemental_Arrows_C
+# 1F900..1F9FF Supplemental_Symbols_And_Pictographs
+# 1FA00..1FA6F Chess_Symbols
+# 1FA70..1FAFF Symbols_And_Pictographs_Extended_A
+# @missing: 1F000..1FAFF; Ideographic
+
+# @missing: 1FC00..1FFFD; Ideographic
+
+# 20000..2A6DF CJK_Unified_Ideographs_Extension_B
+# 2A700..2B73F CJK_Unified_Ideographs_Extension_C
+# 2B740..2B81F CJK_Unified_Ideographs_Extension_D
+# 2B820..2CEAF CJK_Unified_Ideographs_Extension_E
+# 2CEB0..2EBEF CJK_Unified_Ideographs_Extension_F
+# 2F800..2FA1F CJK_Compatibility_Ideographs_Supplement
+# @missing: 20000..2FFFD; Ideographic
+
+# 30000..3134F CJK_Unified_Ideographs_Extension_G
+# 31350..323AF CJK_Unified_Ideographs_Extension_H
+# @missing: 30000..3FFFD; Ideographic
 
 # ================================================
 
@@ -385,7 +428,6 @@ FE13..FE14    ; IS # Po   [2] PRESENTATION FORM FOR VERTICAL COLON..PRESENTATION
 20B7..20BA    ; PR # Sc   [4] SPESMILO SIGN..TURKISH LIRA SIGN
 20BC..20BD    ; PR # Sc   [2] MANAT SIGN..RUBLE SIGN
 20BF          ; PR # Sc       BITCOIN SIGN
-20C1..20CF    ; PR # Cn  [15] <reserved-20C1>..<reserved-20CF>
 2116          ; PR # So       NUMERO SIGN
 2212..2213    ; PR # Sm   [2] MINUS SIGN..MINUS-OR-PLUS SIGN
 FE69          ; PR # Sc       SMALL DOLLAR SIGN
@@ -394,6 +436,7 @@ FFE1          ; PR # Sc       FULLWIDTH POUND SIGN
 FFE5..FFE6    ; PR # Sc   [2] FULLWIDTH YEN SIGN..FULLWIDTH WON SIGN
 1E2FF         ; PR # Sc       WANCHO NGUN SIGN
 
+# The above property value applies to 15 code points not listed here.
 # Total code points: 67
 
 # ================================================
@@ -1669,9 +1712,7 @@ FFED..FFEE    ; AL # So   [2] HALFWIDTH BLACK SQUARE..HALFWIDTH WHITE CIRCLE
 A016..A48C    ; ID # Lo [1143] YI SYLLABLE BIT..YI SYLLABLE YYR
 A490..A4C6    ; ID # So  [55] YI RADICAL QOT..YI RADICAL KE
 F900..FA6D    ; ID # Lo [366] CJK COMPATIBILITY IDEOGRAPH-F900..CJK COMPATIBILITY IDEOGRAPH-FA6D
-FA6E..FA6F    ; ID # Cn   [2] <reserved-FA6E>..<reserved-FA6F>
 FA70..FAD9    ; ID # Lo [106] CJK COMPATIBILITY IDEOGRAPH-FA70..CJK COMPATIBILITY IDEOGRAPH-FAD9
-FADA..FAFF    ; ID # Cn  [38] <reserved-FADA>..<reserved-FAFF>
 FE30          ; ID # Po       PRESENTATION FORM FOR VERTICAL TWO DOT LEADER
 FE31..FE32    ; ID # Pd   [2] PRESENTATION FORM FOR VERTICAL EM DASH..PRESENTATION FORM FOR VERTICAL EN DASH
 FE33..FE34    ; ID # Pc   [2] PRESENTATION FORM FOR VERTICAL LOW LINE..PRESENTATION FORM FOR VERTICAL WAVY LOW LINE
@@ -1720,31 +1761,19 @@ FFE4          ; ID # So       FULLWIDTH BROKEN BAR
 1B000..1B122  ; ID # Lo [291] KATAKANA LETTER ARCHAIC E..KATAKANA LETTER ARCHAIC WU
 1B170..1B2FB  ; ID # Lo [396] NUSHU CHARACTER-1B170..NUSHU CHARACTER-1B2FB
 1F000..1F02B  ; ID # So  [44] MAHJONG TILE EAST WIND..MAHJONG TILE BACK
-1F02C..1F02F  ; ID # Cn   [4] <reserved-1F02C>..<reserved-1F02F>
 1F030..1F093  ; ID # So [100] DOMINO TILE HORIZONTAL BACK..DOMINO TILE VERTICAL-06-06
-1F094..1F09F  ; ID # Cn  [12] <reserved-1F094>..<reserved-1F09F>
 1F0A0..1F0AE  ; ID # So  [15] PLAYING CARD BACK..PLAYING CARD KING OF SPADES
-1F0AF..1F0B0  ; ID # Cn   [2] <reserved-1F0AF>..<reserved-1F0B0>
 1F0B1..1F0BF  ; ID # So  [15] PLAYING CARD ACE OF HEARTS..PLAYING CARD RED JOKER
-1F0C0         ; ID # Cn       <reserved-1F0C0>
 1F0C1..1F0CF  ; ID # So  [15] PLAYING CARD ACE OF DIAMONDS..PLAYING CARD BLACK JOKER
-1F0D0         ; ID # Cn       <reserved-1F0D0>
 1F0D1..1F0F5  ; ID # So  [37] PLAYING CARD ACE OF CLUBS..PLAYING CARD TRUMP-21
-1F0F6..1F0FF  ; ID # Cn  [10] <reserved-1F0F6>..<reserved-1F0FF>
 1F10D..1F10F  ; ID # So   [3] CIRCLED ZERO WITH SLASH..CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH
 1F16D..1F16F  ; ID # So   [3] CIRCLED CC..CIRCLED HUMAN FIGURE
 1F1AD         ; ID # So       MASK WORK SYMBOL
-1F1AE..1F1E5  ; ID # Cn  [56] <reserved-1F1AE>..<reserved-1F1E5>
 1F200..1F202  ; ID # So   [3] SQUARE HIRAGANA HOKA..SQUARED KATAKANA SA
-1F203..1F20F  ; ID # Cn  [13] <reserved-1F203>..<reserved-1F20F>
 1F210..1F23B  ; ID # So  [44] SQUARED CJK UNIFIED IDEOGRAPH-624B..SQUARED CJK UNIFIED IDEOGRAPH-914D
-1F23C..1F23F  ; ID # Cn   [4] <reserved-1F23C>..<reserved-1F23F>
 1F240..1F248  ; ID # So   [9] TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-672C..TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-6557
-1F249..1F24F  ; ID # Cn   [7] <reserved-1F249>..<reserved-1F24F>
 1F250..1F251  ; ID # So   [2] CIRCLED IDEOGRAPH ADVANTAGE..CIRCLED IDEOGRAPH ACCEPT
-1F252..1F25F  ; ID # Cn  [14] <reserved-1F252>..<reserved-1F25F>
 1F260..1F265  ; ID # So   [6] ROUNDED SYMBOL FOR FU..ROUNDED SYMBOL FOR CAI
-1F266..1F2FF  ; ID # Cn [154] <reserved-1F266>..<reserved-1F2FF>
 1F300..1F384  ; ID # So [133] CYCLONE..CHRISTMAS TREE
 1F386..1F39B  ; ID # So  [22] FIREWORKS..CONTROL KNOBS
 1F39E..1F3B4  ; ID # So  [23] FILM FRAMES..FLOWER PLAYING CARDS
@@ -1783,27 +1812,14 @@ FFE4          ; ID # So       FULLWIDTH BROKEN BAR
 1F6B7..1F6BF  ; ID # So   [9] NO PEDESTRIANS..SHOWER
 1F6C1..1F6CB  ; ID # So  [11] BATHTUB..COUCH AND LAMP
 1F6CD..1F6D7  ; ID # So  [11] SHOPPING BAGS..ELEVATOR
-1F6D8..1F6DB  ; ID # Cn   [4] <reserved-1F6D8>..<reserved-1F6DB>
 1F6DC..1F6EC  ; ID # So  [17] WIRELESS..AIRPLANE ARRIVING
-1F6ED..1F6EF  ; ID # Cn   [3] <reserved-1F6ED>..<reserved-1F6EF>
 1F6F0..1F6FC  ; ID # So  [13] SATELLITE..ROLLER SKATE
-1F6FD..1F6FF  ; ID # Cn   [3] <reserved-1F6FD>..<reserved-1F6FF>
 1F774..1F776  ; ID # So   [3] LOT OF FORTUNE..LUNAR ECLIPSE
-1F777..1F77A  ; ID # Cn   [4] <reserved-1F777>..<reserved-1F77A>
 1F77B..1F77F  ; ID # So   [5] HAUMEA..ORCUS
 1F7D5..1F7D9  ; ID # So   [5] CIRCLED TRIANGLE..NINE POINTED WHITE STAR
-1F7DA..1F7DF  ; ID # Cn   [6] <reserved-1F7DA>..<reserved-1F7DF>
 1F7E0..1F7EB  ; ID # So  [12] LARGE ORANGE CIRCLE..LARGE BROWN SQUARE
-1F7EC..1F7EF  ; ID # Cn   [4] <reserved-1F7EC>..<reserved-1F7EF>
 1F7F0         ; ID # So       HEAVY EQUALS SIGN
-1F7F1..1F7FF  ; ID # Cn  [15] <reserved-1F7F1>..<reserved-1F7FF>
-1F80C..1F80F  ; ID # Cn   [4] <reserved-1F80C>..<reserved-1F80F>
-1F848..1F84F  ; ID # Cn   [8] <reserved-1F848>..<reserved-1F84F>
-1F85A..1F85F  ; ID # Cn   [6] <reserved-1F85A>..<reserved-1F85F>
-1F888..1F88F  ; ID # Cn   [8] <reserved-1F888>..<reserved-1F88F>
-1F8AE..1F8AF  ; ID # Cn   [2] <reserved-1F8AE>..<reserved-1F8AF>
 1F8B0..1F8B1  ; ID # So   [2] ARROW POINTING UPWARDS THEN NORTH WEST..ARROW POINTING RIGHTWARDS THEN CURVING SOUTH WEST
-1F8B2..1F8FF  ; ID # Cn  [78] <reserved-1F8B2>..<reserved-1F8FF>
 1F90D..1F90E  ; ID # So   [2] WHITE HEART..BROWN HEART
 1F910..1F917  ; ID # So   [8] ZIPPER-MOUTH FACE..HUGGING FACE
 1F920..1F925  ; ID # So   [6] FACE WITH COWBOY HAT..LYING FACE
@@ -1816,40 +1832,23 @@ FFE4          ; ID # So       FULLWIDTH BROKEN BAR
 1F9BC..1F9CC  ; ID # So  [17] MOTORIZED WHEELCHAIR..TROLL
 1F9D0         ; ID # So       FACE WITH MONOCLE
 1F9DE..1F9FF  ; ID # So  [34] GENIE..NAZAR AMULET
-1FA54..1FA5F  ; ID # Cn  [12] <reserved-1FA54>..<reserved-1FA5F>
 1FA60..1FA6D  ; ID # So  [14] XIANGQI RED GENERAL..XIANGQI BLACK SOLDIER
-1FA6E..1FA6F  ; ID # Cn   [2] <reserved-1FA6E>..<reserved-1FA6F>
 1FA70..1FA7C  ; ID # So  [13] BALLET SHOES..CRUTCH
-1FA7D..1FA7F  ; ID # Cn   [3] <reserved-1FA7D>..<reserved-1FA7F>
 1FA80..1FA88  ; ID # So   [9] YO-YO..FLUTE
-1FA89..1FA8F  ; ID # Cn   [7] <reserved-1FA89>..<reserved-1FA8F>
 1FA90..1FABD  ; ID # So  [46] RINGED PLANET..WING
-1FABE         ; ID # Cn       <reserved-1FABE>
 1FABF..1FAC2  ; ID # So   [4] GOOSE..PEOPLE HUGGING
-1FAC6..1FACD  ; ID # Cn   [8] <reserved-1FAC6>..<reserved-1FACD>
 1FACE..1FADB  ; ID # So  [14] MOOSE..PEA POD
-1FADC..1FADF  ; ID # Cn   [4] <reserved-1FADC>..<reserved-1FADF>
 1FAE0..1FAE8  ; ID # So   [9] MELTING FACE..SHAKING FACE
-1FAE9..1FAEF  ; ID # Cn   [7] <reserved-1FAE9>..<reserved-1FAEF>
-1FAF9..1FAFF  ; ID # Cn   [7] <reserved-1FAF9>..<reserved-1FAFF>
-1FC00..1FFFD  ; ID # Cn [1022] <reserved-1FC00>..<reserved-1FFFD>
 20000..2A6DF  ; ID # Lo [42720] CJK UNIFIED IDEOGRAPH-20000..CJK UNIFIED IDEOGRAPH-2A6DF
-2A6E0..2A6FF  ; ID # Cn  [32] <reserved-2A6E0>..<reserved-2A6FF>
 2A700..2B739  ; ID # Lo [4154] CJK UNIFIED IDEOGRAPH-2A700..CJK UNIFIED IDEOGRAPH-2B739
-2B73A..2B73F  ; ID # Cn   [6] <reserved-2B73A>..<reserved-2B73F>
 2B740..2B81D  ; ID # Lo [222] CJK UNIFIED IDEOGRAPH-2B740..CJK UNIFIED IDEOGRAPH-2B81D
-2B81E..2B81F  ; ID # Cn   [2] <reserved-2B81E>..<reserved-2B81F>
 2B820..2CEA1  ; ID # Lo [5762] CJK UNIFIED IDEOGRAPH-2B820..CJK UNIFIED IDEOGRAPH-2CEA1
-2CEA2..2CEAF  ; ID # Cn  [14] <reserved-2CEA2>..<reserved-2CEAF>
 2CEB0..2EBE0  ; ID # Lo [7473] CJK UNIFIED IDEOGRAPH-2CEB0..CJK UNIFIED IDEOGRAPH-2EBE0
-2EBE1..2F7FF  ; ID # Cn [3103] <reserved-2EBE1>..<reserved-2F7FF>
 2F800..2FA1D  ; ID # Lo [542] CJK COMPATIBILITY IDEOGRAPH-2F800..CJK COMPATIBILITY IDEOGRAPH-2FA1D
-2FA1E..2FFFD  ; ID # Cn [1504] <reserved-2FA1E>..<reserved-2FFFD>
 30000..3134A  ; ID # Lo [4939] CJK UNIFIED IDEOGRAPH-30000..CJK UNIFIED IDEOGRAPH-3134A
-3134B..3134F  ; ID # Cn   [5] <reserved-3134B>..<reserved-3134F>
 31350..323AF  ; ID # Lo [4192] CJK UNIFIED IDEOGRAPH-31350..CJK UNIFIED IDEOGRAPH-323AF
-323B0..3FFFD  ; ID # Cn [56398] <reserved-323B0>..<reserved-3FFFD>
 
+# The above property value applies to 62600 code points not listed here.
 # Total code points: 172465
 
 # ================================================

--- a/unicodetools/src/main/java/org/unicode/props/DefaultValues.java
+++ b/unicodetools/src/main/java/org/unicode/props/DefaultValues.java
@@ -6,13 +6,19 @@ import com.ibm.icu.util.VersionInfo;
 import org.unicode.props.UcdPropertyValues.Bidi_Class_Values;
 import org.unicode.props.UcdPropertyValues.Block_Values;
 import org.unicode.props.UcdPropertyValues.East_Asian_Width_Values;
+import org.unicode.props.UcdPropertyValues.Line_Break_Values;
 
 /**
  * Default property values for some properties and certain ranges other than all of Unicode. See
  * https://www.unicode.org/reports/tr44/#Complex_Default_Values
  */
 public final class DefaultValues {
-    private static class BuilderBase {
+    private static final Block_Values CJK_Ext_A = Block_Values.CJK_Unified_Ideographs_Extension_A;
+
+    private static final UnicodeSet IDEO_PLANES =
+            new UnicodeSet(0x20000, 0x2FFFD, 0x30000, 0x3FFFD).freeze();
+
+    private static class BuilderBase<T> {
         int compositeVersion;
         IndexUnicodeProperties props;
         UnicodeMap<Block_Values> blocks;
@@ -22,6 +28,28 @@ public final class DefaultValues {
                     (version.getMajor() << 16) | (version.getMinor() << 8) | version.getMilli();
             props = IndexUnicodeProperties.make(version);
             blocks = props.loadEnum(UcdProperty.Block);
+        }
+
+        protected void addRangeValueIfAtLeast(
+                UnicodeMap<T> map, int start, int end, int minVersion, T value) {
+            if (compositeVersion >= minVersion) {
+                map.putAll(start, end, value);
+            }
+        }
+
+        protected void addSetValueIfAtLeast(
+                UnicodeMap<T> map, UnicodeSet set, int minVersion, T value) {
+            if (compositeVersion >= minVersion) {
+                map.putAll(set, value);
+            }
+        }
+
+        protected void addBlockValueIfAtLeast(
+                UnicodeMap<T> map, Block_Values blockValue, int minVersion, T value) {
+            if (compositeVersion >= minVersion) {
+                UnicodeSet block = blocks.keySet(blockValue);
+                map.putAll(block, value);
+            }
         }
     }
 
@@ -37,7 +65,7 @@ public final class DefaultValues {
             OMIT_BN
         };
 
-        private static final class Builder extends BuilderBase {
+        private static final class Builder extends BuilderBase<Bidi_Class_Values> {
             UnicodeMap<Bidi_Class_Values> bidi = new UnicodeMap<>();
 
             Builder(VersionInfo version) {
@@ -116,17 +144,12 @@ public final class DefaultValues {
 
             private void addRangeValueIfAtLeast(
                     int start, int end, int minVersion, Bidi_Class_Values value) {
-                if (compositeVersion >= minVersion) {
-                    bidi.putAll(start, end, value);
-                }
+                addRangeValueIfAtLeast(bidi, start, end, minVersion, value);
             }
 
             private void addBlockValueIfAtLeast(
                     Block_Values blockValue, int minVersion, Bidi_Class_Values value) {
-                if (compositeVersion >= minVersion) {
-                    UnicodeSet block = blocks.keySet(blockValue);
-                    bidi.putAll(block, value);
-                }
+                addBlockValueIfAtLeast(bidi, blockValue, minVersion, value);
             }
         }
 
@@ -136,11 +159,11 @@ public final class DefaultValues {
     }
 
     public static final class EastAsianWidth {
-        private static final East_Asian_Width_Values A = East_Asian_Width_Values.Ambiguous;
+        // private static final East_Asian_Width_Values A = East_Asian_Width_Values.Ambiguous;
         private static final East_Asian_Width_Values N = East_Asian_Width_Values.Neutral;
         private static final East_Asian_Width_Values W = East_Asian_Width_Values.Wide;
 
-        private static final class Builder extends BuilderBase {
+        private static final class Builder extends BuilderBase<East_Asian_Width_Values> {
             UnicodeMap<East_Asian_Width_Values> ea = new UnicodeMap<>();
 
             Builder(VersionInfo version) {
@@ -148,9 +171,6 @@ public final class DefaultValues {
             }
 
             UnicodeMap<East_Asian_Width_Values> build() {
-                // Overall default
-                ea.setMissing(N);
-
                 // Unicode 3.0 was the first version to publish UAX #11, effectively create
                 // the East_Asian_Width property, and assign default East_Asian_Width values.
 
@@ -158,6 +178,7 @@ public final class DefaultValues {
                 // This property defaults to Neutral for most code points, but
                 // defaults to Wide for unassigned code points in blocks associated with CJK
                 // ideographs.
+                ea.setMissing(N);
 
                 // https://www.unicode.org/reports/tr11/#Unassigned
                 // All private-use characters are by default classified as Ambiguous...
@@ -178,32 +199,57 @@ public final class DefaultValues {
                 // - the Supplementary Ideographic Plane, 20000..2FFFF
                 // - the Tertiary Ideographic Plane, 30000..3FFFF
                 // (except not the noncharacters)
-                addBlockValueIfAtLeast(Block_Values.CJK_Unified_Ideographs, 0x50200, W);
-                addBlockValueIfAtLeast(Block_Values.CJK_Unified_Ideographs_Extension_A, 0x50200, W);
-                addBlockValueIfAtLeast(Block_Values.CJK_Compatibility_Ideographs, 0x50200, W);
-                addRangeValueIfAtLeast(0x20000, 0x2FFFD, 0x40000, W);
-                addRangeValueIfAtLeast(0x30000, 0x3FFFD, 0x40000, W);
+                addBlockValueIfAtLeast(ea, Block_Values.CJK_Unified_Ideographs, 0x50200, W);
+                addBlockValueIfAtLeast(ea, CJK_Ext_A, 0x50200, W);
+                addBlockValueIfAtLeast(ea, Block_Values.CJK_Compatibility_Ideographs, 0x50200, W);
+                addSetValueIfAtLeast(ea, IDEO_PLANES, 0x40000, W);
 
                 return ea;
-            }
-
-            private void addRangeValueIfAtLeast(
-                    int start, int end, int minVersion, East_Asian_Width_Values value) {
-                if (compositeVersion >= minVersion) {
-                    ea.putAll(start, end, value);
-                }
-            }
-
-            private void addBlockValueIfAtLeast(
-                    Block_Values blockValue, int minVersion, East_Asian_Width_Values value) {
-                if (compositeVersion >= minVersion) {
-                    UnicodeSet block = blocks.keySet(blockValue);
-                    ea.putAll(block, value);
-                }
             }
         }
 
         public static UnicodeMap<East_Asian_Width_Values> forVersion(VersionInfo version) {
+            return new Builder(version).build();
+        }
+    }
+
+    public static final class LineBreak {
+        private static final Line_Break_Values XX = Line_Break_Values.Unknown;
+        private static final Line_Break_Values ID = Line_Break_Values.Ideographic;
+        private static final Line_Break_Values PR = Line_Break_Values.Prefix_Numeric;
+
+        private static final class Builder extends BuilderBase<Line_Break_Values> {
+            UnicodeMap<Line_Break_Values> lb = new UnicodeMap<>();
+
+            Builder(VersionInfo version) {
+                super(version);
+            }
+
+            UnicodeMap<Line_Break_Values> build() {
+                // https://www.unicode.org/reports/tr44/#Complex_Default_Values
+                // This property defaults to Unknown for most code points, but defaults to
+                // ID for unassigned code points in blocks associated with CJK ideographs,
+                // and in blocks in the ranges U+1F000..U+1FAFF and U+1FC00..U+1FFFD.
+                // The property defaults to PR for unassigned code points in the
+                // Currency Symbols block.
+                // (except not the noncharacters)
+                lb.setMissing(XX);
+                addBlockValueIfAtLeast(lb, Block_Values.CJK_Unified_Ideographs, 0x50200, ID);
+                addBlockValueIfAtLeast(lb, CJK_Ext_A, 0x50200, ID);
+                addBlockValueIfAtLeast(lb, Block_Values.CJK_Compatibility_Ideographs, 0x50200, ID);
+                addSetValueIfAtLeast(lb, IDEO_PLANES, 0x50200, ID);
+
+                addBlockValueIfAtLeast(lb, Block_Values.Currency_Symbols, 0x60300, PR);
+
+                addRangeValueIfAtLeast(lb, 0x1F000, 0x1FFFD, 0x90000, ID);
+                // Unicode 13+: punch a hole
+                addRangeValueIfAtLeast(lb, 0x1FB00, 0x1FBFF, 0xD0000, XX);
+
+                return lb;
+            }
+        }
+
+        public static UnicodeMap<Line_Break_Values> forVersion(VersionInfo version) {
             return new Builder(version).build();
         }
     }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
@@ -39,6 +39,7 @@ import org.unicode.props.UcdProperty;
 import org.unicode.props.UcdPropertyValues.Bidi_Class_Values;
 import org.unicode.props.UcdPropertyValues.Block_Values;
 import org.unicode.props.UcdPropertyValues.East_Asian_Width_Values;
+import org.unicode.props.UcdPropertyValues.Line_Break_Values;
 import org.unicode.props.UnicodeProperty;
 import org.unicode.text.UCD.MakeUnicodeFiles.Format.PrintStyle;
 import org.unicode.text.utility.ChainException;
@@ -1188,6 +1189,7 @@ public class MakeUnicodeFiles {
 
         UnicodeMap<Bidi_Class_Values> defaultBidiValues = null;
         UnicodeMap<East_Asian_Width_Values> defaultEaValues = null;
+        UnicodeMap<Line_Break_Values> defaultLbValues = null;
         if (prop.getName().equals("Bidi_Class")) {
             VersionInfo versionInfo = Default.ucdVersionInfo();
             defaultBidiValues =
@@ -1196,6 +1198,9 @@ public class MakeUnicodeFiles {
         } else if (prop.getName().equals("East_Asian_Width")) {
             VersionInfo versionInfo = Default.ucdVersionInfo();
             defaultEaValues = DefaultValues.EastAsianWidth.forVersion(versionInfo);
+        } else if (prop.getName().equals("Line_Break")) {
+            VersionInfo versionInfo = Default.ucdVersionInfo();
+            defaultLbValues = DefaultValues.LineBreak.forVersion(versionInfo);
         }
 
         final String missing = ps.skipUnassigned != null ? ps.skipUnassigned : ps.skipValue;
@@ -1213,6 +1218,9 @@ public class MakeUnicodeFiles {
             } else if (prop.getName().equals("East_Asian_Width")) {
                 East_Asian_Width_Values overallDefault = East_Asian_Width_Values.forName(missing);
                 writeEnumeratedMissingValues(pw, overallDefault, defaultEaValues);
+            } else if (prop.getName().equals("Line_Break")) {
+                Line_Break_Values overallDefault = Line_Break_Values.forName(missing);
+                writeEnumeratedMissingValues(pw, overallDefault, defaultLbValues);
             }
         }
         for (final Iterator<String> it = aliases.iterator(); it.hasNext(); ) {
@@ -1268,6 +1276,15 @@ public class MakeUnicodeFiles {
             } else if (defaultEaValues != null) {
                 East_Asian_Width_Values eaValue = East_Asian_Width_Values.forName(value);
                 if (defaultEaValues.containsValue(eaValue)) {
+                    // We assume that unassigned code points that have this value
+                    // according to the props data also have this value according to the defaults.
+                    // Otherwise we would need to intersect defaultEaValues.keySet(eaValue)
+                    // with the unassigned set before removing from s.
+                    s.removeAll(unassigned);
+                }
+            } else if (defaultLbValues != null) {
+                Line_Break_Values lbValue = Line_Break_Values.forName(value);
+                if (defaultLbValues.containsValue(lbValue)) {
                     // We assume that unassigned code points that have this value
                     // according to the props data also have this value according to the defaults.
                     // Otherwise we would need to intersect defaultEaValues.keySet(eaValue)

--- a/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
@@ -38,6 +38,7 @@ import org.unicode.props.IndexUnicodeProperties;
 import org.unicode.props.UcdProperty;
 import org.unicode.props.UcdPropertyValues.Bidi_Class_Values;
 import org.unicode.props.UcdPropertyValues.Block_Values;
+import org.unicode.props.UcdPropertyValues.East_Asian_Width_Values;
 import org.unicode.props.UnicodeProperty;
 import org.unicode.text.UCD.MakeUnicodeFiles.Format.PrintStyle;
 import org.unicode.text.utility.ChainException;
@@ -1186,11 +1187,15 @@ public class MakeUnicodeFiles {
         }
 
         UnicodeMap<Bidi_Class_Values> defaultBidiValues = null;
+        UnicodeMap<East_Asian_Width_Values> defaultEaValues = null;
         if (prop.getName().equals("Bidi_Class")) {
             VersionInfo versionInfo = Default.ucdVersionInfo();
             defaultBidiValues =
                     DefaultValues.BidiClass.forVersion(
                             versionInfo, DefaultValues.BidiClass.Option.OMIT_BN);
+        } else if (prop.getName().equals("East_Asian_Width")) {
+            VersionInfo versionInfo = Default.ucdVersionInfo();
+            defaultEaValues = DefaultValues.EastAsianWidth.forVersion(versionInfo);
         }
 
         final String missing = ps.skipUnassigned != null ? ps.skipUnassigned : ps.skipValue;
@@ -1205,6 +1210,9 @@ public class MakeUnicodeFiles {
             if (prop.getName().equals("Bidi_Class")) {
                 Bidi_Class_Values overallDefault = Bidi_Class_Values.forName(missing);
                 writeEnumeratedMissingValues(pw, overallDefault, defaultBidiValues);
+            } else if (prop.getName().equals("East_Asian_Width")) {
+                East_Asian_Width_Values overallDefault = East_Asian_Width_Values.forName(missing);
+                writeEnumeratedMissingValues(pw, overallDefault, defaultEaValues);
             }
         }
         for (final Iterator<String> it = aliases.iterator(); it.hasNext(); ) {
@@ -1254,6 +1262,15 @@ public class MakeUnicodeFiles {
                     // We assume that unassigned code points that have this value
                     // according to the props data also have this value according to the defaults.
                     // Otherwise we would need to intersect defaultBidiValues.keySet(bidiValue)
+                    // with the unassigned set before removing from s.
+                    s.removeAll(unassigned);
+                }
+            } else if (defaultEaValues != null) {
+                East_Asian_Width_Values eaValue = East_Asian_Width_Values.forName(value);
+                if (defaultEaValues.containsValue(eaValue)) {
+                    // We assume that unassigned code points that have this value
+                    // according to the props data also have this value according to the defaults.
+                    // Otherwise we would need to intersect defaultEaValues.keySet(eaValue)
                     // with the unassigned set before removing from s.
                     s.removeAll(unassigned);
                 }


### PR DESCRIPTION
For UTC action item [168-A7](https://www.unicode.org/cgi-bin/GetL2Ref.pl?168-A7): Propose a change in one or more UCD files to use multiple `@missing` lines; for Unicode version 15.0. See document L2/21-126 item D2.

PR #267 did this for Bidi_Class.
This PR now does the same thing for East_Asian_Width & Line_Break.

Writing multiple `@missing` lines for Extended_Pictographic is incomplete, mostly because the UCD syntax does not yet support it. I added most of the necessary code and left comments about the status.

See also
- https://www.unicode.org/reports/tr44/#Complex_Default_Values
- https://www.unicode.org/reports/tr44/#Missing_Conventions