### PR TITLE
PVA: remove redundant at-missing lines

### DIFF
--- a/unicodetools/data/ucd/dev/PropertyValueAliases.txt
+++ b/unicodetools/data/ucd/dev/PropertyValueAliases.txt
@@ -1,5 +1,5 @@
 # PropertyValueAliases-15.0.0.txt
-# Date: 2022-02-02, 23:35:44 GMT
+# Date: 2022-08-05, 23:42:17 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -136,7 +136,6 @@ Bidi_M; Y                             ; Yes                              ; T    
 
 # Bidi_Mirroring_Glyph (bmg)
 
-# @missing: 0000..10FFFF; Bidi_Mirroring_Glyph; <none>
 
 # Bidi_Paired_Bracket (bpb)
 
@@ -671,7 +670,6 @@ EPres; Y                              ; Yes                              ; T    
 
 # Equivalent_Unified_Ideograph (EqUIdeo)
 
-# @missing: 0000..10FFFF; Equivalent_Unified_Ideograph; <none>
 
 # Expands_On_NFC (XO_NFC)
 
@@ -1151,7 +1149,6 @@ NFD_QC; Y                             ; Yes
 
 # NFKC_Casefold (NFKC_CF)
 
-# @missing: 0000..10FFFF; NFKC_Casefold; <code point>
 
 # NFKC_Quick_Check (NFKC_QC)
 
@@ -1428,7 +1425,6 @@ sc ; Zzzz                             ; Unknown
 
 # Script_Extensions (scx)
 
-# @missing: 0000..10FFFF; Script_Extensions; <script>
 
 # Sentence_Break (SB)
 

--- a/unicodetools/src/main/java/org/unicode/props/PropertyParsingInfo.java
+++ b/unicodetools/src/main/java/org/unicode/props/PropertyParsingInfo.java
@@ -872,6 +872,21 @@ public class PropertyParsingInfo implements Comparable<PropertyParsingInfo> {
                 }
             }
             if (line.contents == UcdLine.Contents.DATA) {
+                if (propInfo.getDefaultValue() == null) {
+                    // Old versions of data files did not yet have @missing lines.
+                    // Supply the default value before applying the first real data line.
+                    String defaultValue = null;
+                    switch (propInfo.property) {
+                        case NFKC_Casefold:
+                            defaultValue = "<code point>";
+                            break;
+                        default:
+                            break;
+                    }
+                    if (defaultValue != null) {
+                        setPropDefault(propInfo.property, defaultValue, "hardcoded", false);
+                    }
+                }
                 final UnicodeMap<String> data;
                 try {
                     data = indexUnicodeProperties.property2UnicodeMap.get(propInfo.property);
@@ -1087,6 +1102,27 @@ public class PropertyParsingInfo implements Comparable<PropertyParsingInfo> {
             UcdLineParser parser, PropertyParsingInfo propInfo, UnicodeMap<String> data) {
         for (UcdLine line : parser) {
             if (line.contents == UcdLine.Contents.DATA) {
+                if (propInfo.getDefaultValue() == null) {
+                    // Old versions of data files did not yet have @missing lines.
+                    // Supply the default value before applying the first real data line.
+                    String defaultValue = null;
+                    switch (propInfo.property) {
+                        case Bidi_Mirroring_Glyph:
+                            defaultValue = "<none>";
+                            break;
+                        case Equivalent_Unified_Ideograph:
+                            defaultValue = "<none>";
+                            break;
+                        case Script_Extensions:
+                            defaultValue = "<script>";
+                            break;
+                        default:
+                            break;
+                    }
+                    if (defaultValue != null) {
+                        setPropDefault(propInfo.property, defaultValue, "hardcoded", false);
+                    }
+                }
                 propInfo.put(data, line.missingSet, line.intRange, line.parts[1], null, false);
             } else {
                 setPropDefault(
@@ -1179,6 +1215,7 @@ public class PropertyParsingInfo implements Comparable<PropertyParsingInfo> {
      * @internal
      * @deprecated
      */
+    @Deprecated
     public static Relation<String, PropertyParsingInfo> getFile2PropertyInfoSet() {
         return file2PropertyInfoSet;
     }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
@@ -815,6 +815,7 @@ public class MakeUnicodeFiles {
         CASELESS_COMPARATOR.freeze();
     }
 
+    // PropertyValueAliases.txt
     public static void generateValueAliasFile(String filename) throws IOException {
         String outputDir = "UCD/" + Default.ucdVersion() + '/';
         final UnicodeDataFile udf =
@@ -948,7 +949,13 @@ public class MakeUnicodeFiles {
                     pw.println("ccc; 133; CCC133                     ; CCC133 # RESERVED");
                 }
             }
-            if (sortedSet.size() == 0 || isGC || isJamoShortName) {
+            if (propName.equals("Bidi_Mirroring_Glyph")
+                    || propName.equals("Equivalent_Unified_Ideograph")
+                    || propName.equals("NFKC_Casefold")
+                    || propName.equals("Script_Extensions")) {
+                // Action item [172-A71]: Don't print @missing lines
+                // for properties whose specific data files already contain such lines.
+            } else if (sortedSet.size() == 0 || isGC || isJamoShortName) {
                 printDefaultValueComment(pw, propName, up, true, null);
             } else if (propName.equals("Bidi_Paired_Bracket_Type")) {
                 printDefaultValueComment(pw, propName, up, true, "n");


### PR DESCRIPTION
[172-A71] Action Item for Markus Scherer, PAG: In PropertyValueAliases.txt remove the `@missing` lines for Equivalent_Unified_Ideograph, Bidi_Mirroring_Glyph and NFKC_Casefold and Script_Extensions; for Unicode Version 15.0.

Modified Java generator code and generated output.

The IndexUnicodeProperties / PropertyParsingInfo code seems to use the latest Unicode version's PVA.txt `@missing` values when parsing old data files, such as Unicode 6.0 ScriptExtensions.txt which did not have an `@missing` line. I modified the parser to set the default values for the properties above when there is no `@missing` line in the specific data file. (FYI @macchiati)