### PR TITLE
Add command-line tool for file watching to run formatter on file save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ ipch
 pkgdata.inc
 pkgdataMakefile
 rules.mk
+target/watcher.txt
 
 # Directory specific wildcards
 # (none yet, see ICU .gitignore for examples)

--- a/docs/build.md
+++ b/docs/build.md
@@ -97,10 +97,11 @@ When creating pull requests, you can check the formatting locally using the comm
 
 Some IDEs can integrate the formatter via plugins, which can minimize the need to manually run the formatter separately.  The following links for specific IDEs may work:
 
-* Eclipse: Follow the [instructions](https://source.android.com/devices/tech/test_infra/tradefed/development/eclipse#auto_format) in the "Auto format" section. You can alternatively use this link for [`android-formatting.xml`](https://raw.githubusercontent.com/aosp-mirror/platform_development/master/ide/eclipse/android-formatting.xml).
+* Eclipse: Follow the [instructions](https://source.android.com/devices/tech/test_infra/tradefed/development/eclipse#auto_format) in the "Auto format" section. You can alternatively use this link for [`android-formatting.xml`](https://raw.githubusercontent.com/aosp-mirror/platform_development/master/ide/eclipse/android-formatting.xml) from the [AOSP mirror on Github](https://github.com/aosp-mirror/platform_development/tree/master/ide/eclipse).
 * VSCode: Follow the [instructions](https://code.visualstudio.com/docs/java/java-linting#_formatter) in "Applying formatter settings", but use the same `android-formatting.xml` link mentioned for Eclipse (ex: `"java.format.settings.url": "https://raw.githubusercontent.com/aosp-mirror/platform_development/master/ide/eclipse/android-formatting.xml",`).  Also use the profile name corresponding to that XML file: (ex: `"java.format.settings.profile": "Android",`).
 * IntelliJ: Use the [official plugin](https://plugins.jetbrains.com/plugin/8527-google-java-format/) for the formatter.
 
+As an alternative to IDE formatter plugins, you can pre-apply the canonically correct formatting in a pseudo-interactive manner by opening a separate terminal session that runs the formatter every time a file is saved. This is achieved by running the command `mvn fizzed-watcher:run` in that terminal session. The command should be terminated manually (ex: Ctrl+C) after local editing is done.
 
 #### Eclipse-specific Additional Setup
 

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,30 @@
                         </java>
                     </configuration>
                 </plugin>
+                <!--
+                    Allows the possibility to auto-run a Maven command on every file save
+                    https://github.com/fizzed/maven-plugins#watcher-fizzed-watcher-maven-plugin
+
+                    To execute, open a separate terminal and run this command:
+                    mvn fizzed-watcher:run
+
+                    The process will continue until you manually terminate it.
+                 -->
+                <plugin>
+                    <groupId>com.fizzed</groupId>
+                    <artifactId>fizzed-watcher-maven-plugin</artifactId>
+                    <version>1.0.6</version>
+                    <configuration>
+                        <watches>
+                            <watch>
+                                <directory>.</directory>
+                            </watch>
+                        </watches>
+                        <goals>
+                            <goal>spotless:apply</goal>
+                        </goals>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
This PR demonstrates a way to make formatting source code pseudo-automatic, in cases when an IDE plugin for formatting is not ideal or available.

In particular, this PR adds a Maven plugin that watches for any file changes and then executes a given command if any file change occurs. In this case, the command `mvn spotless:apply` to apply source formatting is the provided command in the plugin configuration.