### PR TITLE
Unicode 15 security data final AIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,12 +26,12 @@
             For ICU versions, see https://github.com/orgs/unicode-org/packages?repo_name=icu
             Note that we can't use the general ICU maven packages, because utilities isn't exported (yet).
          -->
-        <icu.version>72.0.1-SNAPSHOT-cldr-2022-06-27</icu.version>
+        <icu.version>72.0.1-SNAPSHOT-cldr-2022-08-17</icu.version>
 
         <!--
              For CLDR versions, see https://github.com/orgs/unicode-org/packages?repo_name=cldr
           -->
-        <cldr.version>0.0.0-SNAPSHOT-11ae1ba2f8</cldr.version>
+        <cldr.version>0.0.0-SNAPSHOT-273d736f11</cldr.version>
 
 
         <!-- these two set the JDK version for source and target -->

--- a/unicodetools/data/security/dev/IdentifierStatus.txt
+++ b/unicodetools/data/security/dev/IdentifierStatus.txt
@@ -1,5 +1,5 @@
 ﻿# IdentifierStatus.txt
-# Date: 2022-05-18, 21:51:57 GMT
+# Date: 2022-08-22, 22:20:56 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -531,8 +531,6 @@ A788          ; Allowed    # 5.1        MODIFIER LETTER LOW CIRCUMFLEX ACCENT
 A78D          ; Allowed    # 6.0        LATIN CAPITAL LETTER TURNED H
 A792..A793    ; Allowed    # 6.1    [2] LATIN CAPITAL LETTER C WITH BAR..LATIN SMALL LETTER C WITH BAR
 A7AA          ; Allowed    # 6.1        LATIN CAPITAL LETTER H WITH HOOK
-A7AE          ; Allowed    # 9.0        LATIN CAPITAL LETTER SMALL CAPITAL I
-A7B8..A7B9    ; Allowed    # 11.0   [2] LATIN CAPITAL LETTER U WITH STROKE..LATIN SMALL LETTER U WITH STROKE
 A7C0..A7C1    ; Allowed    # 14.0   [2] LATIN CAPITAL LETTER OLD POLISH O..LATIN SMALL LETTER OLD POLISH O
 A7C2..A7C6    ; Allowed    # 12.0   [5] LATIN CAPITAL LETTER ANGLICANA W..LATIN CAPITAL LETTER Z WITH PALATAL HOOK
 A7C7..A7CA    ; Allowed    # 13.0   [4] LATIN CAPITAL LETTER D WITH SHORT STROKE OVERLAY..LATIN SMALL LETTER S WITH SHORT STROKE OVERLAY
@@ -586,4 +584,4 @@ FA27..FA29    ; Allowed    # 1.1    [3] CJK COMPATIBILITY IDEOGRAPH-FA27..CJK CO
 30000..3134A  ; Allowed    # 13.0 [4939] CJK UNIFIED IDEOGRAPH-30000..CJK UNIFIED IDEOGRAPH-3134A
 31350..323AF  ; Allowed    # 15.0 [4192] CJK UNIFIED IDEOGRAPH-31350..CJK UNIFIED IDEOGRAPH-323AF
 
-# Total code points: 112159
+# Total code points: 112156

--- a/unicodetools/data/security/dev/IdentifierStatus.txt
+++ b/unicodetools/data/security/dev/IdentifierStatus.txt
@@ -1,5 +1,5 @@
 ﻿# IdentifierStatus.txt
-# Date: 2022-08-22, 22:20:56 GMT
+# Date: 2022-08-22, 23:13:14 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -14,16 +14,17 @@
 # Field 0: code point
 # Field 1: Identifier_Status value (see Table 1 of http://www.unicode.org/reports/tr39)
 #
-# Any missing code points have the Identifier_Status value Restricted
-#
 # For the purpose of regular expressions, the property Identifier_Status is defined as
 # an enumerated property of code points.
 # The short name of Identifier_Status is the same as the long name.
 # The possible values are:
 #   Allowed, Restricted
 # The short name of each value is the same as its long name.
-# The default property value for all Unicode code points U+0000..U+10FFFF
-# not mentioned in this data file is Restricted.
+
+# All code points not explicitly listed for Identifier_Status
+# have the value Restricted.
+
+# @missing: 0000..10FFFF; Restricted
 
 
 #	Identifier_Status:	Allowed

--- a/unicodetools/data/security/dev/IdentifierType.txt
+++ b/unicodetools/data/security/dev/IdentifierType.txt
@@ -1,5 +1,5 @@
 ﻿# IdentifierType.txt
-# Date: 2022-05-18, 21:51:56 GMT
+# Date: 2022-08-22, 22:20:55 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -524,8 +524,6 @@ A788          ; Recommended                    # 5.1        MODIFIER LETTER LOW 
 A78D          ; Recommended                    # 6.0        LATIN CAPITAL LETTER TURNED H
 A792..A793    ; Recommended                    # 6.1    [2] LATIN CAPITAL LETTER C WITH BAR..LATIN SMALL LETTER C WITH BAR
 A7AA          ; Recommended                    # 6.1        LATIN CAPITAL LETTER H WITH HOOK
-A7AE          ; Recommended                    # 9.0        LATIN CAPITAL LETTER SMALL CAPITAL I
-A7B8..A7B9    ; Recommended                    # 11.0   [2] LATIN CAPITAL LETTER U WITH STROKE..LATIN SMALL LETTER U WITH STROKE
 A7C0..A7C1    ; Recommended                    # 14.0   [2] LATIN CAPITAL LETTER OLD POLISH O..LATIN SMALL LETTER OLD POLISH O
 A7C2..A7C6    ; Recommended                    # 12.0   [5] LATIN CAPITAL LETTER ANGLICANA W..LATIN CAPITAL LETTER Z WITH PALATAL HOOK
 A7C7..A7CA    ; Recommended                    # 13.0   [4] LATIN CAPITAL LETTER D WITH SHORT STROKE OVERLAY..LATIN SMALL LETTER S WITH SHORT STROKE OVERLAY
@@ -579,7 +577,7 @@ FA27..FA29    ; Recommended                    # 1.1    [3] CJK COMPATIBILITY ID
 30000..3134A  ; Recommended                    # 13.0 [4939] CJK UNIFIED IDEOGRAPH-30000..CJK UNIFIED IDEOGRAPH-3134A
 31350..323AF  ; Recommended                    # 15.0 [4192] CJK UNIFIED IDEOGRAPH-31350..CJK UNIFIED IDEOGRAPH-323AF
 
-# Total code points: 112142
+# Total code points: 112139
 
 #	Identifier_Type:	Inclusion
 
@@ -858,6 +856,7 @@ A67C..A67D    ; Uncommon_Use                   # 5.1    [2] COMBINING CYRILLIC K
 A78B..A78C    ; Uncommon_Use                   # 5.1    [2] LATIN CAPITAL LETTER SALTILLO..LATIN SMALL LETTER SALTILLO
 A78F          ; Uncommon_Use                   # 8.0        LATIN LETTER SINOLOGICAL DOT
 A7B2..A7B7    ; Uncommon_Use                   # 8.0    [6] LATIN CAPITAL LETTER J WITH CROSSED-TAIL..LATIN SMALL LETTER OMEGA
+A7B8..A7B9    ; Uncommon_Use                   # 11.0   [2] LATIN CAPITAL LETTER U WITH STROKE..LATIN SMALL LETTER U WITH STROKE
 AB60..AB63    ; Uncommon_Use                   # 8.0    [4] LATIN SMALL LETTER SAKHA YAT..LATIN SMALL LETTER UO
 10780         ; Uncommon_Use                   # 14.0       MODIFIER LETTER SMALL CAPITAL AA
 10EFD..10EFF  ; Uncommon_Use                   # 15.0   [3] ARABIC SMALL LOW WORD SAKTA..ARABIC SMALL LOW WORD MADDA
@@ -865,7 +864,7 @@ AB60..AB63    ; Uncommon_Use                   # 8.0    [4] LATIN SMALL LETTER S
 1AFF5..1AFFB  ; Uncommon_Use                   # 14.0   [7] KATAKANA LETTER MINNAN TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-5
 1AFFD..1AFFE  ; Uncommon_Use                   # 14.0   [2] KATAKANA LETTER MINNAN NASALIZED TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-8
 
-# Total code points: 311
+# Total code points: 313
 
 #	Identifier_Type:	Uncommon_Use Technical
 
@@ -1008,6 +1007,7 @@ A8FC          ; Uncommon_Use Obsolete Not_XID  # 8.0        DEVANAGARI SIGN SIDD
 3031..3035    ; Technical                      # 1.1    [5] VERTICAL KANA REPEAT MARK..VERTICAL KANA REPEAT MARK LOWER HALF
 303B..303C    ; Technical                      # 3.2    [2] VERTICAL IDEOGRAPHIC ITERATION MARK..MASU MARK
 A78E          ; Technical                      # 6.0        LATIN SMALL LETTER L WITH RETROFLEX HOOK AND BELT
+A7AE          ; Technical                      # 9.0        LATIN CAPITAL LETTER SMALL CAPITAL I
 A7AF          ; Technical                      # 11.0       LATIN LETTER SMALL CAPITAL Q
 A7BA..A7BF    ; Technical                      # 12.0   [6] LATIN CAPITAL LETTER GLOTTAL A..LATIN SMALL LETTER GLOTTAL U
 A7FA          ; Technical                      # 6.0        LATIN LETTER SMALL CAPITAL TURNED M
@@ -1024,7 +1024,7 @@ FE73          ; Technical                      # 3.2        ARABIC TAIL FRAGMENT
 1D185..1D18B  ; Technical                      # 3.1    [7] MUSICAL SYMBOL COMBINING DOIT..MUSICAL SYMBOL COMBINING TRIPLE TONGUE
 1D1AA..1D1AD  ; Technical                      # 3.1    [4] MUSICAL SYMBOL COMBINING DOWN BOW..MUSICAL SYMBOL COMBINING SNAP PIZZICATO
 
-# Total code points: 500
+# Total code points: 501
 
 #	Identifier_Type:	Technical Exclusion
 

--- a/unicodetools/data/security/dev/IdentifierType.txt
+++ b/unicodetools/data/security/dev/IdentifierType.txt
@@ -1,5 +1,5 @@
 ﻿# IdentifierType.txt
-# Date: 2022-08-22, 22:20:55 GMT
+# Date: 2022-08-22, 23:13:13 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -14,8 +14,6 @@
 # Field 0: code point
 # Field 1: set of Identifier_Type values (see Table 1 of http://www.unicode.org/reports/tr39)
 #
-# Any missing code points have the Identifier_Type value Not_Character
-#
 # For the purpose of regular expressions, the property Identifier_Type is defined as
 # mapping each code point to a set of enumerated values.
 # The short name of Identifier_Type is the same as the long name.
@@ -23,8 +21,12 @@
 #   Not_Character, Deprecated, Default_Ignorable, Not_NFKC, Not_XID,
 #   Exclusion, Obsolete, Technical, Uncommon_Use, Limited_Use, Inclusion, Recommended
 # The short name of each value is the same as its long name.
-# The default property value for all Unicode code points U+0000..U+10FFFF
-# not mentioned in this data file is Not_Character.
+
+# All code points not explicitly listed for Identifier_Type
+# have the value Not_Character.
+
+# @missing: 0000..10FFFF; Not_Character
+
 # As usual, sets are unordered, with no duplicate values.
 
 

--- a/unicodetools/data/security/dev/confusables.txt
+++ b/unicodetools/data/security/dev/confusables.txt
@@ -1,5 +1,5 @@
 ﻿# confusables.txt
-# Date: 2022-05-18, 21:51:56 GMT
+# Date: 2022-08-22, 22:20:55 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -7535,9 +7535,9 @@ FA7E ;	5944 ;	MA	# ( 奄 → 奄 ) CJK COMPATIBILITY IDEOGRAPH-FA7E → CJK UNIF
 
 F90C ;	5948 ;	MA	# ( 奈 → 奈 ) CJK COMPATIBILITY IDEOGRAPH-F90C → CJK UNIFIED IDEOGRAPH-5948	# 
 
-F909 ;	5951 ;	MA	# ( 契 → 契 ) CJK COMPATIBILITY IDEOGRAPH-F909 → CJK UNIFIED IDEOGRAPH-5951	# 
-
 FA7F ;	5954 ;	MA	# ( 奔 → 奔 ) CJK COMPATIBILITY IDEOGRAPH-FA7F → CJK UNIFIED IDEOGRAPH-5954	# 
+
+F909 ;	5951 ;	MA	# ( 契 → 契 ) CJK COMPATIBILITY IDEOGRAPH-F909 → CJK UNIFIED IDEOGRAPH-5951	# 
 
 2F85F ;	5962 ;	MA	# ( 奢 → 奢 ) CJK COMPATIBILITY IDEOGRAPH-2F85F → CJK UNIFIED IDEOGRAPH-5962	# 
 

--- a/unicodetools/data/security/dev/data/draft-restrictions.txt
+++ b/unicodetools/data/security/dev/data/draft-restrictions.txt
@@ -19388,6 +19388,7 @@ D7FB          ;  ; Obsolete #      (ퟻ)  HANGUL JONGSEONG PHIEUPH-THIEUTH
 303B          ;  ; Technical #      (〻)  VERTICAL IDEOGRAPHIC ITERATION MARK
 303C          ;  ; Technical #      (〼)  MASU MARK
 A78E          ;  ; Technical #      (ꞎ)  LATIN SMALL LETTER L WITH RETROFLEX HOOK AND BELT
+A7AE          ;  ; Technical #      (Ɪ)  LATIN CAPITAL LETTER SMALL CAPITAL I
 A7AF          ;  ; Technical #      (ꞯ)  LATIN LETTER SMALL CAPITAL Q
 A7BA          ;  ; Technical #      (Ꞻ)  LATIN CAPITAL LETTER GLOTTAL A
 A7BB          ;  ; Technical #      (ꞻ)  LATIN SMALL LETTER GLOTTAL A
@@ -19476,7 +19477,7 @@ FE73          ;  ; Technical #      (ﹳ)  ARABIC TAIL FRAGMENT
 1D185..1D18B  ;  ; Technical #  [7] (𝆅..𝆋)  MUSICAL SYMBOL COMBINING DOIT..MUSICAL SYMBOL COMBINING TRIPLE TONGUE
 1D1AA..1D1AD  ;  ; Technical #  [4] (𝆪..𝆭)  MUSICAL SYMBOL COMBINING DOWN BOW..MUSICAL SYMBOL COMBINING SNAP PIZZICATO
 
-# Total code points: 561
+# Total code points: 562
 
 0181..0182    ;  ; Uncommon_Use #  [2] (Ɓ..Ƃ)  LATIN CAPITAL LETTER B WITH HOOK..LATIN CAPITAL LETTER B WITH TOPBAR
 0183          ;  ; Uncommon_Use #      (ƃ)  LATIN SMALL LETTER B WITH TOPBAR
@@ -19748,6 +19749,8 @@ A7B2..A7B4    ;  ; Uncommon_Use #  [3] (Ʝ..Ꞵ)  LATIN CAPITAL LETTER J WITH C
 A7B5          ;  ; Uncommon_Use #      (ꞵ)  LATIN SMALL LETTER BETA
 A7B6          ;  ; Uncommon_Use #      (Ꞷ)  LATIN CAPITAL LETTER OMEGA
 A7B7          ;  ; Uncommon_Use #      (ꞷ)  LATIN SMALL LETTER OMEGA
+A7B8          ;  ; Uncommon_Use #      (Ꞹ)  LATIN CAPITAL LETTER U WITH STROKE
+A7B9          ;  ; Uncommon_Use #      (ꞹ)  LATIN SMALL LETTER U WITH STROKE
 AB60          ;  ; Uncommon_Use #      (ꭠ)  LATIN SMALL LETTER SAKHA YAT
 AB61          ;  ; Uncommon_Use #      (ꭡ)  LATIN SMALL LETTER IOTIFIED E
 AB62          ;  ; Uncommon_Use #      (ꭢ)  LATIN SMALL LETTER OPEN OE
@@ -19770,7 +19773,7 @@ AB63          ;  ; Uncommon_Use #      (ꭣ)  LATIN SMALL LETTER UO
 1AFFD         ;  ; Uncommon_Use #      (𚿽)  KATAKANA LETTER MINNAN NASALIZED TONE-7
 1AFFE         ;  ; Uncommon_Use #      (𚿾)  KATAKANA LETTER MINNAN NASALIZED TONE-8
 
-# Total code points: 311
+# Total code points: 313
 
 00B7          ; Allowed ; Inclusion #      (·)  MIDDLE DOT
 
@@ -22882,9 +22885,6 @@ A78D          ; Allowed ; Recommended #      (Ɥ)  LATIN CAPITAL LETTER TURNED 
 A792          ; Allowed ; Recommended #      (Ꞓ)  LATIN CAPITAL LETTER C WITH BAR
 A793          ; Allowed ; Recommended #      (ꞓ)  LATIN SMALL LETTER C WITH BAR
 A7AA          ; Allowed ; Recommended #      (Ɦ)  LATIN CAPITAL LETTER H WITH HOOK
-A7AE          ; Allowed ; Recommended #      (Ɪ)  LATIN CAPITAL LETTER SMALL CAPITAL I
-A7B8          ; Allowed ; Recommended #      (Ꞹ)  LATIN CAPITAL LETTER U WITH STROKE
-A7B9          ; Allowed ; Recommended #      (ꞹ)  LATIN SMALL LETTER U WITH STROKE
 A7C0          ; Allowed ; Recommended #      (Ꟁ)  LATIN CAPITAL LETTER OLD POLISH O
 A7C1          ; Allowed ; Recommended #      (ꟁ)  LATIN SMALL LETTER OLD POLISH O
 A7C2          ; Allowed ; Recommended #      (Ꟃ)  LATIN CAPITAL LETTER ANGLICANA W
@@ -49789,7 +49789,7 @@ FA29          ; Allowed ; Recommended #      (﨩)  CJK COMPATIBILITY IDEOGRAPH-
 323AF         ; Allowed ; Recommended #      (𲎯)  CJK UNIFIED IDEOGRAPH-323AF
 E0100..E01EF  ; Allowed ; Recommended # [240] (U+E0100..U+E01EF)  VARIATION SELECTOR-17..VARIATION SELECTOR-256
 
-# Total code points: 112377
+# Total code points: 112374
 
 005F          ; ~IDNA #      (_)  LOW LINE
 04C0          ; ~IDNA #      (Ӏ)  CYRILLIC LETTER PALOCHKA
@@ -50166,7 +50166,7 @@ FFF9..FFFD    ; ~Unicode Identifier #  [5] (U+FFF9..�)  INTERLINEAR ANNOTATION
 11FFF         ; ~Unicode Identifier #      (𑿿)  TAMIL PUNCTUATION END OF TEXT
 12470..12474  ; ~Unicode Identifier #  [5] (𒑰..𒑴)  CUNEIFORM PUNCTUATION SIGN OLD ASSYRIAN WORD DIVIDER..CUNEIFORM PUNCTUATION SIGN DIAGONAL QUADCOLON
 12FF1..12FF2  ; ~Unicode Identifier #  [2] (𒿱..𒿲)  CYPRO-MINOAN SIGN CM301..CYPRO-MINOAN SIGN CM302
-13430..1343F  ; ~Unicode Identifier # [16] (U+13430..𓐿)  EGYPTIAN HIEROGLYPH VERTICAL JOINER..EGYPTIAN HIEROGLYPH END WALLED ENCLOSURE
+13430..1343F  ; ~Unicode Identifier # [16] (U+13430..U+1343F)  EGYPTIAN HIEROGLYPH VERTICAL JOINER..EGYPTIAN HIEROGLYPH END WALLED ENCLOSURE
 16A6E..16A6F  ; ~Unicode Identifier #  [2] (𖩮..𖩯)  MRO DANDA..MRO DOUBLE DANDA
 16AF5         ; ~Unicode Identifier #      (𖫵)  BASSA VAH FULL STOP
 16B37..16B3F  ; ~Unicode Identifier #  [9] (𖬷..𖬿)  PAHAWH HMONG SIGN VOS THOM..PAHAWH HMONG SIGN XYEEM FAIB

--- a/unicodetools/data/security/dev/data/idnchars.txt
+++ b/unicodetools/data/security/dev/data/idnchars.txt
@@ -1,5 +1,5 @@
 ﻿# idnchars.txt
-# Date: 2022-05-18, 21:51:57 GMT
+# Date: 2022-08-22, 22:20:57 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -611,7 +611,6 @@ A67F          ; output #      (ꙿ)  CYRILLIC PAYEROK
 A717..A71F    ; output #  [9] (ꜗ..ꜟ)  MODIFIER LETTER DOT VERTICAL BAR..MODIFIER LETTER LOW INVERTED EXCLAMATION MARK
 A788          ; output #      (ꞈ)  MODIFIER LETTER LOW CIRCUMFLEX ACCENT
 A793          ; output #      (ꞓ)  LATIN SMALL LETTER C WITH BAR
-A7B9          ; output #      (ꞹ)  LATIN SMALL LETTER U WITH STROKE
 A7C1          ; output #      (ꟁ)  LATIN SMALL LETTER OLD POLISH O
 A7C3          ; output #      (ꟃ)  LATIN SMALL LETTER ANGLICANA W
 A7C8          ; output #      (ꟈ)  LATIN SMALL LETTER D WITH SHORT STROKE OVERLAY
@@ -662,7 +661,7 @@ FA27..FA29    ; output #  [3] (﨧..﨩)  CJK COMPATIBILITY IDEOGRAPH-FA27..CJK 
 30000..3134A  ; output # [4939] (𰀀..𱍊)  CJK UNIFIED IDEOGRAPH-30000..CJK UNIFIED IDEOGRAPH-3134A
 31350..323AF  ; output # [4192] (𱍐..𲎯)  CJK UNIFIED IDEOGRAPH-31350..CJK UNIFIED IDEOGRAPH-323AF
 
-# Total code points: 111484
+# Total code points: 111483
 
 # Not allowed at start of identifier
 
@@ -733,6 +732,7 @@ FA27..FA29    ; output #  [3] (﨧..﨩)  CJK COMPATIBILITY IDEOGRAPH-FA27..CJK 
 0CCA..0CCD    ; nonstarting #  [4] (ೊ..್)  KANNADA VOWEL SIGN O..KANNADA SIGN VIRAMA
 0CD5..0CD6    ; nonstarting #  [2] (ೕ..ೖ)  KANNADA LENGTH MARK..KANNADA AI LENGTH MARK
 0CE2..0CE3    ; nonstarting #  [2] (ೢ..ೣ)  KANNADA VOWEL SIGN VOCALIC L..KANNADA VOWEL SIGN VOCALIC LL
+0CF3          ; nonstarting #      (ೳ)  KANNADA SIGN COMBINING ANUSVARA ABOVE RIGHT
 0D00          ; nonstarting #      (ഀ)  MALAYALAM SIGN COMBINING ANUSVARA ABOVE
 0D02..0D03    ; nonstarting #  [2] (ം..ഃ)  MALAYALAM SIGN ANUSVARA..MALAYALAM SIGN VISARGA
 0D3E..0D43    ; nonstarting #  [6] (ാ..ൃ)  MALAYALAM VOWEL SIGN AA..MALAYALAM VOWEL SIGN VOCALIC R
@@ -750,7 +750,7 @@ FA27..FA29    ; output #  [3] (﨧..﨩)  CJK COMPATIBILITY IDEOGRAPH-FA27..CJK 
 0E47..0E4E    ; nonstarting #  [8] (็..๎)  THAI CHARACTER MAITAIKHU..THAI CHARACTER YAMAKKAN
 0EB1          ; nonstarting #      (ັ)  LAO VOWEL SIGN MAI KAN
 0EB4..0EBC    ; nonstarting #  [9] (ິ..ຼ)  LAO VOWEL SIGN I..LAO SEMIVOWEL SIGN LO
-0EC8..0ECD    ; nonstarting #  [6] (່..ໍ)  LAO TONE MAI EK..LAO NIGGAHITA
+0EC8..0ECE    ; nonstarting #  [7] (່..໎)  LAO TONE MAI EK..LAO YAMAKKAN
 0F35          ; nonstarting #      (༵)  TIBETAN MARK NGAS BZUNG NYI ZLA
 0F37          ; nonstarting #      (༷)  TIBETAN MARK NGAS BZUNG SGOR RTAGS
 0F3E..0F3F    ; nonstarting #  [2] (༾..༿)  TIBETAN SIGN YAR TSHES..TIBETAN SIGN MAR TSHES
@@ -782,5 +782,6 @@ AA7B..AA7D    ; nonstarting #  [3] (ꩻ..ꩽ)  MYANMAR SIGN PAO KAREN TONE..MYAN
 11303         ; nonstarting #      (𑌃)  GRANTHA SIGN VISARGA
 1133B..1133C  ; nonstarting #  [2] (𑌻..𑌼)  COMBINING BINDU BELOW..GRANTHA SIGN NUKTA
 16FF0..16FF1  ; nonstarting #  [2] (𖿰..𖿱)  VIETNAMESE ALTERNATE READING MARK CA..VIETNAMESE ALTERNATE READING MARK NHAY
+1E08F         ; nonstarting #      (𞂏)  COMBINING CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
 
-# Total code points: 450
+# Total code points: 453

--- a/unicodetools/data/security/dev/data/source/removals.txt
+++ b/unicodetools/data/security/dev/data/source/removals.txt
@@ -211,6 +211,17 @@
 024E ; uncommon-use # ( Ɏ ) LATIN CAPITAL LETTER Y WITH STROKE
 024F ; uncommon-use # ( ɏ ) LATIN SMALL LETTER Y WITH STROKE
 
+# A few lines above, U+023A LATIN CAPITAL LETTER A WITH STROKE
+# and U+0246, U+0247 are set to uncommon-use,
+# and elsewhere U+2C65 is set to technical.
+# These are used in Mazahua.
+# For consistency, change the following which are also used in Mazahua:
+# [172-A62] ... Change the Identifier_Type of
+# U+A7B8 [LATIN CAPITAL LETTER U WITH STROKE] and
+# U+A7B9 [LATIN SMALL LETTER U WITH STROKE] to Uncommon_Use
+# (and thus their Identifier_Status to Restricted), for Unicode Version 15.0.
+A7B8..A7B9 ; uncommon-use
+
 # IPA Extensions - IPA extensions: 20
 0253 ; technical # ( ɓ ) LATIN SMALL LETTER B WITH HOOK
 0254 ; technical # ( ɔ ) LATIN SMALL LETTER OPEN O
@@ -336,6 +347,11 @@ A78B..A78C ; uncommon-use # ( Ꞌ ) LATIN CAPITAL LETTER SALTILLO .. ( ꞌ ) LAT
 02A3..02AB; technical #  symbol (Latin digraph)
 02AC          ; technical # symbol (phonetic) #      (ʬ)  LATIN LETTER BILABIAL PERCUSSIVE
 02AD          ; technical # symbol (phonetic) #      (ʭ)  LATIN LETTER BIDENTAL PERCUSSIVE
+
+# A few lines above, U+026A LATIN LETTER SMALL CAPITAL I is set to technical.
+# [172-A61] ... Change the Identifier_Type of U+A7AE [LATIN CAPITAL LETTER SMALL CAPITAL I] to Technical
+# (and thus its Identifier_Status to Restricted), for Unicode Version 15.0. See L2/22-124 item UCD7.
+A7AE; technical
 
 03F3; technical # presentation form
 0483..0486; historic

--- a/unicodetools/src/main/java/org/unicode/text/UCD/IdentifierInfo.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/IdentifierInfo.java
@@ -1072,7 +1072,9 @@ public class IdentifierInfo {
                             + "#   Not_Character, Deprecated, Default_Ignorable, Not_NFKC, Not_XID,\n"
                             + "#   Exclusion, Obsolete, Technical, Uncommon_Use, Limited_Use, Inclusion, Recommended\n"
                             + "# The short name of each value is the same as its long name.\n\n"
-                            + "# All code points not explicitly listed for " + propName + "\n"
+                            + "# All code points not explicitly listed for "
+                            + propName
+                            + "\n"
                             + "# have the value Not_Character.\n\n"
                             + "# @missing: 0000..10FFFF; Not_Character\n\n"
                             + "# As usual, sets are unordered, with no duplicate values.\n");
@@ -1140,7 +1142,9 @@ public class IdentifierInfo {
                             + "# The possible values are:\n"
                             + "#   Allowed, Restricted\n"
                             + "# The short name of each value is the same as its long name.\n\n"
-                            + "# All code points not explicitly listed for " + propName + "\n"
+                            + "# All code points not explicitly listed for "
+                            + propName
+                            + "\n"
                             + "# have the value Restricted.\n\n"
                             + "# @missing: 0000..10FFFF; Restricted\n");
 

--- a/unicodetools/src/main/java/org/unicode/text/UCD/IdentifierInfo.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/IdentifierInfo.java
@@ -918,7 +918,7 @@ public class IdentifierInfo {
                         if (b == null) {
                             return null;
                         }
-                        String x = (String) b;
+                        String x = b;
                         //                if (ALT) {
                         //                    if
                         // (!GenerateConfusables.IDNOutputSet.contains(codePoint)) {
@@ -988,7 +988,7 @@ public class IdentifierInfo {
         if (MAIN_CODE) {
             final Set<String> values = new TreeSet<>(someRemovals.getAvailableValues());
             for (final Iterator<String> it = values.iterator(); it.hasNext(); ) {
-                final String reason1 = (String) it.next();
+                final String reason1 = it.next();
                 bf.setValueSource(reason1);
                 final UnicodeSet keySet = someRemovals.keySet(reason1);
                 if (reason1.contains("recommended")) {
@@ -1057,11 +1057,7 @@ public class IdentifierInfo {
                     "# Format"
                             + "\n#"
                             + "\n# Field 0: code point"
-                            + "\n# Field 1: set of Identifier_Type values (see Table 1 of http://www.unicode.org/reports/tr39)"
-                            + "\n#"
-                            + "\n# Any missing code points have the "
-                            + propName
-                            + " value Not_Character");
+                            + "\n# Field 1: set of Identifier_Type values (see Table 1 of http://www.unicode.org/reports/tr39)");
 
             out2.println(
                     "#\n"
@@ -1075,9 +1071,10 @@ public class IdentifierInfo {
                             + "# The possible values are:\n"
                             + "#   Not_Character, Deprecated, Default_Ignorable, Not_NFKC, Not_XID,\n"
                             + "#   Exclusion, Obsolete, Technical, Uncommon_Use, Limited_Use, Inclusion, Recommended\n"
-                            + "# The short name of each value is the same as its long name.\n"
-                            + "# The default property value for all Unicode code points U+0000..U+10FFFF\n"
-                            + "# not mentioned in this data file is Not_Character.\n"
+                            + "# The short name of each value is the same as its long name.\n\n"
+                            + "# All code points not explicitly listed for " + propName + "\n"
+                            + "# have the value Not_Character.\n\n"
+                            + "# @missing: 0000..10FFFF; Not_Character\n\n"
                             + "# As usual, sets are unordered, with no duplicate values.\n");
 
             bf2.setValueSource(
@@ -1129,11 +1126,7 @@ public class IdentifierInfo {
                     "# Format"
                             + "\n#"
                             + "\n# Field 0: code point"
-                            + "\n# Field 1: Identifier_Status value (see Table 1 of http://www.unicode.org/reports/tr39)"
-                            + "\n#"
-                            + "\n# Any missing code points have the "
-                            + propName
-                            + " value Restricted");
+                            + "\n# Field 1: Identifier_Status value (see Table 1 of http://www.unicode.org/reports/tr39)");
 
             out2.println(
                     "#\n"
@@ -1146,9 +1139,10 @@ public class IdentifierInfo {
                             + " is the same as the long name.\n"
                             + "# The possible values are:\n"
                             + "#   Allowed, Restricted\n"
-                            + "# The short name of each value is the same as its long name.\n"
-                            + "# The default property value for all Unicode code points U+0000..U+10FFFF\n"
-                            + "# not mentioned in this data file is Restricted.\n");
+                            + "# The short name of each value is the same as its long name.\n\n"
+                            + "# All code points not explicitly listed for " + propName + "\n"
+                            + "# have the value Restricted.\n\n"
+                            + "# @missing: 0000..10FFFF; Restricted\n");
 
             bf2.setValueSource(
                     (new UnicodeProperty.UnicodeMapProperty() {})

--- a/unicodetools/src/test/java/org/unicode/propstest/TestInvariants.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/TestInvariants.java
@@ -322,6 +322,16 @@ public class TestInvariants extends TestFmwkMinusMinus {
                     // from Identifier_Type=Inclusion and Identifier_Status=Allowed.
                     level = LOG;
                 }
+                if (ucdProperty == UcdProperty.Identifier_Type
+                        && value.equals("Recommended")
+                        && Settings.latestVersion.equals("15.0.0")
+                        && missing.size() == 3
+                        && missing.containsAll("\uA7AE\uA7B8\uA7B9")) {
+                    // Intentional removal of characters from Identifier_Type=Recommended:
+                    // [172-A61] Change the Identifier_Type of U+A7AE to Technical
+                    // [172-A62] Change the Identifier_Type of U+A7B8 and U+A7B9 to Uncommon_Use
+                    level = LOG;
+                }
                 msg(
                         "Unicode "
                                 + Settings.latestVersion


### PR DESCRIPTION
Change .../security/dev/data/source/removals.txt to do
- [172-A61] Action Item for Mark Davis, PAG: Change the Identifier_Type of U+A7AE to Technical (and thus its Identifier_Status to Restricted), for Unicode Version 15.0. See L2/22-124 item UCD7.
- [172-A62] Action Item for Mark Davis, PAG: Change the Identifier_Type of U+A7B8 and U+A7B9 to Uncommon_Use (and thus their Identifier_Status to Restricted), for Unicode Version 15.0. See L2/22-124 item UCD8.

Then generate the other security data files and adjust the TestInvariants unit test.

In addition, do the generator code + data file parts of
- [169-A1] In IdentifierStatus.txt and IdentifierType.txt, replace comments with appropriate `@missing` lines. See L2/21-170 item F1. Reference UAX `#44` in the format for data files and spec for UTS `#39`. Targeted at Unicode 15.0. ...

Omit (git restore) the files where only the time stamp changed.

There were CI test failures. Apparently some code fetches a CLDR-main-HEAD copy of [the CLDR ldml.dtd file which since last Friday has new `@TECHPREVIEW` lines](https://github.com/unicode-org/cldr/pull/2301). We have been using an older snapshot of the CLDR code which seems to not understand that annotation. I updated the CLDR version to a [snapshot from today](https://github.com/unicode-org/cldr/packages/521050), and the ICU version to a [snapshot from aug17](https://github.com/unicode-org/icu/packages/411079).