### PR TITLE
Add test for non-alphabetic InSC=Bindu

### DIFF
--- a/.github/workflows/cli-build-instructions.yml
+++ b/.github/workflows/cli-build-instructions.yml
@@ -76,14 +76,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
-      - name: Upload UnicodeTestResults
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: unicode-test-results
-          path: |
-            Generated/UnicodeTestResults.*
-
   out-of-source-build:
     name: Out-of-source Instructions
     runs-on: ubuntu-latest
@@ -125,6 +117,14 @@ jobs:
           MAVEN_OPTS="-ea" mvn -s .github/workflows/mvn-settings.xml package -DCLDR_DIR=$(cd ../../../cldr/mine/src ; pwd)  -DUNICODETOOLS_GEN_DIR=$(cd ../Generated ; pwd)  -DUNICODETOOLS_REPO_DIR=$(pwd)  -DUVERSION=$CURRENT_UVERSION
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload UnicodeTestResults artifact
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: unicode-test-results
+          path: |
+            unicodetools/mine/Generated/UnicodeTestResults.*
 
       - name: Run command - Make Unicode Files
         run: |

--- a/.github/workflows/cli-build-instructions.yml
+++ b/.github/workflows/cli-build-instructions.yml
@@ -75,7 +75,7 @@ jobs:
         run: MAVEN_OPTS="-ea" mvn -s .github/workflows/mvn-settings.xml exec:java -Dexec.mainClass="org.unicode.text.UCD.Main"  -Dexec.args="version $CURRENT_UVERSION build MakeUnicodeFiles"  -pl unicodetools  -DCLDR_DIR=$(cd ../cldr ; pwd)  -DUNICODETOOLS_GEN_DIR=$(cd Generated; pwd)  -DUNICODETOOLS_REPO_DIR=$(pwd)  -DUVERSION=$CURRENT_UVERSION
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
   out-of-source-build:
     name: Out-of-source Instructions
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-build-instructions.yml
+++ b/.github/workflows/cli-build-instructions.yml
@@ -75,6 +75,14 @@ jobs:
         run: MAVEN_OPTS="-ea" mvn -s .github/workflows/mvn-settings.xml exec:java -Dexec.mainClass="org.unicode.text.UCD.Main"  -Dexec.args="version $CURRENT_UVERSION build MakeUnicodeFiles"  -pl unicodetools  -DCLDR_DIR=$(cd ../cldr ; pwd)  -DUNICODETOOLS_GEN_DIR=$(cd Generated; pwd)  -DUNICODETOOLS_REPO_DIR=$(pwd)  -DUVERSION=$CURRENT_UVERSION
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Upload UnicodeTestResults
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: unicode-test-results
+          path: |
+            Generated/UnicodeTestResults.*
 
   out-of-source-build:
     name: Out-of-source Instructions
@@ -236,4 +244,3 @@ jobs:
           mvn -s .github/workflows/mvn-settings.xml -Dexec.mainClass="org.unicode.propstest.CheckProperties" -Dexec.classpathScope=test test-compile  -Dexec.args="COMPARE ALL $PREVIOUS_UVERSION" exec:java  -pl unicodetools  -DCLDR_DIR=$(cd ../../../cldr/mine/src ; pwd)  -DUNICODETOOLS_GEN_DIR=$(cd ../Generated ; pwd)  -DUNICODETOOLS_REPO_DIR=$(pwd)  -DUVERSION=$CURRENT_UVERSION
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/docs/build.md
+++ b/docs/build.md
@@ -635,6 +635,7 @@ Unicode 15 TODO: See above; commit new input data, run tools, review output, cop
     1.  Run>Run
     2.  Select the Arguments tab, and add the following
         1.  VM arguments: `-DSHOW_FILES`
+2.  The CI job will retrieve the "UnicodeTestData.html" file that is generated when running this test and attach it to the CI job as an artifact that can be downloaded and examined as an aid in understanding test failures when run in CI.
 
 ## UCA
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -635,7 +635,7 @@ Unicode 15 TODO: See above; commit new input data, run tools, review output, cop
     1.  Run>Run
     2.  Select the Arguments tab, and add the following
         1.  VM arguments: `-DSHOW_FILES`
-2.  The CI job will retrieve the "UnicodeTestData.html" file that is generated when running this test and attach it to the CI job as an artifact that can be downloaded and examined as an aid in understanding test failures when run in CI.
+2.  The CI job will retrieve the "UnicodeTestData.html" file that is generated when running this test and attach it to the CI job as an artifact that can be downloaded from the CI run by navigating to the [unicodetools Actions tab](https://github.com/unicode-org/unicodetools/actions/runs/), selecting the relevant run for "build.md", then clicking `unicode-test-results` in the "Artifacts" section.
 
 ## UCA
 

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
@@ -431,6 +431,10 @@ Show [\u20b9]
 # [\p{Alphabetic}] ∥ \p{Script=Common}
 #  & [\p{Decomposition_Type=None} \p{Decomposition_Type=Canonical}]
 
+# Nonalphabetic bindus
+Let $nonAlphaBindus = [\u0C04\u0F82\u0F83\U00011080\U00011081]
+[\p{InSc=Bindu} - $nonAlphaBindus - \p{Alphabetic}] = [] 
+
 ##########################
 # LineBreak property
 ##########################

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
@@ -431,7 +431,12 @@ Show [\u20b9]
 # [\p{Alphabetic}] ∥ \p{Script=Common}
 #  & [\p{Decomposition_Type=None} \p{Decomposition_Type=Canonical}]
 
-# Nonalphabetic bindus
+# The UTC 172 script ad hoc report (L2/22-128) item VII 27 “Nonalphabetic bindus” points out that
+# “Most characters with InSC=Bindu have Alphabetic=Yes.” but there could be exceptions.
+# TODO: Review with SAH:
+# - is the rule roughly right?
+# - if so, are these intentional exceptions?
+# - otherwise, are these wrong? should these 5 be alphabetic?
 Let $nonAlphaBindus = [\u0C04\u0F82\u0F83\U00011080\U00011081]
 [\p{InSc=Bindu} - $nonAlphaBindus - \p{Alphabetic}] = [] 
 


### PR DESCRIPTION
- Updated UnicodeInvariantTest.txt (Misc. section) with check for non-Alphabetic InSc=Bindus. See #289.
- Added step to cli-build-instructions.yml workflow to upload generated `UnicodeTestResults.html` file as a build artifact (out-of-source build). This step is set to run `always()` so it will attempt to upload the artifact even if previous steps fail.
