### PR TITLE
fix the U+0130 full lowercase mapping

### DIFF
--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateCaseFolding.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateCaseFolding.java
@@ -108,21 +108,19 @@ public class GenerateCaseFolding implements UCD_Types {
                 continue;
             }
 
-            if (rFull != null && rFull.equals(rSimple)
+            // Hardcode variants of letter i.
+            if (ch == 0x49) {
+                drawLine(out, ch, "C", "i");
+                drawLine(out, ch, "T", "\u0131");
+            } else if (ch == 0x130) {
+                drawLine(out, ch, "F", "i\u0307");
+                drawLine(out, ch, "T", "i");
+            } else if (ch == 0x131) {
+                // do nothing
+                // drawLine(out, ch, "I", "i");
+            } else if (rFull != null && rFull.equals(rSimple)
                     || (PICK_SHORT && UTF16.countCodePoint(rFull) == 1)) {
-                final String type = "C";
-                if (ch == 0x49) {
-                    drawLine(out, ch, "C", "i");
-                    drawLine(out, ch, "T", "\u0131");
-                } else if (ch == 0x130) {
-                    drawLine(out, ch, "F", "i\u0307");
-                    drawLine(out, ch, "T", "i");
-                } else if (ch == 0x131) {
-                    // do nothing
-                    // drawLine(out, ch, "I", "i");
-                } else {
-                    drawLine(out, ch, type, rFull);
-                }
+                drawLine(out, ch, "C", rFull);
             } else {
                 if (rFull != null) {
                     drawLine(out, ch, "F", rFull);
@@ -188,8 +186,8 @@ public class GenerateCaseFolding implements UCD_Types {
     static int probeCh = 0x01f0;
     static String shower = UTF16.valueOf(probeCh);
 
-    static Map<String, String> getCaseFolding(boolean full, boolean nfClose, String condition)
-            throws java.io.IOException {
+    private static Map<String, String> getCaseFolding(
+            boolean full, boolean nfClose, String condition) throws java.io.IOException {
         final Map<String, Set<String>> data = new TreeMap<String, Set<String>>();
         final Map<String, String> repChar = new TreeMap<String, String>();
 
@@ -729,7 +727,7 @@ public class GenerateCaseFolding implements UCD_Types {
                 if (ch == 0x01F0) {
                     x = 0x03B1; // HACK to reorder the same
                 }
-                sorted.put(new Integer((order << 24) | x), mapping);
+                sorted.put((order << 24) | x, mapping);
             }
         }
         log.close();

--- a/unicodetools/src/main/java/org/unicode/text/UCD/UCD.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/UCD.java
@@ -607,7 +607,17 @@ public final class UCD implements UCD_Types {
         }
         if (caseType < FOLD) {
             if (simpleVsFull == FULL && udata.specialCasing.length() != 0) {
-                if (condition.length() == 0 || udata.specialCasing.indexOf(condition) < 0) {
+                // When we are looking for a full case mapping
+                // for a character that has conditional mappings,
+                // and looking for the default mapping (empty condition string),
+                // or when the condition does not match one in SpecialCasing.txt for this character,
+                // then return the simple case mapping.
+                // This mostly works, but not always.
+                if (codePoint == 0x130 && caseType == LOWER) {
+                    // LATIN CAPITAL LETTER I WITH DOT ABOVE has a simple lowercase mapping to 'i'
+                    // but a full lowercase mapping to "i\u0307".
+                    // Return fullLowercase.
+                } else if (condition.length() == 0 || udata.specialCasing.indexOf(condition) < 0) {
                     simpleVsFull = SIMPLE;
                 }
             }


### PR DESCRIPTION
For
- [171-A122] ... Check the case chart generator for how U+0130 is processed, and fix if necessary

The case mapping code in Java class UCD had a bug for the full lowercase mapping of U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE. This was visible in the Latin-script case chart.

See SpecialCasing.txt:
```
0130; 0069 0307; 0130; 0130; # LATIN CAPITAL LETTER I WITH DOT ABOVE
...
0130; 0069; 0130; 0130; tr; # LATIN CAPITAL LETTER I WITH DOT ABOVE
0130; 0069; 0130; 0130; az; # LATIN CAPITAL LETTER I WITH DOT ABOVE
```

I then had to more strongly hardcode the case folding of variants of i to keep those mappings stable.