### PR TITLE
security data files without UTF-8 BOM

### DIFF
--- a/unicodetools/data/security/dev/IdentifierStatus.txt
+++ b/unicodetools/data/security/dev/IdentifierStatus.txt
@@ -1,5 +1,5 @@
-﻿# IdentifierStatus.txt
-# Date: 2022-08-22, 23:13:14 GMT
+# IdentifierStatus.txt
+# Date: 2022-08-26, 16:49:09 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/security/dev/IdentifierType.txt
+++ b/unicodetools/data/security/dev/IdentifierType.txt
@@ -1,5 +1,5 @@
-﻿# IdentifierType.txt
-# Date: 2022-08-22, 23:13:13 GMT
+# IdentifierType.txt
+# Date: 2022-08-26, 16:49:09 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/security/dev/confusables.txt
+++ b/unicodetools/data/security/dev/confusables.txt
@@ -1,5 +1,5 @@
-﻿# confusables.txt
-# Date: 2022-08-22, 22:20:55 GMT
+# confusables.txt
+# Date: 2022-08-26, 16:49:08 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/security/dev/confusablesSummary.txt
+++ b/unicodetools/data/security/dev/confusablesSummary.txt
@@ -1,5 +1,5 @@
-﻿# confusablesSummary.txt
-# Date: 2022-05-18, 21:51:56 GMT
+# confusablesSummary.txt
+# Date: 2022-08-26, 16:49:08 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/security/dev/data/confusablesSummaryIdentifier.txt
+++ b/unicodetools/data/security/dev/data/confusablesSummaryIdentifier.txt
@@ -1,5 +1,5 @@
-﻿# confusablesSummaryIdentifier.txt
-# Date: 2022-05-10, 17:59:53 GMT
+# confusablesSummaryIdentifier.txt
+# Date: 2022-08-26, 16:49:08 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/security/dev/data/idnchars.txt
+++ b/unicodetools/data/security/dev/data/idnchars.txt
@@ -1,5 +1,5 @@
-﻿# idnchars.txt
-# Date: 2022-08-22, 22:20:57 GMT
+# idnchars.txt
+# Date: 2022-08-26, 16:49:10 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/security/dev/data/source/formatted-cherokee.txt
+++ b/unicodetools/data/security/dev/data/source/formatted-cherokee.txt
@@ -1,5 +1,5 @@
-﻿# formatted-cherokee.txt
-# Date: 2022-05-10, 17:59:51 GMT
+# formatted-cherokee.txt
+# Date: 2022-08-26, 16:49:04 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/security/dev/data/source/formatted-cjk
+++ b/unicodetools/data/security/dev/data/source/formatted-cjk
@@ -1,5 +1,5 @@
-﻿# formatted-cjk.txt
-# Date: 2022-05-10, 17:59:52 GMT
+# formatted-cjk.txt
+# Date: 2022-08-26, 16:49:05 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/security/dev/data/source/formatted-macFonts.txt
+++ b/unicodetools/data/security/dev/data/source/formatted-macFonts.txt
@@ -1,5 +1,5 @@
-﻿# formatted-macFonts.txt
-# Date: 2022-05-10, 17:59:51 GMT
+# formatted-macFonts.txt
+# Date: 2022-08-26, 16:49:04 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/security/dev/data/source/formatted-source.txt
+++ b/unicodetools/data/security/dev/data/source/formatted-source.txt
@@ -1,5 +1,5 @@
-﻿# formatted-source.txt
-# Date: 2022-05-10, 17:59:51 GMT
+# formatted-source.txt
+# Date: 2022-08-26, 16:49:04 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/security/dev/data/source/formatted-winFonts.txt
+++ b/unicodetools/data/security/dev/data/source/formatted-winFonts.txt
@@ -1,5 +1,5 @@
-﻿# formatted-winFonts.txt
-# Date: 2022-05-10, 17:59:51 GMT
+# formatted-winFonts.txt
+# Date: 2022-08-26, 16:49:05 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/security/dev/data/xidAllowed.txt
+++ b/unicodetools/data/security/dev/data/xidAllowed.txt
@@ -1,5 +1,5 @@
-﻿# xidAllowed.txt
-# Date: 2022-05-10, 17:59:54 GMT
+# xidAllowed.txt
+# Date: 2022-08-26, 16:49:09 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/security/dev/intentional.txt
+++ b/unicodetools/data/security/dev/intentional.txt
@@ -1,5 +1,5 @@
-﻿# intentional.txt
-# Date: 2022-05-10, 17:59:51 GMT
+# intentional.txt
+# Date: 2022-08-26, 16:49:04 GMT
 # © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java
@@ -1476,6 +1476,7 @@ public class GenerateConfusables {
 
         private static Comparator<Pair<String, String>> MyPairComparator =
                 new Comparator<Pair<String, String>>() {
+                    @Override
                     public int compare(Pair<String, String> o1, Pair<String, String> o2) {
                         int result = UCAComparator.compare(o1.getFirst(), o2.getFirst());
                         return result != 0
@@ -2640,8 +2641,6 @@ public class GenerateConfusables {
     static PrintWriter openAndWriteHeader(String dir, String filename, String title)
             throws IOException {
         final PrintWriter out = FileUtilities.openUTF8Writer(dir, filename);
-        out.print('\uFEFF');
-        // int trNumber, String title, String filename, String version
         out.println(
                 Utility.getBaseDataHeader(filename, 39, "Unicode Security Mechanisms", version));
         //        out.println("# " + title);


### PR DESCRIPTION
The file-initial Byte Order Mark is not recommended for UTF-8 (where it is more properly a ["signature byte sequence"](https://www.unicode.org/reports/tr6/tr6-4.html#Signature)). Stop writing it for security data files.

Fixes #123