### PR TITLE
fix(build): use cldr.version for cldr

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,6 +5,9 @@ statistics = True
 indent-size = 2
 max-line-length = 100
 max-complexity = 10
-ignore = E302, # expected 2 blank lines, found 1
-         E701, # multiple statements on one line
-         W504, # line break after binary operator
+ignore = E302,
+       	 # expected 2 blank lines, found 1
+         E701,
+       	 # multiple statements on one line
+         W504,
+       	 # line break after binary operator

--- a/.github/workflows/build-jsp.yml
+++ b/.github/workflows/build-jsp.yml
@@ -1,5 +1,9 @@
 name: Build JSP
 
+env:
+  CURRENT_UVERSION: 15.1.0
+  PREVIOUS_UVERSION: 15.0.0  # not used at present
+
 on:
   push:
     branches:
@@ -11,15 +15,31 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    - name: Get the CLDR_REF from pom.xml
+      id: cldr_ref
+      run: echo "CLDR_REF="$(mvn help:evaluate -Dexpression=cldr.version -q -DforceStdout | cut -d- -f3) >> $GITHUB_OUTPUT && cat ${GITHUB_OUTPUT}
+    - name: Verify CLDR checkout ref
+      run: echo CLDR_REF="${{ steps.cldr_ref.outputs.CLDR_REF }}" && [ "${{ steps.cldr_ref.outputs.CLDR_REF }}x" != "x" ] # fail if empty
+    - name: Cache CLDR repository
+      uses: actions/cache@v3
+      with:
+        path: cldr
+        key: cldr-${{ steps.cldr_ref.outputs.CLDR_REF }}
+        restore-keys: |
+          cldr
     - name: Check out CLDR
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: unicode-org/cldr
         path: cldr
+        ref: main
+        fetch-depth: 0
+    - name: Switch CLDR to CLDR_REF
+      run: cd cldr && git fetch && git checkout ${{ steps.cldr_ref.outputs.CLDR_REF }}
     - name: Backup Unicodetools and CLDR for jsps  # this is needed only for the Docker build
       run:
-        mkdir -p UnicodeJsps/target && tar cfpz UnicodeJsps/target/cldr-unicodetools.tgz ./cldr ./unicodetools
+        mkdir -p UnicodeJsps/target && tar -cpz --exclude=.git -f UnicodeJsps/target/cldr-unicodetools.tgz ./cldr ./unicodetools
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
@@ -38,16 +58,16 @@ jobs:
       run: >
         mkdir -pv $(pwd)/output/Generated/ &&
         mvn -s .github/workflows/mvn-settings.xml -B compile exec:java -DskipTests=true
-        -Dexec.mainClass="org.unicode.text.UCD.Main" -Dexec.args="version 15.1.0 build MakeUnicodeFiles"
+        -Dexec.mainClass="org.unicode.text.UCD.Main" -Dexec.args="version ${CURRENT_UVERSION} build MakeUnicodeFiles"
         -am -pl unicodetools -DCLDR_DIR=${GITHUB_WORKSPACE}/cldr
-        -DUNICODETOOLS_REPO_DIR=$(pwd) -DUVERSION=15.1.0
+        -DUNICODETOOLS_REPO_DIR=$(pwd) -DUVERSION=${CURRENT_UVERSION}
         -DUNICODETOOLS_GEN_DIR=$(pwd)/output/Generated
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Run unicodetools tests
       run: >
         mvn -s .github/workflows/mvn-settings.xml -B test -am -pl unicodetools
-        -DCLDR_DIR=${GITHUB_WORKSPACE}/cldr -T 1C -Dparallel=classes -DUNICODETOOLS_REPO_DIR=$(pwd) -DUVERSION=15.1.0 -DUNICODETOOLS_GEN_DIR=$(pwd)/output/Generated
+        -DCLDR_DIR=${GITHUB_WORKSPACE}/cldr -T 1C -Dparallel=classes -DUNICODETOOLS_REPO_DIR=$(pwd) -DUVERSION=${CURRENT_UVERSION} -DUNICODETOOLS_GEN_DIR=$(pwd)/output/Generated
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Package JSPs

--- a/.github/workflows/cli-build-instructions.yml
+++ b/.github/workflows/cli-build-instructions.yml
@@ -65,7 +65,7 @@ jobs:
           mkdir -p UnicodeJsps/target && tar -cpz --exclude=.git -f UnicodeJsps/target/cldr-unicodetools.tgz ./cldr ./unicodetools
       - name: Symlink CLDR working copy to be sibling of Unicode Tools
         run: |
-          ln -s cldr ..
+          ln -s $(pwd)/cldr ..
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/cli-build-instructions.yml
+++ b/.github/workflows/cli-build-instructions.yml
@@ -39,14 +39,33 @@ jobs:
     steps:
       - name: Checkout Unicode Tools
         uses: actions/checkout@v3
+      - name: Get the CLDR_REF from pom.xml
+        id: cldr_ref
+        run: echo "CLDR_REF="$(mvn help:evaluate -Dexpression=cldr.version -q -DforceStdout | cut -d- -f3) >> $GITHUB_OUTPUT && cat ${GITHUB_OUTPUT}
+      - name: Verify CLDR checkout ref
+        run: echo CLDR_REF="${{ steps.cldr_ref.outputs.CLDR_REF }}" && [ "${{ steps.cldr_ref.outputs.CLDR_REF }}x" != "x" ] # fail if empty
+      - name: Cache CLDR repository
+        uses: actions/cache@v3
+        with:
+          path: cldr
+          key: cldr-${{ steps.cldr_ref.outputs.CLDR_REF }}
+          restore-keys: |
+            cldr
       - name: Check out CLDR
         uses: actions/checkout@v3
         with:
           repository: unicode-org/cldr
           path: cldr
-      - name: Move CLDR working copy to be sibling of Unicode Tools
+          ref: main
+          fetch-depth: 0
+      - name: Switch CLDR to CLDR_REF
+        run: cd cldr && git fetch && git checkout ${{ steps.cldr_ref.outputs.CLDR_REF }}
+      - name: Backup Unicodetools and CLDR for jsps  # this is needed only for the Docker build
+        run:
+          mkdir -p UnicodeJsps/target && tar -cpz --exclude=.git -f UnicodeJsps/target/cldr-unicodetools.tgz ./cldr ./unicodetools
+      - name: Symlink CLDR working copy to be sibling of Unicode Tools
         run: |
-          mv cldr ..
+          ln -s cldr ..
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
@@ -81,11 +100,27 @@ jobs:
         with:
           repository: unicode-org/unicodetools
           path: unicodetools/mine/src
-      - name: Checkout CLDR
+      - name: Get the CLDR_REF from pom.xml
+        id: cldr_ref
+        run: echo "CLDR_REF="$(mvn --file unicodetools/mine/src/pom.xml help:evaluate -Dexpression=cldr.version -q -DforceStdout | cut -d- -f3) >> $GITHUB_OUTPUT && cat ${GITHUB_OUTPUT}
+      - name: Verify CLDR checkout ref
+        run: echo CLDR_REF="${{ steps.cldr_ref.outputs.CLDR_REF }}" && [ "${{ steps.cldr_ref.outputs.CLDR_REF }}x" != "x" ] # fail if empty
+      - name: Cache CLDR repository
+        uses: actions/cache@v3
+        with:
+          path: cldr/mine/src
+          key: cldr-${{ steps.cldr_ref.outputs.CLDR_REF }}
+          restore-keys: |
+            cldr
+      - name: Check out CLDR
         uses: actions/checkout@v3
         with:
           repository: unicode-org/cldr
           path: cldr/mine/src
+          ref: main
+          fetch-depth: 0
+      - name: Switch CLDR to CLDR_REF
+        run: cd cldr/mine/src && git fetch && git checkout ${{ steps.cldr_ref.outputs.CLDR_REF }}
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
@@ -198,7 +233,7 @@ jobs:
             exit 1
           fi
           # TODO(#100): Note: when running locally on a clean checkout, this command
-          # leaves a change in UcdPropertyValues.java by not preserving the comment 
+          # leaves a change in UcdPropertyValues.java by not preserving the comment
           # about the fake Unicode version 13.1.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -210,7 +245,7 @@ jobs:
           # run GenerateConfusables
           mvn -s .github/workflows/mvn-settings.xml compile exec:java -Dexec.mainClass="org.unicode.text.UCD.GenerateConfusables"  -Dexec.args="-c -b" -am -pl unicodetools  -DCLDR_DIR=$(cd ../../../cldr/mine/src ; pwd)  -DUNICODETOOLS_GEN_DIR=$(cd ../Generated ; pwd)  -DUNICODETOOLS_REPO_DIR=$(pwd)  -DUVERSION=$CURRENT_UVERSION
           # run Build & Test command again to rerun TestSecurity test to verify output is okay
-          MAVEN_OPTS="-ea" mvn -s .github/workflows/mvn-settings.xml test -pl unicodetools -Dtest=TestSecurity -DCLDR_DIR=$(cd ../../../cldr/mine/src ; pwd)  -DUNICODETOOLS_GEN_DIR=$(cd ../Generated ; pwd)  -DUNICODETOOLS_REPO_DIR=$(pwd)  -DUVERSION=$CURRENT_UVERSION
+          MAVEN_OPTS="-ea" mvn -s .github/workflows/mvn-settings.xml test -am -pl unicodetools -Dtest=TestSecurity -DCLDR_DIR=$(cd ../../../cldr/mine/src ; pwd)  -DUNICODETOOLS_GEN_DIR=$(cd ../Generated ; pwd)  -DUNICODETOOLS_REPO_DIR=$(pwd)  -DUVERSION=$CURRENT_UVERSION
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -222,7 +257,7 @@ jobs:
           mvn -s .github/workflows/mvn-settings.xml compile exec:java -Dexec.mainClass="org.unicode.draft.GenerateUnihanCollators"  -Dexec.args="" -am -pl unicodetools  -DCLDR_DIR=$(cd ../../../cldr/mine/src ; pwd)  -DUNICODETOOLS_GEN_DIR=$(cd ../Generated ; pwd)  -DUNICODETOOLS_REPO_DIR=$(pwd)  -DUVERSION=$CURRENT_UVERSION
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       # https://github.com/unicode-org/unicodetools/blob/main/docs/newunicodeproperties.md#checking-other-properties
       - name: Run command - Checking Other Properties
         run: |
@@ -231,6 +266,6 @@ jobs:
           # Note: the test-compile phase/target needs to precede `compile exec:java` because
           # the source code is in src/test/java, not src/main/java, and we need the
           # code to compile before it is executed.
-          mvn -s .github/workflows/mvn-settings.xml -Dexec.mainClass="org.unicode.propstest.CheckProperties" -Dexec.classpathScope=test test-compile  -Dexec.args="COMPARE ALL $PREVIOUS_UVERSION" compile exec:java -am  -pl unicodetools  -DCLDR_DIR=$(cd ../../../cldr/mine/src ; pwd)  -DUNICODETOOLS_GEN_DIR=$(cd ../Generated ; pwd)  -DUNICODETOOLS_REPO_DIR=$(pwd)  -DUVERSION=$CURRENT_UVERSION
+          mvn -s .github/workflows/mvn-settings.xml -Dexec.mainClass="org.unicode.propstest.CheckProperties" -Dexec.classpathScope=test test-compile  -Dexec.args="COMPARE ALL $PREVIOUS_UVERSION" compile exec:java -am -pl unicodetools  -DCLDR_DIR=$(cd ../../../cldr/mine/src ; pwd)  -DUNICODETOOLS_GEN_DIR=$(cd ../Generated ; pwd)  -DUNICODETOOLS_REPO_DIR=$(pwd)  -DUVERSION=$CURRENT_UVERSION
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cli-build-instructions.yml
+++ b/.github/workflows/cli-build-instructions.yml
@@ -245,7 +245,7 @@ jobs:
           # run GenerateConfusables
           mvn -s .github/workflows/mvn-settings.xml compile exec:java -Dexec.mainClass="org.unicode.text.UCD.GenerateConfusables"  -Dexec.args="-c -b" -am -pl unicodetools  -DCLDR_DIR=$(cd ../../../cldr/mine/src ; pwd)  -DUNICODETOOLS_GEN_DIR=$(cd ../Generated ; pwd)  -DUNICODETOOLS_REPO_DIR=$(pwd)  -DUVERSION=$CURRENT_UVERSION
           # run Build & Test command again to rerun TestSecurity test to verify output is okay
-          MAVEN_OPTS="-ea" mvn -s .github/workflows/mvn-settings.xml test -am -pl unicodetools -Dtest=TestSecurity -DCLDR_DIR=$(cd ../../../cldr/mine/src ; pwd)  -DUNICODETOOLS_GEN_DIR=$(cd ../Generated ; pwd)  -DUNICODETOOLS_REPO_DIR=$(pwd)  -DUVERSION=$CURRENT_UVERSION
+          MAVEN_OPTS="-ea" mvn -s .github/workflows/mvn-settings.xml test -am -pl unicodetools -Dtest=TestSecurity -DCLDR_DIR=$(cd ../../../cldr/mine/src ; pwd)  -DUNICODETOOLS_GEN_DIR=$(cd ../Generated ; pwd)  -DUNICODETOOLS_REPO_DIR=$(pwd)  -DUVERSION=$CURRENT_UVERSION -DfailIfNoTests=false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/push-jsp-on-tag.yml
+++ b/.github/workflows/push-jsp-on-tag.yml
@@ -7,20 +7,32 @@ jobs:
   build-and-push-to-gcr:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - uses: actions/checkout@v2
+    - name: Get the CLDR_REF from pom.xml
+      id: cldr_ref
+      run: echo "CLDR_REF="$(mvn help:evaluate -Dexpression=cldr.version -q -DforceStdout | cut -d- -f3) >> $GITHUB_OUTPUT && cat ${GITHUB_OUTPUT}
+    - name: Verify CLDR checkout ref
+      run: echo CLDR_REF="${{ steps.cldr_ref.outputs.CLDR_REF }}" && [ "${{ steps.cldr_ref.outputs.CLDR_REF }}x" != "x" ] # fail if empty
+    - name: Cache CLDR
+      uses: actions/cache@v2
+      with:
+        path: cldr
+        key: cldr-${{ steps.cldr_ref.outputs.CLDR_REF }}
+        restore-keys: |
+          cldr-${{ steps.cldr_ref.outputs.CLDR_REF }}
     - name: Check out CLDR
-      uses: actions/checkout@v2
+      uses: actions/checkout@v1.2  # yes, v1 due to https://github.com/actions/checkout/issues/265
       with:
         repository: unicode-org/cldr
         path: cldr
+        ref: ${{ steps.cldr_ref.outputs.CLDR_REF }}
     - name: Backup Unicodetools and CLDR for jsps
       run:
-        mkdir -p UnicodeJsps/target && tar cfpz UnicodeJsps/target/cldr-unicodetools.tgz ./cldr ./unicodetools
+        mkdir -p UnicodeJsps/target && tar -cpz --exclude=.git -f UnicodeJsps/target/cldr-unicodetools.tgz ./cldr ./unicodetools
     - name: Cache local Maven repository
       uses: actions/cache@v2
       with:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: [3.8]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:

--- a/unicodetools-testutils/src/test/java/org/unicode/unittest/TestTestFmwk.java
+++ b/unicodetools-testutils/src/test/java/org/unicode/unittest/TestTestFmwk.java
@@ -1,0 +1,9 @@
+package org.unicode.unittest;
+
+public class TestTestFmwk extends TestFmwkMinusMinus {
+    @org.junit.jupiter.api.Test
+    void Test() {
+        assertContains("hay hay hay hay needle hay hay hay", "needle");
+        logln("Everything is OK");
+    }
+}


### PR DESCRIPTION
- github action should use the cldr.version for checkout
- also bump the version of some actions

Fixes #316