### PR TITLE
Support U+ notation in character.jsp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ ARM/
 ARM64/
 Debug/
 Generated[!!-~]Files/
+Generated/
 Release/
 __pycache__/
 arm/

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeJsp.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeJsp.java
@@ -214,7 +214,8 @@ public class UnicodeJsp {
         // Accept U+ notation and standalone hexadecimal digits, as well as a variety
         // of hexadecimal character escape and numeric literal syntaxes.
         Matcher matcher =
-                Pattern.compile("(?:U\\+|\\\\[ux]\\{?|&#x|0x|16#|&H)?([0-9a-f'_]+)[\\};#]?",
+                Pattern.compile(
+                                "(?:U\\+|\\\\[ux]\\{?|&#x|0x|16#|&H)?([0-9a-f'_]+)[\\};#]?",
                                 Pattern.CASE_INSENSITIVE)
                         .matcher(trimmed);
         String digits = matcher.matches() ? matcher.group(1).replaceAll("['_]", "") : null;

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeJsp.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeJsp.java
@@ -208,28 +208,37 @@ public class UnicodeJsp {
         UnicodeUtilities.getDifferences(setA, setB, abbreviate, abResults, abSizes, abLinks);
     }
 
-    public static int parseCode(String text, String nextButton, String previousButton) {
+    public static int[] parseCode(String text, String nextButton, String previousButton) {
         // text = fromHTML.transliterate(text);
         String trimmed = text.trim();
-        if (trimmed.length() > 1) {
+        // Accept U+ notation and standalone hexadecimal digits, as well as a variety
+        // of hexadecimal character escape and numeric literal syntaxes.
+        Matcher matcher = Pattern.compile(
+            "(?:U\\+|\\\\[ux]\\{?|&#x|0x|16#|&H)?([0-9a-f'_]+)[\\};#]?",
+            Pattern.CASE_INSENSITIVE).matcher(trimmed);
+        String digits = matcher.matches() ? matcher.group(1).replaceAll("['_]", "") : null;
+        if (digits != null && digits.length() > 1) {
             try {
-                text = UTF16.valueOf(Integer.parseInt(trimmed, 16));
+                text = UTF16.valueOf(Integer.parseInt(digits, 16));
             } catch (Exception e) {
             }
         }
-        int cp = UTF16.charAt(text, 0);
+        int[] result = text.codePoints().toArray();
+        int cp = result[0];
         if (nextButton != null) {
             cp += 1;
             if (cp > 0x10FFFF) {
                 cp = 0;
             }
+            return new int[]{cp};
         } else if (previousButton != null) {
             cp -= 1;
             if (cp < 0) {
                 cp = 0x10FFFF;
             }
+            return new int[]{cp};
         }
-        return cp;
+        return result;
     }
 
     public static String getConfusables(String test, int choice) {

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeJsp.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeJsp.java
@@ -213,9 +213,10 @@ public class UnicodeJsp {
         String trimmed = text.trim();
         // Accept U+ notation and standalone hexadecimal digits, as well as a variety
         // of hexadecimal character escape and numeric literal syntaxes.
-        Matcher matcher = Pattern.compile(
-            "(?:U\\+|\\\\[ux]\\{?|&#x|0x|16#|&H)?([0-9a-f'_]+)[\\};#]?",
-            Pattern.CASE_INSENSITIVE).matcher(trimmed);
+        Matcher matcher =
+                Pattern.compile("(?:U\\+|\\\\[ux]\\{?|&#x|0x|16#|&H)?([0-9a-f'_]+)[\\};#]?",
+                                Pattern.CASE_INSENSITIVE)
+                        .matcher(trimmed);
         String digits = matcher.matches() ? matcher.group(1).replaceAll("['_]", "") : null;
         if (digits != null && digits.length() > 1) {
             try {
@@ -230,13 +231,13 @@ public class UnicodeJsp {
             if (cp > 0x10FFFF) {
                 cp = 0;
             }
-            return new int[]{cp};
+            return new int[] {cp};
         } else if (previousButton != null) {
             cp -= 1;
             if (cp < 0) {
                 cp = 0x10FFFF;
             }
-            return new int[]{cp};
+            return new int[] {cp};
         }
         return result;
     }

--- a/UnicodeJsps/src/main/webapp/character.jsp
+++ b/UnicodeJsps/src/main/webapp/character.jsp
@@ -24,14 +24,44 @@ th           { text-align: left }
         UtfParameters utfParameters = new UtfParameters(queryString);
 		String text = utfParameters.getParameter("a", "\u2615", "\u2615");
 
-		int cp = UnicodeJsp.parseCode(text,null,null);
-		//text = UTF16.valueOf(cp);
-	    String nextHex = "character.jsp?a=" + Utility.hex(cp < 0x110000 ? cp+1 : 0, 4);
+		int[] codePoints = UnicodeJsp.parseCode(text,null,null);
+		int cp = codePoints[0];
+    String nextHex = "character.jsp?a=" + Utility.hex(cp < 0x110000 ? cp+1 : 0, 4);
 		String prevHex = "character.jsp?a=" + Utility.hex(cp > 0 ? cp-1 : 0x10FFFF, 4);
+    if (codePoints.length > 1) {
+      %>
+        <p class="error">
+          Multiple code points or unrecognized hexadecimal syntax.
+        </p>
+        <p>
+          This tool shows the properties of individual code points.
+          Code points may be entered directly (<code>&#x2615;</code>), as bare hexadecimal
+          digits (<code>2615</code>), in U+ notation (<code>U+2615</code>), or in a variety
+          of hexadecimal escape sequence and numeric literal syntaxes
+          (<code>\u{2615}</code>, <code>&amp;#x2615;</code>, <code>0x2615</code>, etc.).
+        </p>
+        <p>
+          Showing the properties of the first code point. See the properties of
+      <%
+      for (int i = 1; i < codePoints.length; ++i) {
+        String digits = String.format("%04X", codePoints[i]);
+        String escaped = UnicodeUtilities.toHTML(UTF16.valueOf(codePoints[i]));
+        String codePoint = "U+" + digits;
+        if (escaped != "") {
+          codePoint += " (" + escaped + ")";
+        }
+        %>
+        <a href="?a=<%=digits%>"><%=codePoint%></a><%=i==codePoints.length - 1 ? "." : "," %>
+        <%
+      }
+      %>
+        </p>
+      <%
+    }
 %>
   <p>
   <input name="B3" type="button" value="-" onClick="window.location.href='<%=prevHex%>'">
-  <input name="a" type="text" style='text-align:center; font-size:150%' size="10" value="<%=text%>">
+  <input name="a" type="text" style='text-align:center; font-size:150%' size="10" value="<%=UnicodeUtilities.toHTML(text)%>">
   <input name="B2" type="button" value="+" onClick="window.location.href='<%=nextHex%>'"><br>
   <input name="B1" type="submit" value="Show">
   </p>

--- a/docs/unicodejsps/index.md
+++ b/docs/unicodejsps/index.md
@@ -15,7 +15,7 @@ need to actually need to download or build CLDR itself.
 
 ### Building from the command line
 
-Run `mvn package` in the UnicodeJsps directory to build the JSPs.
+Run `mvn package -DskipTests` in the repository directory to build the JSPs.
 
 ### Building from Eclipse
 
@@ -29,6 +29,10 @@ If you already have `UnicodeJsps` in eclipse, it might be better to remove it fr
 ```shell
 mvn org.eclipse.jetty:jetty-maven-plugin:run
 ```
+
+If port 8080 is in use, another port can be specified with `-Djetty.port=⟨port number⟩`.
+
+The following system properties described in [Building Unicode Tools](../build.md#java-system-properties-used-in-unicode-tools) must be set in order for the JSPs to function properly: `CLDR_DIR`, `UNICODETOOLS_REPO_DIR`; this can be done with `-DCLDR_DIR=⟨some path⟩ -DUNICODETOOLS_REPO_DIR=.`.
 
 You can now connect to <http://127.0.0.1:8080> as suggested from the command line.
 Use Control-C to stop the server.

--- a/docs/unicodejsps/index.md
+++ b/docs/unicodejsps/index.md
@@ -15,7 +15,7 @@ need to actually need to download or build CLDR itself.
 
 ### Building from the command line
 
-Run `mvn package -DskipTests` in the repository directory to build the JSPs.
+Run `mvn -am -pl UnicodeJsps package -DskipTests` at the root directory of the repository to build the JSPs.
 
 ### Building from Eclipse
 

--- a/unicodetools/.project
+++ b/unicodetools/.project
@@ -35,12 +35,12 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1625517710081</id>
+			<id>1669808791356</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>

--- a/unicodetools/.project
+++ b/unicodetools/.project
@@ -35,12 +35,12 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1669808791356</id>
+			<id>1625517710081</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>


### PR DESCRIPTION
As well as a number of other hex escape and hex numeric literal syntaxes.

This fixes #350.

Provide some help in an error message if we still get multiple code points, pointing to the pages for the individual code points, which can be useful when one is interested in combining marks; see screenshots below.

Drive-by changes to documentation so that it doesn’t suggest a running maven in a place where it doesn’t see the POM, and to .gitignore so that it ignores the Generated directory suggested by the build instructions.

Unfortunately this breaks this important feature of character.jsp: https://util.unicode.org/UnicodeJsps/character.jsp?a=%F0%9F%90%88%22/%3E%3Cscript%3Ealert(%22meow%22)%3C/script%3E%3Cspan%20class=%22&B1=Show.

Screenshots:

| U+ notation | Multiple code points | Escaping |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/2284290/204826060-266085c6-631c-4ce3-b327-3a9c6521a383.png) | ![image](https://user-images.githubusercontent.com/2284290/204826455-79610713-2dbb-446f-8af1-dc46d9d99a09.png) | ![image](https://user-images.githubusercontent.com/2284290/204826903-ba8ffaac-31f9-416b-ad84-ca532ea9b3d4.png) |
