### PR TITLE
UCD 15.1.0: Update NamesList.txt+StandardizedVariants.txt

### DIFF
--- a/unicodetools/data/ucd/dev/CaseFolding.txt
+++ b/unicodetools/data/ucd/dev/CaseFolding.txt
@@ -1,6 +1,6 @@
-# CaseFolding-15.0.0.txt
-# Date: 2022-02-02, 23:35:35 GMT
-# © 2022 Unicode®, Inc.
+# CaseFolding-15.1.0.txt
+# Date: 2023-01-05, 20:34:30 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/DerivedAge.txt
+++ b/unicodetools/data/ucd/dev/DerivedAge.txt
@@ -1,6 +1,6 @@
 # DerivedAge-15.1.0.txt
-# Date: 2022-12-12, 03:54:25 GMT
-# © 2022 Unicode®, Inc.
+# Date: 2023-01-05, 20:34:30 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/DerivedCoreProperties.txt
+++ b/unicodetools/data/ucd/dev/DerivedCoreProperties.txt
@@ -1,6 +1,6 @@
 # DerivedCoreProperties-15.1.0.txt
-# Date: 2022-12-12, 19:16:09 GMT
-# © 2022 Unicode®, Inc.
+# Date: 2023-01-05, 20:34:34 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/DerivedNormalizationProps.txt
+++ b/unicodetools/data/ucd/dev/DerivedNormalizationProps.txt
@@ -1,6 +1,6 @@
 # DerivedNormalizationProps-15.1.0.txt
-# Date: 2022-12-12, 19:16:14 GMT
-# © 2022 Unicode®, Inc.
+# Date: 2023-01-05, 20:34:39 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/HangulSyllableType.txt
+++ b/unicodetools/data/ucd/dev/HangulSyllableType.txt
@@ -1,6 +1,6 @@
-# HangulSyllableType-15.0.0.txt
-# Date: 2022-02-02, 23:35:41 GMT
-# © 2022 Unicode®, Inc.
+# HangulSyllableType-15.1.0.txt
+# Date: 2023-01-05, 20:34:42 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/NamesList.txt
+++ b/unicodetools/data/ucd/dev/NamesList.txt
@@ -1,14 +1,10 @@
 ; charset=UTF-8
 @@@	The Unicode Standard 15.1.0
-@@@+	U15M221201.lst
-	Unicode 15.1.0 names list, second delta.
+@@@+	U15M221219.lst
+	Unicode 15.1.0 names list, third delta.
 	Repertoire synched with UnicodeData-15.1.0d1.txt.
-	Added Kangxi radical number annotations to Kangxi Radicals block.
-	Add blind xref from 2E9A to 2F46.
-	Added annotation for new Hieroglyph format control.
-	Added xrefs for 20A3 and A798.
-	Updated annotation for A799.
-	Added annotation and xref for AB3E.
+	Update copyright date to 2023.
+	Correct blind xref syntax for x2E9A.
 	This file is semi-automatically derived from UnicodeData.txt and
 	a set of manually created annotations using a script to select
 	or suppress information from the data file. The rules used
@@ -19471,7 +19467,7 @@
 	* form used on right side
 	x 6535
 2E9A	<reserved>
-	x 2F46
+	x (kangxi radical not - 2F46)
 2E9B	CJK RADICAL CHOKE
 	x 65E1
 2E9C	CJK RADICAL SUN

--- a/unicodetools/data/ucd/dev/NormalizationTest.txt
+++ b/unicodetools/data/ucd/dev/NormalizationTest.txt
@@ -1,6 +1,6 @@
-# NormalizationTest-15.0.0.txt
-# Date: 2022-04-02, 01:29:09 GMT
-# © 2022 Unicode®, Inc.
+# NormalizationTest-15.1.0.txt
+# Date: 2023-01-05, 20:34:44 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/PropList.txt
+++ b/unicodetools/data/ucd/dev/PropList.txt
@@ -1,6 +1,6 @@
-# PropList-15.0.0.txt
-# Date: 2022-11-04, 14:18:18 GMT
-# © 2022 Unicode®, Inc.
+# PropList-15.1.0.txt
+# Date: 2023-01-05, 20:34:45 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/PropertyAliases.txt
+++ b/unicodetools/data/ucd/dev/PropertyAliases.txt
@@ -1,6 +1,6 @@
 # PropertyAliases-15.1.0.txt
-# Date: 2022-12-09
-# © 2022 Unicode®, Inc.
+# Date: 2023-01-05, 20:34:48 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/PropertyValueAliases.txt
+++ b/unicodetools/data/ucd/dev/PropertyValueAliases.txt
@@ -1,6 +1,6 @@
 # PropertyValueAliases-15.1.0.txt
-# Date: 2022-12-12, 03:55:10 GMT
-# © 2022 Unicode®, Inc.
+# Date: 2023-01-05, 20:34:48 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/ScriptExtensions.txt
+++ b/unicodetools/data/ucd/dev/ScriptExtensions.txt
@@ -1,6 +1,6 @@
-# ScriptExtensions-15.0.0.txt
-# Date: 2022-02-02, 00:57:11 GMT
-# © 2022 Unicode®, Inc.
+# ScriptExtensions-15.1.0.txt
+# Date: 2023-01-05, 20:35:02 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/Scripts.txt
+++ b/unicodetools/data/ucd/dev/Scripts.txt
@@ -1,6 +1,6 @@
-# Scripts-15.0.0.txt
-# Date: 2022-11-04, 14:16:16 GMT
-# © 2022 Unicode®, Inc.
+# Scripts-15.1.0.txt
+# Date: 2023-01-05, 20:35:02 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/SpecialCasing.txt
+++ b/unicodetools/data/ucd/dev/SpecialCasing.txt
@@ -1,6 +1,6 @@
-# SpecialCasing-15.0.0.txt
-# Date: 2022-02-02, 23:35:52 GMT
-# © 2022 Unicode®, Inc.
+# SpecialCasing-15.1.0.txt
+# Date: 2023-01-05, 20:35:03 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/StandardizedVariants.txt
+++ b/unicodetools/data/ucd/dev/StandardizedVariants.txt
@@ -1,5 +1,5 @@
-# StandardizedVariants-15.0.0.txt
-# Date: 2022-08-16, 19:08:00 GMT [KW]
+# StandardizedVariants-15.1.0.txt
+# Date: 2022-12-19, 23:53:00 GMT [KW]
 # © 2022 Unicode®, Inc.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/auxiliary/GraphemeBreakProperty.txt
+++ b/unicodetools/data/ucd/dev/auxiliary/GraphemeBreakProperty.txt
@@ -1,6 +1,6 @@
 # GraphemeBreakProperty-15.1.0.txt
-# Date: 2022-12-12, 19:16:17 GMT
-# © 2022 Unicode®, Inc.
+# Date: 2023-01-05, 20:34:41 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/auxiliary/GraphemeBreakTest.txt
+++ b/unicodetools/data/ucd/dev/auxiliary/GraphemeBreakTest.txt
@@ -1,6 +1,6 @@
 # GraphemeBreakTest-15.1.0.txt
-# Date: 2022-12-12, 19:16:18 GMT
-# © 2022 Unicode®, Inc.
+# Date: 2023-01-05, 20:34:42 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/auxiliary/LineBreakTest.txt
+++ b/unicodetools/data/ucd/dev/auxiliary/LineBreakTest.txt
@@ -1,6 +1,6 @@
-# LineBreakTest-15.0.0.txt
-# Date: 2022-02-26, 00:38:39 GMT
-# © 2022 Unicode®, Inc.
+# LineBreakTest-15.1.0.txt
+# Date: 2023-01-05, 20:34:43 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/auxiliary/SentenceBreakProperty.txt
+++ b/unicodetools/data/ucd/dev/auxiliary/SentenceBreakProperty.txt
@@ -1,6 +1,6 @@
-# SentenceBreakProperty-15.0.0.txt
-# Date: 2022-08-05, 22:17:35 GMT
-# © 2022 Unicode®, Inc.
+# SentenceBreakProperty-15.1.0.txt
+# Date: 2023-01-05, 20:35:03 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/auxiliary/SentenceBreakTest.txt
+++ b/unicodetools/data/ucd/dev/auxiliary/SentenceBreakTest.txt
@@ -1,6 +1,6 @@
-# SentenceBreakTest-15.0.0.txt
-# Date: 2022-02-26, 00:39:00 GMT
-# © 2022 Unicode®, Inc.
+# SentenceBreakTest-15.1.0.txt
+# Date: 2023-01-05, 20:35:03 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/auxiliary/WordBreakProperty.txt
+++ b/unicodetools/data/ucd/dev/auxiliary/WordBreakProperty.txt
@@ -1,6 +1,6 @@
-# WordBreakProperty-15.0.0.txt
-# Date: 2022-04-27, 02:41:26 GMT
-# © 2022 Unicode®, Inc.
+# WordBreakProperty-15.1.0.txt
+# Date: 2023-01-05, 20:35:04 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/auxiliary/WordBreakTest.txt
+++ b/unicodetools/data/ucd/dev/auxiliary/WordBreakTest.txt
@@ -1,6 +1,6 @@
-# WordBreakTest-15.0.0.txt
-# Date: 2022-02-26, 00:39:00 GMT
-# © 2022 Unicode®, Inc.
+# WordBreakTest-15.1.0.txt
+# Date: 2023-01-05, 20:35:04 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/extracted/DerivedBidiClass.txt
+++ b/unicodetools/data/ucd/dev/extracted/DerivedBidiClass.txt
@@ -1,6 +1,6 @@
 # DerivedBidiClass-15.1.0.txt
-# Date: 2022-12-12, 03:54:51 GMT
-# © 2022 Unicode®, Inc.
+# Date: 2023-01-05, 20:34:32 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/extracted/DerivedBinaryProperties.txt
+++ b/unicodetools/data/ucd/dev/extracted/DerivedBinaryProperties.txt
@@ -1,6 +1,6 @@
-# DerivedBinaryProperties-15.0.0.txt
-# Date: 2022-02-26, 00:38:29 GMT
-# © 2022 Unicode®, Inc.
+# DerivedBinaryProperties-15.1.0.txt
+# Date: 2023-01-05, 20:34:33 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/extracted/DerivedCombiningClass.txt
+++ b/unicodetools/data/ucd/dev/extracted/DerivedCombiningClass.txt
@@ -1,6 +1,6 @@
 # DerivedCombiningClass-15.1.0.txt
-# Date: 2022-12-12, 03:54:54 GMT
-# © 2022 Unicode®, Inc.
+# Date: 2023-01-05, 20:34:33 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/extracted/DerivedDecompositionType.txt
+++ b/unicodetools/data/ucd/dev/extracted/DerivedDecompositionType.txt
@@ -1,6 +1,6 @@
-# DerivedDecompositionType-15.0.0.txt
-# Date: 2022-02-26, 00:38:31 GMT
-# © 2022 Unicode®, Inc.
+# DerivedDecompositionType-15.1.0.txt
+# Date: 2023-01-05, 20:34:36 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/extracted/DerivedEastAsianWidth.txt
+++ b/unicodetools/data/ucd/dev/extracted/DerivedEastAsianWidth.txt
@@ -1,6 +1,6 @@
 # DerivedEastAsianWidth-15.1.0.txt
-# Date: 2022-12-12, 03:54:57 GMT
-# © 2022 Unicode®, Inc.
+# Date: 2023-01-05, 20:34:36 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/extracted/DerivedGeneralCategory.txt
+++ b/unicodetools/data/ucd/dev/extracted/DerivedGeneralCategory.txt
@@ -1,6 +1,6 @@
 # DerivedGeneralCategory-15.1.0.txt
-# Date: 2022-12-12, 03:54:57 GMT
-# © 2022 Unicode®, Inc.
+# Date: 2023-01-05, 20:34:37 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/extracted/DerivedJoiningGroup.txt
+++ b/unicodetools/data/ucd/dev/extracted/DerivedJoiningGroup.txt
@@ -1,6 +1,6 @@
-# DerivedJoiningGroup-15.0.0.txt
-# Date: 2022-02-26, 00:38:32 GMT
-# © 2022 Unicode®, Inc.
+# DerivedJoiningGroup-15.1.0.txt
+# Date: 2023-01-05, 20:34:37 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/extracted/DerivedJoiningType.txt
+++ b/unicodetools/data/ucd/dev/extracted/DerivedJoiningType.txt
@@ -1,6 +1,6 @@
-# DerivedJoiningType-15.0.0.txt
-# Date: 2022-04-26, 23:14:36 GMT
-# © 2022 Unicode®, Inc.
+# DerivedJoiningType-15.1.0.txt
+# Date: 2023-01-05, 20:34:38 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/extracted/DerivedLineBreak.txt
+++ b/unicodetools/data/ucd/dev/extracted/DerivedLineBreak.txt
@@ -1,6 +1,6 @@
 # DerivedLineBreak-15.1.0.txt
-# Date: 2022-12-12, 03:54:59 GMT
-# © 2022 Unicode®, Inc.
+# Date: 2023-01-05, 20:34:38 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/extracted/DerivedName.txt
+++ b/unicodetools/data/ucd/dev/extracted/DerivedName.txt
@@ -1,6 +1,6 @@
 # DerivedName-15.1.0.txt
-# Date: 2022-12-12, 03:54:59 GMT
-# © 2022 Unicode®, Inc.
+# Date: 2023-01-05, 20:34:38 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/extracted/DerivedNumericType.txt
+++ b/unicodetools/data/ucd/dev/extracted/DerivedNumericType.txt
@@ -1,6 +1,6 @@
 # DerivedNumericType-15.1.0.txt
-# Date: 2022-12-12, 03:55:02 GMT
-# © 2022 Unicode®, Inc.
+# Date: 2023-01-05, 20:34:41 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/data/ucd/dev/extracted/DerivedNumericValues.txt
+++ b/unicodetools/data/ucd/dev/extracted/DerivedNumericValues.txt
@@ -1,6 +1,6 @@
 # DerivedNumericValues-15.1.0.txt
-# Date: 2022-12-12, 03:55:02 GMT
-# © 2022 Unicode®, Inc.
+# Date: 2023-01-05, 20:34:41 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/MakeUnicodeFiles.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/MakeUnicodeFiles.txt
@@ -1,5 +1,5 @@
 Generate: .
-CopyrightYear: 2022
+CopyrightYear: 2023
 
 File: extra/ScriptNfkc
 Property: SPECIAL


### PR DESCRIPTION
From Ken:
- small update to NamesList.txt to fix a cross-reference syntax error
- initial drop of the 15.1.0 version of StandardizedVariants.txt; only change: internal version number

Plus: Generate files with copyright 2023.