### PR TITLE
script: copy alpha files to draft

### DIFF
--- a/docs/data-workflow.md
+++ b/docs/data-workflow.md
@@ -95,10 +95,10 @@ and skip any others that are only for internal use.
 
 ### Publish an alpha snapshot
 
-TODO: Define the minimal set of files to be published for an alpha.
+For the alpha review, publish (at least) the UCD and emoji files, and the charts.
 
-TODO: Write a script like /pub/copy-alpha-to-draft.sh that will be run on the unicode.org server
-and copy the set of the .../dev/ data files for an alpha snapshot
+Run the [pub/copy-alpha-to-draft.sh](https://github.com/unicode-org/unicodetools/blob/main/pub/copy-alpha-to-draft.sh)
+on the unicode.org server which copies the set of the .../dev/ data files for an alpha snapshot
 from a unicodetools workspace to the location behind https://www.unicode.org/Public/draft/ .
 
 Note: No version/delta infixes in names of data files.

--- a/pub/copy-alpha-to-draft.sh
+++ b/pub/copy-alpha-to-draft.sh
@@ -1,0 +1,28 @@
+# Script for
+# https://github.com/unicode-org/unicodetools/blob/main/docs/data-workflow.md#publish-an-alpha-snapshot
+#
+# Invoke like this:
+#
+# pub/copy-alpha-to-draft.sh  ~/unitools/mine/src  /tmp/unicode/Public/draft
+
+UNICODETOOLS=$1
+DRAFT=$2
+
+UNITOOLS_DATA=$UNICODETOOLS/unicodetools/data
+
+mkdir -p $DRAFT/UCD/ucd
+cp -r $UNITOOLS_DATA/ucd/dev/* $DRAFT/UCD/ucd
+rm -r $DRAFT/UCD/ucd/Unihan
+mv $DRAFT/UCD/ucd/version-ReadMe.txt $DRAFT/UCD/ReadMe.txt
+rm $DRAFT/UCD/ucd/zipped-ReadMe.txt
+
+mkdir -p $DRAFT/emoji
+cp $UNITOOLS_DATA/emoji/dev/* $DRAFT/emoji
+rm $DRAFT/emoji/emoji-data.txt
+rm $DRAFT/emoji/emoji-variation-sequences.txt
+
+echo "--------------------"
+echo "Copy files from elsewhere:"
+echo "- Unihan.zip to $DRAFT/UCD/ucd"
+echo "- alpha charts to $DRAFT/UCD/charts"
+


### PR DESCRIPTION
Shell script which copies the alpha review files (UCD & emoji) from a local git clone of the unicodetools repo to the folder behind https://www.unicode.org/Public/draft/ (or to a staging area for that).