### PR TITLE
alpha data workflow update: emoji files deduped, zip draft folder

### DIFF
--- a/docs/data-workflow.md
+++ b/docs/data-workflow.md
@@ -98,8 +98,14 @@ and skip any others that are only for internal use.
 For the alpha review, publish (at least) the UCD and emoji files, and the charts.
 
 Run the [pub/copy-alpha-to-draft.sh](https://github.com/unicode-org/unicodetools/blob/main/pub/copy-alpha-to-draft.sh)
-on the unicode.org server which copies the set of the .../dev/ data files for an alpha snapshot
-from a unicodetools workspace to the location behind https://www.unicode.org/Public/draft/ .
+script from an up-to-date repo workspace.
+The script copies the set of the .../dev/ data files for an alpha snapshot
+from a unicodetools workspace to a target folder with the layout of https://www.unicode.org/Public/draft/ .
+
+Go into the “draft” target folder and zip its contents. Send the zip file to Rick for posting.
+Ask Rick to add other files that are not tracked in the unicodetools repo:
+*   Unihan.zip to .../draft/UCD/ucd
+*   alpha charts to .../draft/UCD/charts
 
 Note: No version/delta infixes in names of data files.
 We simply use the “draft” folder and the file-internal time stamps for versioning.

--- a/pub/copy-alpha-to-draft.sh
+++ b/pub/copy-alpha-to-draft.sh
@@ -18,8 +18,6 @@ rm $DRAFT/UCD/ucd/zipped-ReadMe.txt
 
 mkdir -p $DRAFT/emoji
 cp $UNITOOLS_DATA/emoji/dev/* $DRAFT/emoji
-rm $DRAFT/emoji/emoji-data.txt
-rm $DRAFT/emoji/emoji-variation-sequences.txt
 
 echo "--------------------"
 echo "Copy files from elsewhere:"


### PR DESCRIPTION
@nedley de-duplicated two emoji files in PR #397 so the copy-alpha script need not delete those any more.

Workflow: Don't assume that the script is run on the unicode.org server; send Rick a zip file with the contents of the “draft” target folder.