### PR TITLE
fix(build): jsp: fix checkout for push to GCR

### DIFF
--- a/.github/workflows/push-jsp-on-tag.yml
+++ b/.github/workflows/push-jsp-on-tag.yml
@@ -25,12 +25,15 @@ jobs:
         restore-keys: |
           cldr-${{ steps.cldr_ref.outputs.CLDR_REF }}
     - name: Check out CLDR
-      uses: actions/checkout@v1.2  # yes, v1 due to https://github.com/actions/checkout/issues/265
+      uses: actions/checkout@v3
       with:
         repository: unicode-org/cldr
         path: cldr
-        ref: ${{ steps.cldr_ref.outputs.CLDR_REF }}
-    - name: Backup Unicodetools and CLDR for jsps
+        ref: main
+        fetch-depth: 0
+    - name: Switch CLDR to CLDR_REF
+      run: cd cldr && git fetch && git checkout ${{ steps.cldr_ref.outputs.CLDR_REF }}
+    - name: Backup Unicodetools and CLDR for jsps  # this is needed only for the Docker build
       run:
         mkdir -p UnicodeJsps/target && tar -cpz --exclude=.git -f UnicodeJsps/target/cldr-unicodetools.tgz ./cldr ./unicodetools
     - name: Cache local Maven repository
@@ -61,6 +64,6 @@ jobs:
         registry: us.gcr.io
         project_id: dev-infra-273822
         image_name: unicode-jsps
-        image_tag: ${{ steps.get_tag_name.outputs.GIT_TAG_NAME}}
+        image_tag: ${{ steps.get_tag_name.outputs.GIT_TAG_NAME }}
         dockerfile: ./UnicodeJsps/Dockerfile
         context: ./UnicodeJsps/

--- a/UnicodeJsps/.gitignore
+++ b/UnicodeJsps/.gitignore
@@ -2,3 +2,6 @@
 
 !/jetty.d
 /target
+
+# copied via update-bidic-ucd.sh
+/src/main/resources/org/unicode/jsp/bidiref1/ucd


### PR DESCRIPTION
#271

understandably, they've removed v1.2 as a tag. But the SHA is still there

We need this version because we need the functionality to checkout a short hash (from the CLDR pom version)