### PR TITLE
Add CI workflow to prevent Maven cache from getting evicted

### DIFF
--- a/.github/workflows/cache_retain.yml
+++ b/.github/workflows/cache_retain.yml
@@ -55,4 +55,4 @@ jobs:
       # invoked and the job completes successfully.
       #
       # It seems sufficient for the CI job here to finish successfully by
-      # trivially run nothing.
+      # trivially running nothing.

--- a/.github/workflows/cache_retain.yml
+++ b/.github/workflows/cache_retain.yml
@@ -1,0 +1,58 @@
+# Copyright (C) 2023 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+#
+# This workflow is designed to keep specific caches on the main
+# branch from getting evicted according to the Github Actions policy
+# (currently in 2023: 7 days) in cases where the cost to construct
+# the cache is high, especially in cases where there is flakiness
+# (ex: network loss / throttling when downloading artifacts) involved in
+# constructing the cache.
+#
+# Preventing a cache from eviction using this workflow requires that:
+#  - the cache is not too big that it starves other caches 
+#    from using the shared cache quota for the repository
+#  - the cache key is specific enough to avoid cache collisions, according
+#    to good cache key design
+#  - the cache key is not overly specific to cause unnecessary cache misses
+#    (resulting in duplicate caches values, thereby wasting space), according
+#    to good cache key design
+#  - For more details, see: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
+
+name: Retain Specific Caches
+
+on:
+  schedule:
+    # Because the Github Actions cache eviction policy is every 7 days,
+    # this cron schedule is set to run every 6 days to ensure retention
+    - cron: '0 12 */6 * *'
+
+jobs:
+  retain-maven-cache:
+    name: Run all tests with Maven
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout and setup
+        uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Set up out-of-source output dir
+        run: |
+          mkdir -p unicodetools/mine/Generated/BIN
+
+      # Omitting running any build instructions.
+      #
+      # The point is to touch the cache before the TTL causes it to get evicted.
+      # For Github Actions, the cache is preserved only when the cache action is
+      # invoked and the job completes successfully.
+      #
+      # It seems sufficient for the CI job here to finish successfully by
+      # trivially run nothing.


### PR DESCRIPTION
Fixes #421 

This is basically a copy of the [ICU CI workflow](https://github.com/unicode-org/icu/blob/main/.github/workflows/cache_retain.yml) that does the same. Except that instead of doing _something_, I think doing _nothing_ is sufficient because the Github's cache action only cares about the job success status.

cc @eggrobin 