### PR TITLE
Add an invariant test for compatibility with Unicode 3 identifier definitions

### DIFF
--- a/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
@@ -324,6 +324,24 @@ In \p{sc=Cher} scf = suc
 \p{ID_Continue} ⊇ \p{XID_Continue}
 \p{ID_Start} ⊇ \p{XID_Start}
 
+# Not a stability policy, but we probably should avoid breaking it further:
+# The sets \p{ID_Start} and and \p{ID_Continue} preserve backward compatibility
+# with the General_Category-based identifier definition from Unicode 3.0, except
+# for \p{Cf}, which was ignored in identifier comparison, and for one—thankfully
+# obscure—letter added to \p{Pattern_Syntax} in Unicode 5.1.
+# See https://www.unicode.org/versions/Unicode3.0.0/ch05.pdf#page=31.
+#
+# NOTE: If this invariant needs to change, the section on migrating from the
+#       Unicode 3.0 identifier definition in UTS #55 must be updated:
+#       https://unicode.org/reports/tr55/#Evolution-Unicode-3.
+Let $identifier_start = [\p{GC=Lu}\p{GC=Ll}\p{GC=Lt}\p{GC=Lm}\p{GC=Lo}\p{GC=Nl}]
+Let $identifier_extend = [\p{GC=Mn}\p{GC=Mc}\p{GC=Nd}\p{GC=Pc}]
+[\p{ID_Start}]    ⊇ $identifier_start
+[\p{ID_Continue}] ⊇ [$identifier_start $identifier_extend]
+
+[\p{XID_Start}]    ⊇ [$identifier_start-\p{NFKC_QC=No}]
+[\p{XID_Continue}] ⊇ [[$identifier_start $identifier_extend]-\p{NFKC_QC=No}]
+
 ##########################
 # Normalization
 ##########################

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
@@ -333,7 +333,7 @@ In \p{sc=Cher} scf = suc
 #
 # NOTE: If this invariant needs to change, the section on migrating from the
 #       Unicode 3.0 identifier definition in UTS #55 must be updated:
-#       https://unicode.org/reports/tr55/#Evolution-Unicode-3.
+#       https://www.unicode.org/reports/tr55/#Evolution-Unicode-3.
 Let $identifier_start = [\p{GC=Lu}\p{GC=Ll}\p{GC=Lt}\p{GC=Lm}\p{GC=Lo}\p{GC=Nl}]
 Let $identifier_extend = [\p{GC=Mn}\p{GC=Mc}\p{GC=Nd}\p{GC=Pc}]
 [\p{ID_Start}\p{Name=VERTICAL TILDE}]    ⊇ $identifier_start

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
@@ -336,11 +336,11 @@ In \p{sc=Cher} scf = suc
 #       https://unicode.org/reports/tr55/#Evolution-Unicode-3.
 Let $identifier_start = [\p{GC=Lu}\p{GC=Ll}\p{GC=Lt}\p{GC=Lm}\p{GC=Lo}\p{GC=Nl}]
 Let $identifier_extend = [\p{GC=Mn}\p{GC=Mc}\p{GC=Nd}\p{GC=Pc}]
-[\p{ID_Start}]    ⊇ $identifier_start
-[\p{ID_Continue}] ⊇ [$identifier_start $identifier_extend]
+[\p{ID_Start}\p{Name=VERTICAL TILDE}]    ⊇ $identifier_start
+[\p{ID_Continue}\p{Name=VERTICAL TILDE}] ⊇ [$identifier_start $identifier_extend]
 
-[\p{XID_Start}]    ⊇ [$identifier_start-\p{NFKC_QC=No}]
-[\p{XID_Continue}] ⊇ [[$identifier_start $identifier_extend]-\p{NFKC_QC=No}]
+[\p{XID_Start}\p{Name=VERTICAL TILDE}]    ⊇ [$identifier_start-\p{NFKC_QC=No}]
+[\p{XID_Continue}\p{Name=VERTICAL TILDE}] ⊇ [[$identifier_start $identifier_extend]-\p{NFKC_QC=No}]
 
 ##########################
 # Normalization


### PR DESCRIPTION
There is one exception, we should avoid adding more.

See discussion in https://github.com/unicode-org/unicode-reports/pull/67#discussion_r1163796866.

(Expected) test failure at e677c9a8ffa9b48d1cfa8488216d17b6782fa7c8:
```
[\p{ID_Start}] ⊇ $identifier_start

**** START Test Failure 1 ****
## Expected empty, got: 1 [\u2E2F]

## In $identifier_start

## But Not In [\p{ID_Start}]

2E2F	#		(ⸯ)	VERTICAL TILDE
**** END Test Failure 1 ****

[\p{ID_Continue}] ⊇ [$identifier_start $identifier_extend]

**** START Test Failure 2 ****
## Expected empty, got: 1 [\u2E2F]

## In [$identifier_start $identifier_extend]

## But Not In [\p{ID_Continue}]

2E2F	#		(ⸯ)	VERTICAL TILDE
**** END Test Failure 2 ****


[\p{XID_Start}] ⊇ [$identifier_start-\p{NFKC_QC=No}]

**** START Test Failure 3 ****
## Expected empty, got: 1 [\u2E2F]

## In [$identifier_start-\p{NFKC_QC=No}]

## But Not In [\p{XID_Start}]

2E2F	#		(ⸯ)	VERTICAL TILDE
**** END Test Failure 3 ****

[\p{XID_Continue}] ⊇ [[$identifier_start $identifier_extend]-\p{NFKC_QC=No}]

**** START Test Failure 4 ****
## Expected empty, got: 1 [\u2E2F]

## In [[$identifier_start $identifier_extend]-\p{NFKC_QC=No}]

## But Not In [\p{XID_Continue}]

2E2F	#		(ⸯ)	VERTICAL TILDE
**** END Test Failure 4 ****
```