### PR TITLE
Sort scx based on script codes rather than aliases.

### DIFF
--- a/unicodetools/src/main/java/org/unicode/text/UCD/ScriptExtensions.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/ScriptExtensions.java
@@ -25,8 +25,8 @@ public class ScriptExtensions {
                     if (o1.equals(o2)) {
                         return 0;
                     }
-                    final String n1 = getNames(o1, UCD_Types.LONG, " ");
-                    final String n2 = getNames(o2, UCD_Types.LONG, " ");
+                    final String n1 = getNames(o1, UCD_Types.SHORT, " ");
+                    final String n2 = getNames(o2, UCD_Types.SHORT, " ");
                     return n1.compareToIgnoreCase(n2);
                 }
             };


### PR DESCRIPTION
Regenerating the UCD currently flips `# Script_Extensions=Arab Nkoo` and `# Script_Extensions=Arab Rohg`, as was noted by @markusicu in https://github.com/unicode-org/unicodetools/pull/416#issuecomment-1456708673. This is very annoying in the new world where we want to have many draft PRs in flight for a long time, requiring frequent regeneration of the UCD.

This is happening because #398 ordered these inconsistently with the order produced by `MakeUnicodeFiles`. That was intentional: the pull request description reads
> Sort scripts, first by count, and then alphabetically

This was already the case, but the sorting was alphabetical by alias, rather than script code, and `Rohg`=`Hanifi_Rohingya`<`Nko`=`Nkoo`. The alternative to this PR would be for @roozbehp to change the logic in https://github.com/roozbehp/unicode-data/blob/67fa2d1bcb4dca1e8f296f1ffca59a3011718179/common.py#L27-L28 to sort `script_set` by alias, but since codes are what shows up in the file, sorting by code seems reasonable enough.
