### PR TITLE
Test that Joining_Group refines Joining_Type

### DIFF
--- a/unicodetools/src/test/java/org/unicode/propstest/TestProperties.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/TestProperties.java
@@ -213,6 +213,33 @@ public class TestProperties extends TestFmwkMinusMinus {
     }
 
     @Test
+    public void TestJoiningGroupConsistency() {
+        // TODO(egg): I would like to be able to put that in the invariants tests as « the partition
+        // defined by Joining_Group is finer than that defined by Joining_Type ».
+        UnicodeMap<String> joiningGroup = iup.load(UcdProperty.Joining_Group);
+        UnicodeMap<String> joiningType = iup.load(UcdProperty.Joining_Type);
+        var charactersByJoiningGroup = new HashMap<String, UnicodeSet>();
+        joiningGroup.addInverseTo(charactersByJoiningGroup).remove("No_Joining_Group");
+        charactersByJoiningGroup.forEach(
+                (group, set) -> {
+                    final int first = set.getRangeStart(0);
+                    final String firstType = joiningType.get(first);
+                    set.forEach(
+                            (c) -> {
+                                assertEquals(
+                                        Utility.hex(c)
+                                                + " and "
+                                                + Utility.hex(first)
+                                                + " have different joining types but are in the"
+                                                + " same joining group "
+                                                + group,
+                                        joiningType.get(c),
+                                        firstType);
+                            });
+                });
+    }
+
+    @Test
     public void TestScripts() {
 
         logln("New chars: " + newChars.size());

--- a/unicodetools/src/test/java/org/unicode/propstest/TestProperties.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/TestProperties.java
@@ -227,14 +227,14 @@ public class TestProperties extends TestFmwkMinusMinus {
                     set.forEach(
                             (c) -> {
                                 assertEquals(
-                                        Utility.hex(c)
+                                        Utility.hex(first)
                                                 + " and "
-                                                + Utility.hex(first)
+                                                + Utility.hex(c)
                                                 + " have different joining types but are in the"
                                                 + " same joining group "
                                                 + group,
-                                        joiningType.get(c),
-                                        firstType);
+                                        firstType,
+                                        joiningType.get(c));
                             });
                 });
     }

--- a/unicodetools/src/test/java/org/unicode/propstest/TestProperties.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/TestProperties.java
@@ -227,12 +227,14 @@ public class TestProperties extends TestFmwkMinusMinus {
                     set.forEach(
                             (c) -> {
                                 assertEquals(
-                                        Utility.hex(first)
-                                                + " and "
-                                                + Utility.hex(c)
-                                                + " have different joining types but are in the"
-                                                + " same joining group "
-                                                + group,
+                                        "U+"
+                                                + getCodeAndName(Character.toString(first))
+                                                + "\nand\nU+"
+                                                + getCodeAndName(c)
+                                                + "\nhave different joining types but are in the"
+                                                + " same joining group ("
+                                                + group
+                                                + ")\n",
                                         firstType,
                                         joiningType.get(c));
                             });


### PR DESCRIPTION
Fix #437.

With this test, #435 fails with the following error:
```
[ERROR] Tests run: 10, Failures: 1, Errors: 0, Skipped: 1, Time elapsed: 2.19 s <<< FAILURE! - in org.unicode.propstest.TestProperties
[ERROR] org.unicode.propstest.TestProperties.TestJoiningGroupConsistency  Time elapsed: 0.03 s  <<< FAILURE!
org.opentest4j.AssertionFailedError:
U+062F (د) ARABIC LETTER DAL
and
U+10EC2 (𐻂) ARABIC LETTER DAL WITH TWO DOTS VERTICALLY BELOW
have different joining types but are in the same joining group (Dal)
 ==> expected: <Right_Joining> but was: <Dual_Joining>
        at org.unicode.propstest.TestProperties.lambda$1(TestProperties.java:229)
        at org.unicode.propstest.TestProperties.lambda$0(TestProperties.java:227)
        at org.unicode.propstest.TestProperties.TestJoiningGroupConsistency(TestProperties.java:223)
```