### PR TITLE
Scripts from the future

### DIFF
--- a/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
@@ -906,6 +906,10 @@ public class MakeUnicodeFiles {
                                             | (1 << UnicodeProperty.NUMERIC)))
                             == 0) {
                 for (final String value : up.getAvailableValues()) {
+                    if (propName.equals("Script") && up.getSet(value).isEmpty() &&
+                        !value.equals("Katakana_Or_Hiragana")) {
+                        continue;
+                    }
                     final List<String> l = up.getValueAliases(value);
                     // HACK
                     if (isJoiningGroup && value.equals("Hamzah_On_Ha_Goal")) {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
@@ -906,8 +906,9 @@ public class MakeUnicodeFiles {
                                             | (1 << UnicodeProperty.NUMERIC)))
                             == 0) {
                 for (final String value : up.getAvailableValues()) {
-                    if (propName.equals("Script") && up.getSet(value).isEmpty() &&
-                        !value.equals("Katakana_Or_Hiragana")) {
+                    if (propName.equals("Script")
+                            && up.getSet(value).isEmpty()
+                            && !value.equals("Katakana_Or_Hiragana")) {
                         continue;
                     }
                     final List<String> l = up.getValueAliases(value);

--- a/unicodetools/src/main/java/org/unicode/text/UCD/UCD_Names.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/UCD_Names.java
@@ -408,6 +408,19 @@ public final class UCD_Names implements UCD_Types {
         // Unicode 15
         "Kawi",
         "Nag_Mundari",
+        // A future version of Unicode
+        "Sunuwar",
+        "Tulu_Tigalari",
+        "Kirat_Rai",
+        "Todhri",
+        "Garay",
+        "Gurung_Khema",
+        "Ol_Onal",
+        // Provisionally assigned
+        "Sidetic",
+        "Chisoi",
+        "Tolong_Siki",
+        "Tai_Yo",
     };
 
     public static final Relation<String, String> EXTRA_SCRIPT =
@@ -592,6 +605,19 @@ public final class UCD_Names implements UCD_Types {
         // Unicode 15
         "Kawi",
         "Nagm",
+        // A future version of Unicode
+        "Qaba",
+        "Qabb",
+        "Qabc",
+        "Qabd",
+        "Qabe",
+        "Qabf",
+        "Qabg",
+        // Provisionally assigned
+        "Qabh",
+        "Qabi",
+        "Qabj",
+        "Qabk",
     };
 
     static final String[] SHORT_AGE = {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/UCD_Types.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/UCD_Types.java
@@ -588,7 +588,20 @@ public interface UCD_Types {
             // Unicode 15
             Kawi = 164,
             Nag_Mundari = 165,
-            LIMIT_SCRIPT = Nag_Mundari + 1;
+            // A future version of Unicode
+            Sunuwar = 166,
+            Tulu_Tigalari = 167,
+            Kirat_Rai = 168,
+            Todhri = 169,
+            Garay = 170,
+            Gurung_Khema = 171,
+            Ol_Onal = 172,
+            // Provisionally assigned
+            Sidetic = 173,
+            Chisoi = 174,
+            Tolong_Siki  = 175,
+            Tai_Yo = 176,
+            LIMIT_SCRIPT = Tai_Yo + 1;
 
     // Bidi_Paired_Bracket_Type
     public static final byte BPT_N = 0, BPT_O = 1, BPT_C = 2, LIMIT_BPT = 3;

--- a/unicodetools/src/main/java/org/unicode/text/UCD/UCD_Types.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/UCD_Types.java
@@ -599,7 +599,7 @@ public interface UCD_Types {
             // Provisionally assigned
             Sidetic = 173,
             Chisoi = 174,
-            Tolong_Siki  = 175,
+            Tolong_Siki = 175,
             Tai_Yo = 176,
             LIMIT_SCRIPT = Tai_Yo + 1;
 


### PR DESCRIPTION
Eventually we should get rid of UCD_Names and UCD_Types, but in the meantime MakeUnicodeFiles depends on them.
While we might hope to make merging of data files painless with #419, this is not going to happen for Java, and since these files are not generated, we should avoid having to resolve merge conflicts there.

At the same time, since the plan is to do the propertizing ahead of the ISO 15924 registration, we need to make sure the private use codes for the pipeline do not collide.

Thus this PR propels UCD_Names and UCD_Types into the distant future, while ensuring that the future scripts do not show up in the generated files. Note that GenerateEnums will not pick those up, since that is based on PVA from which they are suppressed in MakeUnicodeFiles.