### PR TITLE
Regenerate EAW and VO, fix a UnicodeSet bug

### DIFF
--- a/unicodetools/data/ucd/dev/EastAsianWidth.txt
+++ b/unicodetools/data/ucd/dev/EastAsianWidth.txt
@@ -1,11 +1,11 @@
 # EastAsianWidth-15.1.0.txt
-# Date: 2022-11-16, 09:33:27 GMT [KW, LI]
-# © 2022 Unicode®, Inc.
+# Date: 2023-04-19, 18:36:42 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #
 # Unicode Character Database
-# For documentation, see https://www.unicode.org/reports/tr44/
+#   For documentation, see https://www.unicode.org/reports/tr44/
 #
 # East_Asian_Width Property
 #
@@ -30,11 +30,10 @@
 # Character ranges are specified as for other property files in the
 # Unicode Character Database.
 #
-# For legacy reasons, there are no spaces before or after the semicolon
-# which separates the two fields. The comments following the number sign
-# "#" list the General_Category property value or the L& alias of the
-# derived value LC, the Unicode character name or names, and, in lines
-# with ranges of code points, the code point count in square brackets.
+# The comments following the number sign "#" list the General_Category
+# property value or the L& alias of the derived value LC, the Unicode
+# character name or names, and, in lines with ranges of code points,
+# the code point count in square brackets.
 #
 # For more information, see UAX #11: East Asian Width,
 # at https://www.unicode.org/reports/tr11/

--- a/unicodetools/data/ucd/dev/LineBreak.txt
+++ b/unicodetools/data/ucd/dev/LineBreak.txt
@@ -1,5 +1,5 @@
 # LineBreak-15.1.0.txt
-# Date: 2023-04-15, 00:27:09 GMT
+# Date: 2023-04-19, 18:36:42 GMT
 # © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -42,11 +42,10 @@
 # Character ranges are specified as for other property files in the
 # Unicode Character Database.
 #
-# For legacy reasons, there are no spaces before or after the semicolon
-# which separates the two fields. The comments following the number sign
-# "#" list the General_Category property value or the L& alias of the
-# derived value LC, the Unicode character name or names, and, in lines
-# with ranges of code points, the code point count in square brackets.
+# The comments following the number sign "#" list the General_Category
+# property value or the L& alias of the derived value LC, the Unicode
+# character name or names, and, in lines with ranges of code points,
+# the code point count in square brackets.
 #
 # For more information, see UAX #14: Unicode Line Breaking Algorithm,
 # at https://www.unicode.org/reports/tr14/

--- a/unicodetools/data/ucd/dev/VerticalOrientation.txt
+++ b/unicodetools/data/ucd/dev/VerticalOrientation.txt
@@ -1,11 +1,11 @@
 # VerticalOrientation-15.1.0.txt
-# Date: 2022-11-16, 09:36:32 GMT [KW, LI]
-# © 2022 Unicode®, Inc.
+# Date: 2023-04-19, 18:25:32 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #
 # Unicode Character Database
-# For documentation, see https://www.unicode.org/reports/tr44/
+#   For documentation, see https://www.unicode.org/reports/tr44/
 #
 # Vertical_Orientation (vo) Property
 #
@@ -73,7 +73,6 @@
 # the code point count in square brackets.
 #
 # @missing: 0000..10FFFF; R
-
 0000..001F     ; R  # Cc    [32] <control-0000>..<control-001F>
 0020           ; R  # Zs         SPACE
 0021..0023     ; R  # Po     [3] EXCLAMATION MARK..NUMBER SIGN

--- a/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
@@ -1105,12 +1105,14 @@ public class MakeUnicodeFiles {
                 pwProp.println(SEPARATOR);
             }
             final String propComment = Format.theFormat.getValueComments(name, "");
-            if (propComment != null && propComment.length() != 0) {
-                pwProp.println();
-                pwProp.println(propComment);
-            } else if (!prop.isType(UnicodeProperty.BINARY_MASK) && !ps.kenFile) {
-                pwProp.println();
-                pwProp.println("# Property:\t" + name);
+            if (!ps.kenFile) {
+                if (propComment != null && propComment.length() != 0) {
+                    pwProp.println();
+                    pwProp.println(propComment);
+                } else if (!prop.isType(UnicodeProperty.BINARY_MASK)) {
+                    pwProp.println();
+                    pwProp.println("# Property:\t" + name);
+                }
             }
 
             if (DEBUG) {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/ToolUnicodePropertySource.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/ToolUnicodePropertySource.java
@@ -557,6 +557,10 @@ public class ToolUnicodePropertySource extends UnicodeProperty.Factory {
 
         BaseProperty vo =
                 new UnicodeProperty.SimpleProperty() {
+                    {
+                        setUniformUnassigned(false);
+                    }
+
                     @Override
                     public String _getValue(int codepoint) {
                         return ucd.getVertical_OrientationID(codepoint);

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/MakeUnicodeFiles.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/MakeUnicodeFiles.txt
@@ -772,6 +772,113 @@ Format: kenFile skipValue=Unknown
 #
 Property: Line_Break
 
+File:	EastAsianWidth
+Format: kenFile skipValue=Neutral
+#
+# East_Asian_Width Property
+#
+# This file is a normative contributory data file in the
+# Unicode Character Database.
+#
+# The format is two fields separated by a semicolon.
+# Field 0: Unicode code point value or range of code point values
+# Field 1: East_Asian_Width property, consisting of one of the following values:
+#         "A", "F", "H", "N", "Na", "W"
+#  - All code points, assigned or unassigned, that are not listed
+#      explicitly are given the value "N".
+#  - The unassigned code points in the following blocks default to "W":
+#         CJK Unified Ideographs Extension A: U+3400..U+4DBF
+#         CJK Unified Ideographs:             U+4E00..U+9FFF
+#         CJK Compatibility Ideographs:       U+F900..U+FAFF
+#  - All undesignated code points in Planes 2 and 3, whether inside or
+#      outside of allocated blocks, default to "W":
+#         Plane 2:                            U+20000..U+2FFFD
+#         Plane 3:                            U+30000..U+3FFFD
+#
+# Character ranges are specified as for other property files in the
+# Unicode Character Database.
+#
+# For legacy reasons, there are no spaces before or after the semicolon
+# which separates the two fields. The comments following the number sign
+# "#" list the General_Category property value or the L& alias of the
+# derived value LC, the Unicode character name or names, and, in lines
+# with ranges of code points, the code point count in square brackets.
+#
+# For more information, see UAX #11: East Asian Width,
+# at https://www.unicode.org/reports/tr11/
+#
+Property: East_Asian_Width
+
+File:	VerticalOrientation
+Format: kenFile skipValue=Rotated
+#
+# Vertical_Orientation (vo) Property
+#
+# This file defines the Vertical_Orientation property. See UAX #50:
+# Unicode Vertical Text Layout, at https://www.unicode.org/reports/tr50/
+#
+# The format of the file is two fields separated by a semicolon.
+# Field 0: Unicode code point value or range of code point values in
+#   hexadecimal form
+# Field 1: Vertical_Orientation property value, one of the following:
+#   U - Upright, the same orientation as in the code charts
+#   R - Rotated 90 degrees clockwise compared to the code charts
+#   Tu - Transformed typographically, with fallback to Upright
+#   Tr - Transformed typographically, with fallback to Rotated
+#
+#  - Certain ranges of unassigned code points default to U. These ranges
+#      are mostly associated with CJK scripts and punctuation, or with
+#      a small number of other scripts which are predominantly Upright.
+#      The private use areas also default to U, because of their most
+#      common use for CJK. In the following list of explicit code points
+#      and ranges, all unassigned code points default to U:
+#         Canadian Syllabics Extended:        U+18B0..U+18FF
+#         Reserved Default_Ignorable_Code_Point:      U+2065
+#         Number Forms:                       U+2150..U+218F
+#         Control Pictures & OCR              U+2400..U+245F
+#         Symbols:                            U+2BB8..U+2BFF
+#         CJK-Related & Yi:                   U+2E80..U+A4CF
+#         Hangul Jamo Extended-A:             U+A960..U+A97F
+#         Hangul Syllables & Jamo Extended-B: U+AC00..U+D7FF
+#         PUA & CJK Compatibility Ideographs: U+E000..U+FAFF
+#         Vertical Forms:                     U+FE10..U+FE1F
+#         Small Form Variants:                U+FE50..U+FE6F
+#         Fullwidth Forms:                            U+FFE7
+#         Specials:                           U+FFF0..U+FFF8
+#         Siddham:                           U+11580..U+115FF
+#         Zanabazar Square & Soyombo:        U+11A00..U+11AAF
+#         Egyptian Hieroglyphs & Controls:   U+13000..U+1345F
+#         Anatolian Hieroglyphs:             U+14400..U+1467F
+#         Ideographic Symbols & Tangut:      U+16FE0..U+18AFF
+#         Khitan Small Script & Tangut Sup:  U+18B00..U+18D7F
+#         Kana Extended-B:                   U+1AFF0..U+1AFFF
+#         Kana Extended-A & Small Kana Ext:  U+1B100..U+1B16F
+#         Nushu:                             U+1B170..U+1B2FF
+#         Musical Symbols:                   U+1CF00..U+1CFCF
+#         Musical Symbols:                   U+1D000..U+1D1FF
+#         Mayan Numerals:                    U+1D2E0..U+1D2FF
+#         Symbols & Rods:                    U+1D300..U+1D37F
+#         Sutton SignWriting:                U+1D800..U+1DAAF
+#         Game Symbols:                      U+1F000..U+1F0FF
+#         Enclosed Symbols:                  U+1F100..U+1F2FF
+#         Symbols:                           U+1F680..U+1F7FF
+#         Symbols and Pictographs:           U+1F900..U+1F9FF
+#         Chess Symbols & Pictographs Ext-A: U+1FA00..U+1FAFF
+#         Plane 2:                           U+20000..U+2FFFD
+#         Plane 3:                           U+30000..U+3FFFD
+#         Plane 15 PUA:                      U+F0000..U+FFFFD
+#         Plane 16 PUA:                     U+100000..U+10FFFD
+#
+#  - All other code points, assigned and unassigned, that are not listed
+#      explicitly in the data section of this file are given the value R.
+#
+# The comments following the number sign "#" list the General_Category
+# property value or the L& alias of the derived value LC, the Unicode
+# character name or names, and, in lines with ranges of code points,
+# the code point count in square brackets.
+#
+Property: VerticalOrientation
+
 File:	SpecialCasing
 Property: SPECIAL
 
@@ -824,9 +931,7 @@ sorts by the short name
 ArabicShaping
 BidiMirroring
 CompositionExclusions
-EastAsianWidth
 StandardizedVariants
 UnicodeData
-VerticalOrientation
 
 

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/MakeUnicodeFiles.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/MakeUnicodeFiles.txt
@@ -761,11 +761,10 @@ Format: kenFile skipValue=Unknown
 # Character ranges are specified as for other property files in the
 # Unicode Character Database.
 #
-# For legacy reasons, there are no spaces before or after the semicolon
-# which separates the two fields. The comments following the number sign
-# "#" list the General_Category property value or the L& alias of the
-# derived value LC, the Unicode character name or names, and, in lines
-# with ranges of code points, the code point count in square brackets.
+# The comments following the number sign "#" list the General_Category
+# property value or the L& alias of the derived value LC, the Unicode
+# character name or names, and, in lines with ranges of code points,
+# the code point count in square brackets.
 #
 # For more information, see UAX #14: Unicode Line Breaking Algorithm,
 # at https://www.unicode.org/reports/tr14/
@@ -798,11 +797,10 @@ Format: kenFile skipValue=Neutral
 # Character ranges are specified as for other property files in the
 # Unicode Character Database.
 #
-# For legacy reasons, there are no spaces before or after the semicolon
-# which separates the two fields. The comments following the number sign
-# "#" list the General_Category property value or the L& alias of the
-# derived value LC, the Unicode character name or names, and, in lines
-# with ranges of code points, the code point count in square brackets.
+# The comments following the number sign "#" list the General_Category
+# property value or the L& alias of the derived value LC, the Unicode
+# character name or names, and, in lines with ranges of code points,
+# the code point count in square brackets.
 #
 # For more information, see UAX #11: East Asian Width,
 # at https://www.unicode.org/reports/tr11/


### PR DESCRIPTION
Follow-up on #438: MakeUnicodeFiles now does the three Ken files.

Correct an obsolete comment in LB and EAW.

Also fix the VerticalOrientation property created by ToolUnicodePropertySource, which caused UnicodeSet to be wrong about sets based on VO: compare

https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3ACn%3A%5D%26%5B%3Ablk%3DTangut%3A%5D%26%5B%3AVO%3DU%3A%5D&g=&i=

and 

https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3ACn%3A%5D%26%5B%3Ablk%3DTangut%3A%5D&g=VO