### PR TITLE
Fix proposals for sequences containing U+FE0F

### DIFF
--- a/unicodetools/src/main/java/org/unicode/tools/emoji/ChartUtilities.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/ChartUtilities.java
@@ -153,8 +153,6 @@ public class ChartUtilities {
     }
 
     public static String htmlSpanForSkintone(String modifier) {
-        return "<span style=\"display:inline-block;\">"
-                + modifier
-                + "</span>";
+        return "<span style=\"display:inline-block;\">" + modifier + "</span>";
     }
 }

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/ChartUtilities.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/ChartUtilities.java
@@ -151,4 +151,10 @@ public class ChartUtilities {
     public static String getDoubleLink(String anchor) {
         return getDoubleLink(anchor, anchor);
     }
+
+    public static String htmlSpanForSkintone(String modifier) {
+        return "<span style=\"display:inline-block;\">"
+                + modifier
+                + "</span>";
+    }
 }

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/CountEmoji.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/CountEmoji.java
@@ -484,9 +484,7 @@ public class CountEmoji {
             _html =
                     _html.replace(
                             Attribute.skin.label,
-                            "<span style=\"display:inline-block;\">"
-                                    + Attribute.skin.label
-                                    + "</span>");
+                            ChartUtilities.htmlSpanForSkintone(Attribute.skin.label));
             html = title == null ? _html : "<span title='" + title + "'>" + _html + "</span>";
         }
 

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/EmojiData.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/EmojiData.java
@@ -140,6 +140,8 @@ public class EmojiData implements EmojiDataSource {
                             .addAll(Emoji.ZWJ_GENDER_MARKERS)
                             .addAll(Emoji.FULL_ZWJ_GENDER_MARKERS)
                             .freeze());
+    public static final UnicodeSetSpanner GENDER_SPANNER =
+            new UnicodeSetSpanner(new UnicodeSet(Emoji.GENDER_MARKERS).freeze());
     public static final UnicodeSetSpanner SKIN_SPANNER =
             new UnicodeSetSpanner(new UnicodeSet(MODIFIERS).freeze());
 

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/ProposalData.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/ProposalData.java
@@ -46,7 +46,7 @@ public class ProposalData {
     private static final String DEBUG_STRING = EmojiConstants.fromCodePoints(0x1F9AC).toString();
 
     private static final String MISSING_PROPOSAL = "MISSING";
-    private static final String GENDER_REPRESENTATIVE = "\u2640";
+    private static final String GENDER_REPRESENTATIVE = Emoji.FEMALE;
     private static final String SKIN_REPRESENTATIVE = "🏿";
     static final Splitter SPLITTER_SEMI = Splitter.on(';').trimResults();
     static final Splitter SPLITTER_SEMI_HASH = Splitter.on(Pattern.compile("[#;]")).trimResults();
@@ -334,6 +334,10 @@ public class ProposalData {
         return result;
     }
 
+    public static String removeEmojiVariant(String s) {
+        return s.replace(Emoji.EMOJI_VARIANT_STRING, "");
+    }
+
     /**
      * Normalize to woman, darkskin, no FE0F
      *
@@ -341,14 +345,15 @@ public class ProposalData {
      * @return
      */
     public static String getSkeleton(String code) {
-        code = code.trim().replace("\uFE0F", "");
+        code = removeEmojiVariant(code);
         if (CharSequences.getSingleCodePoint(code) != Integer.MAX_VALUE) {
             return code;
         }
         String result =
                 EmojiData.SKIN_SPANNER.replaceFrom(
-                        code.replace(Emoji.EMOJI_VARIANT_STRING, "")
-                                .replace("\u2642", GENDER_REPRESENTATIVE),
+                        EmojiData.GENDER_SPANNER.replaceFrom(
+                                code,
+                                GENDER_REPRESENTATIVE),
                         SKIN_REPRESENTATIVE);
         String shorter = shortestForm(result);
         return shorter == null ? result : shorter;
@@ -545,8 +550,18 @@ public class ProposalData {
                             + "the <a target='doc-registry' href='https://www.unicode.org/L2/L2007/07118.htm'>agreement to form a new Symbols Subcommittee</a> (use Find on page… » C.7.3)</li></ul>\n"
                             + "\n"
                             + "<p>This file is abbreviated by replacing certain characters that are always included in the same proposal:</p>"
-                            + "<ul><li>skintones (🏻 🏼 🏽 🏾 🏿) by "
-                            + SKIN_REPRESENTATIVE
+                            + "<ul><li>skintones ("
+                            + ChartUtilities.htmlSpanForSkintone(UTF16.valueOf(0x1F3FB))
+                            + " "
+                            + ChartUtilities.htmlSpanForSkintone(UTF16.valueOf(0x1F3FC))
+                            + " "
+                            + ChartUtilities.htmlSpanForSkintone(UTF16.valueOf(0x1F3FD))
+                            + " "
+                            + ChartUtilities.htmlSpanForSkintone(UTF16.valueOf(0x1F3FE))
+                            + " "
+                            + ChartUtilities.htmlSpanForSkintone(UTF16.valueOf(0x1F3FF))
+                            + ") by "
+                            + ChartUtilities.htmlSpanForSkintone(SKIN_REPRESENTATIVE)
                             + "</li>\n"
                             + "<li>gender signs (♀️ ♂️) by "
                             + GENDER_REPRESENTATIVE
@@ -616,7 +631,7 @@ public class ProposalData {
                 MajorGroup lastMajor = null;
                 for (String s : yearSet) {
                     String skeleton = getSkeleton(s);
-                    if (!s.equals(skeleton)) {
+                    if (!removeEmojiVariant(s).equals(skeleton)) {
                         continue;
                     }
                     // handle special case for multi-skintones

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/ProposalData.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/ProposalData.java
@@ -351,9 +351,7 @@ public class ProposalData {
         }
         String result =
                 EmojiData.SKIN_SPANNER.replaceFrom(
-                        EmojiData.GENDER_SPANNER.replaceFrom(
-                                code,
-                                GENDER_REPRESENTATIVE),
+                        EmojiData.GENDER_SPANNER.replaceFrom(code, GENDER_REPRESENTATIVE),
                         SKIN_REPRESENTATIVE);
         String shorter = shortestForm(result);
         return shorter == null ? result : shorter;


### PR DESCRIPTION
While reviewing charts I discovered a longstanding issue with the one for proposals “by emoji”: it was omitting all sequences containing U+FE0F due to an overzealous skeleton comparison. For example, if you look at https://www.unicode.org/emoji/charts-15.0/emoji-proposals.html the proposal for heart on fire is listed but that is the only reference to that proposal on the page, plus the pilot sequences are missing (among others).

This also applies the fix for #95 to the proposals chart.