### PR TITLE
IDNA 15.1: new CJK; no NFD validity check

### DIFF
--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestJsp.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestJsp.java
@@ -913,7 +913,7 @@ public class TestJsp extends TestFmwkMinusMinus {
         logln(uts46unic + ", " + error[0]);
         checkValues(error, Uts46.SINGLETON);
         checkValidIdna(Uts46.SINGLETON, "À｡÷");
-        checkInvalidIdna(Uts46.SINGLETON, "≠");
+        checkValidIdna(Uts46.SINGLETON, "≠"); // valid since Unicode 15.1
         checkInvalidIdna(Uts46.SINGLETON, "\u0001");
         checkToUnicode(Uts46.SINGLETON, "ß｡ab", "ß.ab");
         // checkToPunyCode(Uts46.SINGLETON, "\u0002", "xn---");
@@ -939,7 +939,7 @@ public class TestJsp extends TestFmwkMinusMinus {
 
         Uts46.SINGLETON.isValid("≠");
         assertTrue("uts46 a", Uts46.SINGLETON.isValid("a"));
-        assertFalse("uts46 not equals", Uts46.SINGLETON.isValid("≠"));
+        assertTrue("uts46 not equals", Uts46.SINGLETON.isValid("≠")); // valid since Unicode 15.1
 
         String testLines = UnicodeJsp.testIdnaLines("ΣΌΛΟΣ", "[]");
         assertContains(testLines, "xn--wxaikc6b");

--- a/unicodetools/data/idna/dev/IdnaMappingTable.txt
+++ b/unicodetools/data/idna/dev/IdnaMappingTable.txt
@@ -1,11 +1,11 @@
 # IdnaMappingTable.txt
-# Date: 2022-05-02, 19:29:26 GMT
-# © 2022 Unicode®, Inc.
+# Date: 2023-05-15, 22:37:02 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #
 # Unicode IDNA Compatible Preprocessing for UTS #46
-# Version: 15.0.0
+# Version: 15.1.0
 #
 # For documentation and usage, see https://www.unicode.org/reports/tr46
 #
@@ -2565,11 +2565,7 @@
 222E          ; valid                  ;      ; NV8    # 1.1  CONTOUR INTEGRAL
 222F          ; mapped                 ; 222E 222E     # 1.1  SURFACE INTEGRAL
 2230          ; mapped                 ; 222E 222E 222E #1.1  VOLUME INTEGRAL
-2231..225F    ; valid                  ;      ; NV8    # 1.1  CLOCKWISE INTEGRAL..QUESTIONED EQUAL TO
-2260          ; disallowed_STD3_valid                  # 1.1  NOT EQUAL TO
-2261..226D    ; valid                  ;      ; NV8    # 1.1  IDENTICAL TO..NOT EQUIVALENT TO
-226E..226F    ; disallowed_STD3_valid                  # 1.1  NOT LESS-THAN..NOT GREATER-THAN
-2270..22F1    ; valid                  ;      ; NV8    # 1.1  NEITHER LESS-THAN NOR EQUAL TO..DOWN RIGHT DIAGONAL ELLIPSIS
+2231..22F1    ; valid                  ;      ; NV8    # 1.1  CLOCKWISE INTEGRAL..DOWN RIGHT DIAGONAL ELLIPSIS
 22F2..22FF    ; valid                  ;      ; NV8    # 3.2  ELEMENT OF WITH LONG HORIZONTAL STROKE..Z NOTATION BAG MEMBERSHIP
 2300          ; valid                  ;      ; NV8    # 1.1  DIAMETER SIGN
 2301          ; valid                  ;      ; NV8    # 3.0  ELECTRIC ARROW
@@ -3273,7 +3269,7 @@
 2FD5          ; mapped                 ; 9FA0          # 3.0  KANGXI RADICAL FLUTE
 2FD6..2FEF    ; disallowed                             # NA   <reserved-2FD6>..<reserved-2FEF>
 2FF0..2FFB    ; disallowed                             # 3.0  IDEOGRAPHIC DESCRIPTION CHARACTER LEFT TO RIGHT..IDEOGRAPHIC DESCRIPTION CHARACTER OVERLAID
-2FFC..2FFF    ; disallowed                             # NA   <reserved-2FFC>..<reserved-2FFF>
+2FFC..2FFF    ; disallowed                             # 15.1 IDEOGRAPHIC DESCRIPTION CHARACTER SURROUND FROM RIGHT..IDEOGRAPHIC DESCRIPTION CHARACTER ROTATION
 3000          ; disallowed_STD3_mapped ; 0020          # 1.1  IDEOGRAPHIC SPACE
 3001          ; valid                  ;      ; NV8    # 1.1  IDEOGRAPHIC COMMA
 3002          ; mapped                 ; 002E          # 1.1  IDEOGRAPHIC FULL STOP
@@ -3425,7 +3421,8 @@
 31BB..31BF    ; valid                                  # 13.0 BOPOMOFO FINAL LETTER G..BOPOMOFO LETTER AH
 31C0..31CF    ; valid                  ;      ; NV8    # 4.1  CJK STROKE T..CJK STROKE N
 31D0..31E3    ; valid                  ;      ; NV8    # 5.1  CJK STROKE H..CJK STROKE Q
-31E4..31EF    ; disallowed                             # NA   <reserved-31E4>..<reserved-31EF>
+31E4..31EE    ; disallowed                             # NA   <reserved-31E4>..<reserved-31EE>
+31EF          ; valid                  ;      ; NV8    # 15.1 IDEOGRAPHIC DESCRIPTION CHARACTER SUBTRACTION
 31F0..31FF    ; valid                                  # 3.2  KATAKANA LETTER SMALL KU..KATAKANA LETTER SMALL RO
 3200          ; disallowed_STD3_mapped ; 0028 1100 0029 #1.1  PARENTHESIZED HANGUL KIYEOK
 3201          ; disallowed_STD3_mapped ; 0028 1102 0029 #1.1  PARENTHESIZED HANGUL NIEUN
@@ -8450,7 +8447,9 @@ FFFE..FFFF    ; disallowed                             # 1.1  <noncharacter-FFFE
 2B820..2CEA1  ; valid                                  # 8.0  CJK UNIFIED IDEOGRAPH-2B820..CJK UNIFIED IDEOGRAPH-2CEA1
 2CEA2..2CEAF  ; disallowed                             # NA   <reserved-2CEA2>..<reserved-2CEAF>
 2CEB0..2EBE0  ; valid                                  # 10.0 CJK UNIFIED IDEOGRAPH-2CEB0..CJK UNIFIED IDEOGRAPH-2EBE0
-2EBE1..2F7FF  ; disallowed                             # NA   <reserved-2EBE1>..<reserved-2F7FF>
+2EBE1..2EBEF  ; disallowed                             # NA   <reserved-2EBE1>..<reserved-2EBEF>
+2EBF0..2EE4A  ; valid                                  # 15.1 CJK UNIFIED IDEOGRAPH-2EBF0..CJK UNIFIED IDEOGRAPH-2EE4A
+2EE4B..2F7FF  ; disallowed                             # NA   <reserved-2EE4B>..<reserved-2F7FF>
 2F800         ; mapped                 ; 4E3D          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F800
 2F801         ; mapped                 ; 4E38          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F801
 2F802         ; mapped                 ; 4E41          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F802

--- a/unicodetools/data/idna/dev/IdnaTestV2.txt
+++ b/unicodetools/data/idna/dev/IdnaTestV2.txt
@@ -1,6 +1,6 @@
 # IdnaTestV2.txt
-# Date: 2022-12-30, 00:48:43 GMT
-# © 2022 Unicode®, Inc.
+# Date: 2023-05-15, 22:38:49 GMT
+# © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
 #

--- a/unicodetools/src/main/java/org/unicode/idna/GenerateIdna.java
+++ b/unicodetools/src/main/java/org/unicode/idna/GenerateIdna.java
@@ -11,6 +11,7 @@ import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import com.ibm.icu.util.TimeZone;
 import com.ibm.icu.util.ULocale;
+import com.ibm.icu.util.VersionInfo;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Arrays;
@@ -41,7 +42,6 @@ public class GenerateIdna {
 
     // Utility.WORKSPACE_DIRECTORY + "draft/reports/tr46/data";
     private static final int MAX_STATUS_LENGTH = "disallowed_STD3_mapped".length();
-    private static final boolean TESTING = true;
     private static final boolean DISALLOW_BIDI_CONTROLS = true;
     public static UnicodeSet U32;
     public static UnicodeSet U40;
@@ -66,6 +66,8 @@ public class GenerateIdna {
             case 0:
                 break;
             case 1:
+                // TODO: This does not work due to static initializers which
+                // hardcode the latest version.
                 Default.setUCD(args[0]);
                 break;
             default:
@@ -392,7 +394,9 @@ public class GenerateIdna {
                 new UnicodeSet("[\u200C \u200D \u00DF \u03C2]").freeze(); // \u200C \u200D
 
         /**
-         * 1. If the code point is in the deviation set the status is deviation and the mapping
+         * Step 6: Produce the initial status and mapping values
+         *
+         * <p>1. If the code point is in the deviation set the status is deviation and the mapping
          * value is the base mapping value for that code point<br>
          * 2. Otherwise, if (a) the code point is in the base exclusion set, or if (b) any code
          * point in its base mapping value is not in the base valid set the status is disallowed and
@@ -411,9 +415,6 @@ public class GenerateIdna {
         final R2<IdnaType, String> validResult = Row.of(IdnaType.valid, (String) null);
 
         for (int cp = 0; cp <= 0x10FFFF; ++cp) {
-            if (TESTING && cp == 0x10C7) {
-                System.out.println("??TEST");
-            }
             final String cpString = UTF16.valueOf(cp);
             Row.R2<IdnaType, String> result;
             String baseMappingValue = baseMapping.get(cp);
@@ -440,16 +441,25 @@ public class GenerateIdna {
             // if (0==(cp&0xFFF)) System.out.println(cp + " = " + result);
             mappingTable.put(cp, result);
         }
+
+        // Step 7: Produce the final status and mapping values
         final UnicodeSet excluded = new UnicodeSet();
+        VersionInfo unicodeVersion = VersionInfo.getInstance(Default.ucdVersion());
+        boolean is15OrEarlier = unicodeVersion.compareTo(VersionInfo.UNICODE_15_0) <= 0;
         do {
             excluded.clear();
             final UnicodeSet validSet = mappingTable.getSet(validResult);
             final UnicodeSet disallowedSet = mappingTable.getSet(disallowedResult);
             final UnicodeSet ignoredSet = mappingTable.getSet(ignoredResult);
-            for (final String valid : validSet) {
-                final String nfd = Default.nfd().normalize(valid);
-                if (!validSet.containsAll(nfd)) {
-                    excluded.add(valid);
+            // Unicode 15.1 & later: No longer check whether the NFD is valid.
+            // [175-A86] In IdnaMappingTable.txt, change U+2260 (≠), U+226E (≮), and U+226F (≯)
+            // from disallowed_STD3_valid to valid, for Unicode 15.1.
+            if (is15OrEarlier) {
+                for (final String valid : validSet) {
+                    final String nfd = Default.nfd().normalize(valid);
+                    if (!validSet.containsAll(nfd)) {
+                        excluded.add(valid);
+                    }
                 }
             }
             final UnicodeSet mappedSet =
@@ -459,22 +469,41 @@ public class GenerateIdna {
                             .removeAll(ignoredSet);
             for (final String mapped : mappedSet) {
                 final R2<IdnaType, String> mappedValue = mappingTable.get(mapped);
-                final String mapResult = mappedValue.get1();
-                final String nfd = Default.nfd().normalize(mapResult);
-                if (!validSet.containsAll(nfd)) {
+                String mapResult = mappedValue.get1();
+                // Unicode 15.1 & later: No longer check whether the NFD is valid, see above.
+                if (is15OrEarlier) {
+                    mapResult = Default.nfd().normalize(mapResult);
+                }
+                if (!validSet.containsAll(mapResult)) {
                     excluded.add(mapped);
                 }
             }
             mappingTable.putAll(excluded, disallowedResult);
-            System.out.println(STD3 + " ***InvalidDecomposition Exclusion: " + excluded);
+            System.out.println(STD3 + " ***Step 7 Invalid Exclusion: " + excluded);
         } while (excluded.size() != 0);
 
         // detect errors, where invalid character doesn't have at least one invalid in decomposition
-        final UnicodeSet invalidSet = mappingTable.getSet(disallowedResult).freeze();
-        for (final String valid : invalidSet) {
-            final String nfd = Default.nfd().normalize(valid);
+        final UnicodeSet invalidSet =
+                mappingTable
+                        .getSet(disallowedResult)
+                        // Skip the base exclusion set:
+                        // The five CJK compatibility ideographs whose normalization changed
+                        // are not actually "suspicious".
+                        .removeAll(baseExclusionSet)
+                        .freeze();
+        for (final String invalid : invalidSet) {
+            final String nfd = Default.nfd().normalize(invalid);
             if (invalidSet.containsNone(nfd)) {
-                System.out.println("SUSPICIOUS: " + valid + "\t" + nfd);
+                System.out.println(
+                        "SUSPICIOUS: "
+                                + invalid
+                                + " ("
+                                + Utility.hex(invalid)
+                                + ")\t"
+                                + nfd
+                                + " ("
+                                + Utility.hex(nfd)
+                                + ")\t");
             }
         }
 
@@ -488,9 +517,6 @@ public class GenerateIdna {
         final UnicodeSet mappingChanged = new UnicodeSet();
         for (final UnicodeSetIterator it = new UnicodeSetIterator(U32); it.next(); ) {
             final int i = it.codepoint;
-            if (TESTING && i == 0x41) {
-                System.out.println("??TEST??");
-            }
             final IdnaType type = Idna2003Data.types.get(i);
             switch (type) {
                 case disallowed:

--- a/unicodetools/src/test/java/org/unicode/propstest/TestInvariants.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/TestInvariants.java
@@ -257,7 +257,7 @@ public class TestInvariants extends TestFmwkMinusMinus {
 
     @Test
     public void TestStandarizedVariant() {
-        CheckProps(WARN, UcdProperty.Standardized_Variant);
+        CheckProps("TestStandarizedVariant", WARN, UcdProperty.Standardized_Variant);
         //        UnicodeMap<String> currentStatus = iup.load(UcdProperty.Standardized_Variant);
         //        for (Entry<String, String> s : currentStatus.entrySet()) {
         //            System.out.println(s.getKey() + "\t" + Utility.hex(s.getKey()) + "\t" +
@@ -272,18 +272,25 @@ public class TestInvariants extends TestFmwkMinusMinus {
         // added,
         // then the list is longer but looks to the function like a different value.
         // As a result, it fails with what looks like an instability.
-        CheckProps(WARN, UcdProperty.Name_Alias, "END OF MEDIUM; EOM");
+        CheckProps("TestNameAlias", WARN, UcdProperty.Name_Alias, "END OF MEDIUM; EOM");
     }
 
     @Test
     public void TestIdna() {
-        CheckProps(WARN, UcdProperty.Idn_Status, Idn_Status_Values.disallowed.toString());
+        CheckProps(
+                "TestIdna", WARN, UcdProperty.Idn_Status, Idn_Status_Values.disallowed.toString());
     }
 
     @Test
     public void TestSecurity() {
-        CheckProps(WARN, UcdProperty.Identifier_Status, "Restricted", "Allowed");
         CheckProps(
+                "TestSecurity Identifier_Status",
+                WARN,
+                UcdProperty.Identifier_Status,
+                "Restricted",
+                "Allowed");
+        CheckProps(
+                "TestSecurity Identifier_Type",
                 WARN,
                 UcdProperty.Identifier_Type,
                 "Not_Character",
@@ -298,7 +305,8 @@ public class TestInvariants extends TestFmwkMinusMinus {
                 );
     }
 
-    public void CheckProps(int warnVsError, UcdProperty ucdProperty, String... skip) {
+    public void CheckProps(
+            String testName, int warnVsError, UcdProperty ucdProperty, String... skip) {
         UnicodeMap<String> currentStatus = iup.load(ucdProperty);
         UnicodeMap<String> oldStatus = iupLast.load(ucdProperty);
         Set<String> values = new LinkedHashSet<>();
@@ -333,8 +341,19 @@ public class TestInvariants extends TestFmwkMinusMinus {
                     // [172-A62] Change the Identifier_Type of U+A7B8 and U+A7B9 to Uncommon_Use
                     level = LOG;
                 }
+                if (ucdProperty == UcdProperty.Idn_Status
+                        && value.equals("disallowed_STD3_valid")
+                        && Settings.latestVersion.equals("15.1.0")
+                        && missing.size() == 3
+                        && missing.containsAll("\u2260\u226E\u226F")) {
+                    // [175-A86] In IdnaMappingTable.txt,
+                    // change U+2260 (≠), U+226E (≮), and U+226F (≯)
+                    // from disallowed_STD3_valid to valid, for Unicode 15.1.
+                    level = LOG;
+                }
                 msg(
-                        "Unicode "
+                        testName
+                                + ": Unicode "
                                 + Settings.latestVersion
                                 + " [:"
                                 + ucdProperty
@@ -349,7 +368,8 @@ public class TestInvariants extends TestFmwkMinusMinus {
             if (!oldSet.containsAll(newSet)) {
                 UnicodeSet newOnes = new UnicodeSet(newSet).removeAll(oldSet);
                 logln(
-                        "Unicode "
+                        testName
+                                + ": Unicode "
                                 + Settings.lastVersion
                                 + " [:"
                                 + ucdProperty
@@ -363,9 +383,11 @@ public class TestInvariants extends TestFmwkMinusMinus {
         if (same) {
             messageln(
                     warnVsError,
-                    "Should have a difference compared to last version: " + ucdProperty);
+                    testName
+                            + ": Should have a difference compared to last version: "
+                            + ucdProperty);
         } else if (currentStatus.equals(oldStatus)) {
-            warnln("Unicode map equals needs fixing");
+            warnln(testName + ": Unicode map equals needs fixing");
         }
     }
 

--- a/unicodetools/src/test/java/org/unicode/unittest/TestIdnaTest.java
+++ b/unicodetools/src/test/java/org/unicode/unittest/TestIdnaTest.java
@@ -86,7 +86,16 @@ public class TestIdnaTest extends TestFmwkMinusMinus {
             String versionString =
                     " expected=v" + Settings.latestVersion + " actual=v" + Settings.lastVersion;
             assertEquals("mapping" + versionString, idnaMappingLast.get(x), idnaMapping.get(x));
-            assertEquals("status" + versionString, idnaStatusLast.get(x), idnaStatus.get(x));
+            Idn_Status_Values lastStatus = idnaStatusLast.get(x);
+            Idn_Status_Values currentStatus = idnaStatus.get(x);
+            char c0 = x.charAt(0);
+            // Unicode 15.1 changes these from disallowed_STD3_valid to valid.
+            boolean skip =
+                    (c0 == 0x2260 || c0 == 0x226E || c0 == 0x226F)
+                            && currentStatus == Idn_Status_Values.valid;
+            if (!skip) {
+                assertEquals("status" + versionString, lastStatus, currentStatus);
+            }
         }
     }
 


### PR DESCRIPTION
For
[[175-A86](https://www.unicode.org/cgi-bin/GetL2Ref.pl?175-A86)] Action Item for Mark Davis, Markus Scherer, PAG: In IdnaMappingTable.txt, change U+2260 (≠), U+226E (≮), and U+226F (≯) from disallowed_STD3_valid to valid, for Unicode 15.1.

In the code for [Mapping Table Derivation, Step 7](https://unicode.org/reports/tr46/#TableDerivationStep7), we no longer check whether the NFD versions of characters and mappings are valid. We had agreed with feedback that that is not necessary because domain names are in composed form, not decomposed.

----
Also adds the other characters that are new in Unicode 15.1:
- 5 new IDS characters
- 603 new characters in CJK Extension I