### PR TITLE
Fix Jsp versioning

### DIFF
--- a/UnicodeJsps/src/main/java/org/unicode/jsp/CachedProps.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/CachedProps.java
@@ -27,7 +27,6 @@ import java.util.zip.GZIPInputStream;
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.jsp.UnicodeDataInput.ItemReader;
 import org.unicode.props.UnicodeProperty;
-import org.unicode.text.utility.Settings;
 
 public class CachedProps {
     public static final boolean IS_BETA = true;

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/CachedProps.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/CachedProps.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import com.ibm.icu.dev.util.UnicodeMap;
+import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.util.ICUUncheckedIOException;
 import com.ibm.icu.util.VersionInfo;
 import java.io.DataInputStream;
@@ -44,8 +45,7 @@ public class CachedProps {
     final BiMultimap<String, String> nameToAliases = new BiMultimap<String, String>(null, null);
     final Map<String, BiMultimap<String, String>> nameToValueToAliases = new LinkedHashMap();
 
-    static String jspVersion = IS_BETA ? Settings.lastVersion : Settings.latestVersion;
-    static VersionInfo jspVersionInfo = VersionInfo.getInstance(jspVersion);
+    static VersionInfo jspVersionInfo = UCharacter.getUnicodeVersion();
     static CachedProps CACHED_PROPS = getInstance(jspVersionInfo);
 
     static UnicodeProperty NAMES = CachedProps.CACHED_PROPS.getProperty("Name");

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeJsp.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeJsp.java
@@ -25,6 +25,7 @@ import org.unicode.idna.Idna2003;
 import org.unicode.idna.Idna2008;
 import org.unicode.idna.Uts46;
 import org.unicode.jsp.UnicodeUtilities.CodePointShower;
+import org.unicode.text.utility.Settings;
 
 public class UnicodeJsp {
 
@@ -420,7 +421,7 @@ public class UnicodeJsp {
                     : "<p style='border: 1pt solid red;'>Properties use ICU for Unicode V"
                             + UCharacter.getUnicodeVersion().getVersionString(2, 2)
                             + "; the beta properties support Unicode V"
-                            + CachedProps.CACHED_PROPS.version.getVersionString(2, 2)
+                            + VersionInfo.getInstance(Settings.latestVersion).getVersionString(2, 2)
                             + "&beta;. "
                             + "For more information, see <a target='help' href='https://unicode-org.github.io/unicodetools/help/changes'>Unicode Utilities Beta</a>.</p>";
 


### PR DESCRIPTION
Per discussion in unicodetools meeting 13 June 2023:
- "The beta version string should just use Settings.latestVersion" — updated UnicodeJsp.java to use Settings.latestVersion
- "The jspVersionInfo should use UCharacter.getUnicodeVersion() to match what it serves — as long as it serves ICU property values" — reworked CachedProps.java to use UCharacter.getInstance for jspVersionInfo