### PR TITLE
UTS46 map capital to lowercase sharp s

### DIFF
--- a/unicodetools/data/idna/dev/IdnaMappingTable.txt
+++ b/unicodetools/data/idna/dev/IdnaMappingTable.txt
@@ -1,5 +1,5 @@
 # IdnaMappingTable.txt
-# Date: 2023-05-15, 22:37:02 GMT
+# Date: 2023-07-27, 22:42:46 GMT
 # © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -2036,7 +2036,7 @@
 1E9A          ; mapped                 ; 0061 02BE     # 1.1  LATIN SMALL LETTER A WITH RIGHT HALF RING
 1E9B          ; mapped                 ; 1E61          # 2.0  LATIN SMALL LETTER LONG S WITH DOT ABOVE
 1E9C..1E9D    ; valid                                  # 5.1  LATIN SMALL LETTER LONG S WITH DIAGONAL STROKE..LATIN SMALL LETTER LONG S WITH HIGH STROKE
-1E9E          ; mapped                 ; 0073 0073     # 5.1  LATIN CAPITAL LETTER SHARP S
+1E9E          ; mapped                 ; 00DF          # 5.1  LATIN CAPITAL LETTER SHARP S
 1E9F          ; valid                                  # 5.1  LATIN SMALL LETTER DELTA
 1EA0          ; mapped                 ; 1EA1          # 1.1  LATIN CAPITAL LETTER A WITH DOT BELOW
 1EA1          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH DOT BELOW

--- a/unicodetools/data/idna/dev/IdnaTestV2.txt
+++ b/unicodetools/data/idna/dev/IdnaTestV2.txt
@@ -1,5 +1,5 @@
 # IdnaTestV2.txt
-# Date: 2023-06-06, 23:32:28 GMT
+# Date: 2023-07-27, 23:16:06 GMT
 # © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -217,6 +217,8 @@ o\u0308bb; öbb; ; xn--bb-eka; ; ;  # öbb
 Öbb; öbb; ; xn--bb-eka; ; ;  # öbb
 O\u0308bb; öbb; ; xn--bb-eka; ; ;  # öbb
 xn--bb-eka; öbb; ; xn--bb-eka; ; ;  # öbb
+FAẞ.de; faß.de; ; xn--fa-hia.de; ; ; [V6] # faß.de
+FAẞ.DE; faß.de; ; xn--fa-hia.de; ; ; [V6] # faß.de
 βόλος.com; ; ; xn--nxasmm1c.com; ; xn--nxasmq6b.com;  # βόλος.com
 βο\u0301λος.com; βόλος.com; ; xn--nxasmm1c.com; ; xn--nxasmq6b.com;  # βόλος.com
 ΒΟ\u0301ΛΟΣ.COM; βόλοσ.com; ; xn--nxasmq6b.com; ; ;  # βόλοσ.com

--- a/unicodetools/src/main/java/org/unicode/idna/GenerateIdnaTest.java
+++ b/unicodetools/src/main/java/org/unicode/idna/GenerateIdnaTest.java
@@ -672,8 +672,9 @@ public class GenerateIdnaTest {
         {"B\u00FCcher.de", "B", "b\u00FCcher.de", 0},
         // O-umlaut
         {"\u00D6BB", "B", "\u00F6bb", 0},
-        {"fa\u00DF.de", "N", "fa\u00DF.de", 0}, // sharp s
         // sharp s
+        {"fa\u00DF.de", "N", "fa\u00DF.de", 0},
+        {"FA\u1E9E.de", "N", "fa\u00DF.de", 0},
         {"fa\u00DF.de", "T", "fass.de", 0},
         // sharp s in Punycode
         {"XN--fA-hia.dE", "B", "fa\u00DF.de", 0},

--- a/unicodetools/src/test/java/org/unicode/unittest/TestIdnaTest.java
+++ b/unicodetools/src/test/java/org/unicode/unittest/TestIdnaTest.java
@@ -82,19 +82,29 @@ public class TestIdnaTest extends TestFmwkMinusMinus {
                         .complement()
                         .freeze();
 
+        String versionString =
+                " expected=v" + Settings.latestVersion + " actual=v" + Settings.lastVersion;
         for (String x : oldAssigned) {
-            String versionString =
-                    " expected=v" + Settings.latestVersion + " actual=v" + Settings.lastVersion;
-            assertEquals("mapping" + versionString, idnaMappingLast.get(x), idnaMapping.get(x));
-            Idn_Status_Values lastStatus = idnaStatusLast.get(x);
-            Idn_Status_Values currentStatus = idnaStatus.get(x);
             char c0 = x.charAt(0);
-            // Unicode 15.1 changes these from disallowed_STD3_valid to valid.
-            boolean skip =
-                    (c0 == 0x2260 || c0 == 0x226E || c0 == 0x226F)
-                            && currentStatus == Idn_Status_Values.valid;
-            if (!skip) {
-                assertEquals("status" + versionString, lastStatus, currentStatus);
+            {
+                // Unicode 15.1 changes the mapping of capital sharp s:
+                // Used to map to ss, now to lowercase sharp s.
+                boolean skip = c0 == 0x1E9E;
+                if (!skip) {
+                    assertEquals(
+                            "mapping" + versionString, idnaMappingLast.get(x), idnaMapping.get(x));
+                }
+            }
+            {
+                Idn_Status_Values lastStatus = idnaStatusLast.get(x);
+                Idn_Status_Values currentStatus = idnaStatus.get(x);
+                // Unicode 15.1 changes these from disallowed_STD3_valid to valid.
+                boolean skip =
+                        (c0 == 0x2260 || c0 == 0x226E || c0 == 0x226F)
+                                && currentStatus == Idn_Status_Values.valid;
+                if (!skip) {
+                    assertEquals("status" + versionString, lastStatus, currentStatus);
+                }
             }
         }
     }


### PR DESCRIPTION
Changes for new action items from UTC-176:
- In UTS46 Mapping Table Derivation step 1 (base mapping) substep 1 (exceptional characters), map U+1E9E capital sharp s to U+00DF small sharp s. Add a note that this changes the mapping of the capital sharp s. For Unicode 15.1.
- In IdnaMappingTable.txt map U+1E9E capital sharp s to U+00DF small sharp s instead of to "ss", for Unicode 15.1.

*Please read the following and advise!*

It turns out that the first action item (adding a base  mapping) is insufficient: Table derivation step 6 checks that the mapping contains only characters in the base valid set before using the mapping. Lowercase sharp s is not in the base valid set (it has an NFKC_Casefold mapping). Thus, the mapping table is generated with capital sharp s disallowed.

I chose to add lowercase sharp s to the base valid set. That seemed like the most straightforward and understandable way out.

Then it turns out that that is not sufficient either: Table derivation step 7 also checks that every character in a mapping is in the valid set. Lowercase sharp is in the deviation set, not in the valid set. Thus, capital sharp s is still disallowed.

Here I chose to also allow deviation characters in mappings. I was not sure whether that would inadvertently allow more mappings in, but it doesn't (at least not currently).

Please let me know if I should do something different. For example, in step 7 we could just add lowercase sharp s alone to the characters allowed in mappings. We could even just hack this one desired mapping into step 7 and not make any of the other changes.

Note that whatever derivation changes we agree on I will also have to make in the UTS46 spec text.