### PR TITLE
UTS46 disallow new IDC U+31EF

### DIFF
--- a/unicodetools/data/idna/dev/IdnaMappingTable.txt
+++ b/unicodetools/data/idna/dev/IdnaMappingTable.txt
@@ -1,5 +1,5 @@
 # IdnaMappingTable.txt
-# Date: 2023-07-27, 22:42:46 GMT
+# Date: 2023-08-10, 22:32:27 GMT
 # © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -3422,7 +3422,7 @@
 31C0..31CF    ; valid                  ;      ; NV8    # 4.1  CJK STROKE T..CJK STROKE N
 31D0..31E3    ; valid                  ;      ; NV8    # 5.1  CJK STROKE H..CJK STROKE Q
 31E4..31EE    ; disallowed                             # NA   <reserved-31E4>..<reserved-31EE>
-31EF          ; valid                  ;      ; NV8    # 15.1 IDEOGRAPHIC DESCRIPTION CHARACTER SUBTRACTION
+31EF          ; disallowed                             # 15.1 IDEOGRAPHIC DESCRIPTION CHARACTER SUBTRACTION
 31F0..31FF    ; valid                                  # 3.2  KATAKANA LETTER SMALL KU..KATAKANA LETTER SMALL RO
 3200          ; disallowed_STD3_mapped ; 0028 1100 0029 #1.1  PARENTHESIZED HANGUL KIYEOK
 3201          ; disallowed_STD3_mapped ; 0028 1102 0029 #1.1  PARENTHESIZED HANGUL NIEUN
@@ -8448,8 +8448,8 @@ FFFE..FFFF    ; disallowed                             # 1.1  <noncharacter-FFFE
 2CEA2..2CEAF  ; disallowed                             # NA   <reserved-2CEA2>..<reserved-2CEAF>
 2CEB0..2EBE0  ; valid                                  # 10.0 CJK UNIFIED IDEOGRAPH-2CEB0..CJK UNIFIED IDEOGRAPH-2EBE0
 2EBE1..2EBEF  ; disallowed                             # NA   <reserved-2EBE1>..<reserved-2EBEF>
-2EBF0..2EE4A  ; valid                                  # 15.1 CJK UNIFIED IDEOGRAPH-2EBF0..CJK UNIFIED IDEOGRAPH-2EE4A
-2EE4B..2F7FF  ; disallowed                             # NA   <reserved-2EE4B>..<reserved-2F7FF>
+2EBF0..2EE5D  ; valid                                  # 15.1 CJK UNIFIED IDEOGRAPH-2EBF0..CJK UNIFIED IDEOGRAPH-2EE5D
+2EE5E..2F7FF  ; disallowed                             # NA   <reserved-2EE5E>..<reserved-2F7FF>
 2F800         ; mapped                 ; 4E3D          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F800
 2F801         ; mapped                 ; 4E38          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F801
 2F802         ; mapped                 ; 4E41          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F802

--- a/unicodetools/data/idna/dev/IdnaTestV2.txt
+++ b/unicodetools/data/idna/dev/IdnaTestV2.txt
@@ -1,5 +1,5 @@
 # IdnaTestV2.txt
-# Date: 2023-07-27, 23:16:06 GMT
+# Date: 2023-08-10, 22:35:43 GMT
 # © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -1472,18 +1472,18 @@ xn--0s9c.xn--8ug8324p; 𐨿.🄆—; [V5, V6]; xn--0s9c.xn--8ug8324p; ; ;  # �
 xn--lmb18944c0g2z.xn----2k81m; 򔊱񁦮۸.󠾭-; [V3, V6]; xn--lmb18944c0g2z.xn----2k81m; ; ;  # ۸.-
 𼗸\u07CD𐹮。\u06DDᡎᠴ; 𼗸\u07CD𐹮.\u06DDᡎᠴ; [B1, B5, B6, V6]; xn--osb0855kcc2r.xn--tlb299fhc; ; ;  # ߍ𐹮.ᡎᠴ
 xn--osb0855kcc2r.xn--tlb299fhc; 𼗸\u07CD𐹮.\u06DDᡎᠴ; [B1, B5, B6, V6]; xn--osb0855kcc2r.xn--tlb299fhc; ; ;  # ߍ𐹮.ᡎᠴ
-\u200DᠮႾ🄂.🚗\u0841𮹌\u200C; ; [B1, C1, C2, V6]; xn--2nd129ay2gnw71c.xn--zvb692j9664aic1g; ; xn--2nd129ai554b.xn--zvb3124wpkpf; [B1, V6] # ᠮႾ🄂.🚗ࡁ
-\u200DᠮႾ1,.🚗\u0841𮹌\u200C; ; [B1, C1, C2, V6]; xn--1,-ogkx89c39j.xn--zvb692j9664aic1g; ; xn--1,-ogkx89c.xn--zvb3124wpkpf; [B1, B6, V6] # ᠮႾ1,.🚗ࡁ
-\u200Dᠮⴞ1,.🚗\u0841𮹌\u200C; ; [B1, C1, C2, V6]; xn--1,-v3o161c53q.xn--zvb692j9664aic1g; ; xn--1,-v3o625k.xn--zvb3124wpkpf; [B1, B6, V6] # ᠮⴞ1,.🚗ࡁ
-xn--1,-v3o625k.xn--zvb3124wpkpf; ᠮⴞ1,.🚗\u0841𮹌; [B1, B6, V6]; xn--1,-v3o625k.xn--zvb3124wpkpf; ; ;  # ᠮⴞ1,.🚗ࡁ
-xn--1,-v3o161c53q.xn--zvb692j9664aic1g; \u200Dᠮⴞ1,.🚗\u0841𮹌\u200C; [B1, C1, C2, V6]; xn--1,-v3o161c53q.xn--zvb692j9664aic1g; ; ;  # ᠮⴞ1,.🚗ࡁ
-xn--1,-ogkx89c.xn--zvb3124wpkpf; ᠮႾ1,.🚗\u0841𮹌; [B1, B6, V6]; xn--1,-ogkx89c.xn--zvb3124wpkpf; ; ;  # ᠮႾ1,.🚗ࡁ
-xn--1,-ogkx89c39j.xn--zvb692j9664aic1g; \u200DᠮႾ1,.🚗\u0841𮹌\u200C; [B1, C1, C2, V6]; xn--1,-ogkx89c39j.xn--zvb692j9664aic1g; ; ;  # ᠮႾ1,.🚗ࡁ
-\u200Dᠮⴞ🄂.🚗\u0841𮹌\u200C; ; [B1, C1, C2, V6]; xn--h7e341b0wlbv45b.xn--zvb692j9664aic1g; ; xn--h7e438h1p44a.xn--zvb3124wpkpf; [B1, V6] # ᠮⴞ🄂.🚗ࡁ
-xn--h7e438h1p44a.xn--zvb3124wpkpf; ᠮⴞ🄂.🚗\u0841𮹌; [B1, V6]; xn--h7e438h1p44a.xn--zvb3124wpkpf; ; ;  # ᠮⴞ🄂.🚗ࡁ
-xn--h7e341b0wlbv45b.xn--zvb692j9664aic1g; \u200Dᠮⴞ🄂.🚗\u0841𮹌\u200C; [B1, C1, C2, V6]; xn--h7e341b0wlbv45b.xn--zvb692j9664aic1g; ; ;  # ᠮⴞ🄂.🚗ࡁ
-xn--2nd129ai554b.xn--zvb3124wpkpf; ᠮႾ🄂.🚗\u0841𮹌; [B1, V6]; xn--2nd129ai554b.xn--zvb3124wpkpf; ; ;  # ᠮႾ🄂.🚗ࡁ
-xn--2nd129ay2gnw71c.xn--zvb692j9664aic1g; \u200DᠮႾ🄂.🚗\u0841𮹌\u200C; [B1, C1, C2, V6]; xn--2nd129ay2gnw71c.xn--zvb692j9664aic1g; ; ;  # ᠮႾ🄂.🚗ࡁ
+\u200DᠮႾ🄂.🚗\u0841𮹌\u200C; ; [B1, C1, C2, V6]; xn--2nd129ay2gnw71c.xn--zvb692j9664aic1g; ; xn--2nd129ai554b.xn--zvb3124wpkpf; [B1, V6] # ᠮႾ🄂.🚗ࡁ𮹌
+\u200DᠮႾ1,.🚗\u0841𮹌\u200C; ; [B1, C1, C2, V6]; xn--1,-ogkx89c39j.xn--zvb692j9664aic1g; ; xn--1,-ogkx89c.xn--zvb3124wpkpf; [B1, B6, V6] # ᠮႾ1,.🚗ࡁ𮹌
+\u200Dᠮⴞ1,.🚗\u0841𮹌\u200C; ; [B1, C1, C2, V6]; xn--1,-v3o161c53q.xn--zvb692j9664aic1g; ; xn--1,-v3o625k.xn--zvb3124wpkpf; [B1, B6, V6] # ᠮⴞ1,.🚗ࡁ𮹌
+xn--1,-v3o625k.xn--zvb3124wpkpf; ᠮⴞ1,.🚗\u0841𮹌; [B1, B6, V6]; xn--1,-v3o625k.xn--zvb3124wpkpf; ; ;  # ᠮⴞ1,.🚗ࡁ𮹌
+xn--1,-v3o161c53q.xn--zvb692j9664aic1g; \u200Dᠮⴞ1,.🚗\u0841𮹌\u200C; [B1, C1, C2, V6]; xn--1,-v3o161c53q.xn--zvb692j9664aic1g; ; ;  # ᠮⴞ1,.🚗ࡁ𮹌
+xn--1,-ogkx89c.xn--zvb3124wpkpf; ᠮႾ1,.🚗\u0841𮹌; [B1, B6, V6]; xn--1,-ogkx89c.xn--zvb3124wpkpf; ; ;  # ᠮႾ1,.🚗ࡁ𮹌
+xn--1,-ogkx89c39j.xn--zvb692j9664aic1g; \u200DᠮႾ1,.🚗\u0841𮹌\u200C; [B1, C1, C2, V6]; xn--1,-ogkx89c39j.xn--zvb692j9664aic1g; ; ;  # ᠮႾ1,.🚗ࡁ𮹌
+\u200Dᠮⴞ🄂.🚗\u0841𮹌\u200C; ; [B1, C1, C2, V6]; xn--h7e341b0wlbv45b.xn--zvb692j9664aic1g; ; xn--h7e438h1p44a.xn--zvb3124wpkpf; [B1, V6] # ᠮⴞ🄂.🚗ࡁ𮹌
+xn--h7e438h1p44a.xn--zvb3124wpkpf; ᠮⴞ🄂.🚗\u0841𮹌; [B1, V6]; xn--h7e438h1p44a.xn--zvb3124wpkpf; ; ;  # ᠮⴞ🄂.🚗ࡁ𮹌
+xn--h7e341b0wlbv45b.xn--zvb692j9664aic1g; \u200Dᠮⴞ🄂.🚗\u0841𮹌\u200C; [B1, C1, C2, V6]; xn--h7e341b0wlbv45b.xn--zvb692j9664aic1g; ; ;  # ᠮⴞ🄂.🚗ࡁ𮹌
+xn--2nd129ai554b.xn--zvb3124wpkpf; ᠮႾ🄂.🚗\u0841𮹌; [B1, V6]; xn--2nd129ai554b.xn--zvb3124wpkpf; ; ;  # ᠮႾ🄂.🚗ࡁ𮹌
+xn--2nd129ay2gnw71c.xn--zvb692j9664aic1g; \u200DᠮႾ🄂.🚗\u0841𮹌\u200C; [B1, C1, C2, V6]; xn--2nd129ay2gnw71c.xn--zvb692j9664aic1g; ; ;  # ᠮႾ🄂.🚗ࡁ𮹌
 \u0601\u0697．𑚶񼡷⾆; \u0601\u0697.𑚶񼡷舌; [B1, V5, V6]; xn--jfb41a.xn--tc1ap851axo39c; ; ;  # ڗ.𑚶舌
 \u0601\u0697.𑚶񼡷舌; ; [B1, V5, V6]; xn--jfb41a.xn--tc1ap851axo39c; ; ;  # ڗ.𑚶舌
 xn--jfb41a.xn--tc1ap851axo39c; \u0601\u0697.𑚶񼡷舌; [B1, V5, V6]; xn--jfb41a.xn--tc1ap851axo39c; ; ;  # ڗ.𑚶舌

--- a/unicodetools/src/main/java/org/unicode/idna/GenerateIdna.java
+++ b/unicodetools/src/main/java/org/unicode/idna/GenerateIdna.java
@@ -350,6 +350,7 @@ public class GenerateIdna {
                         .removeAll(properties.getSet("gc=Zp"))
                         .removeAll(properties.getSet("gc=Zs"))
                         .removeAll(properties.getSet("Block=Ideographic_Description_Characters"))
+                        .remove(0x31EF) // an IDC added in 15.1 outside the full IDC block
                         .removeAll(new UnicodeSet("[\\u0000-\\u007F]"))
                         // Add lowercase sharp s to the base valid set.
                         // Otherwise the new-in-15.1 baseMapping for capital sharp s


### PR DESCRIPTION
which overflowed from the now-filled Ideographic_Description_Characters block

also picks up new end of CJK extension I

FYI @michelsu