### PR TITLE
UTS46 transitional: map capital sharp s to ss

### DIFF
--- a/unicodetools/data/idna/dev/IdnaTestV2.txt
+++ b/unicodetools/data/idna/dev/IdnaTestV2.txt
@@ -1,5 +1,5 @@
 # IdnaTestV2.txt
-# Date: 2023-08-10, 22:35:43 GMT
+# Date: 2023-08-15, 23:21:16 GMT
 # © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -217,8 +217,8 @@ o\u0308bb; öbb; ; xn--bb-eka; ; ;  # öbb
 Öbb; öbb; ; xn--bb-eka; ; ;  # öbb
 O\u0308bb; öbb; ; xn--bb-eka; ; ;  # öbb
 xn--bb-eka; öbb; ; xn--bb-eka; ; ;  # öbb
-FAẞ.de; faß.de; ; xn--fa-hia.de; ; ; [V6] # faß.de
-FAẞ.DE; faß.de; ; xn--fa-hia.de; ; ; [V6] # faß.de
+FAẞ.de; faß.de; ; xn--fa-hia.de; ; fass.de;  # faß.de
+FAẞ.DE; faß.de; ; xn--fa-hia.de; ; fass.de;  # faß.de
 βόλος.com; ; ; xn--nxasmm1c.com; ; xn--nxasmq6b.com;  # βόλος.com
 βο\u0301λος.com; βόλος.com; ; xn--nxasmm1c.com; ; xn--nxasmq6b.com;  # βόλος.com
 ΒΟ\u0301ΛΟΣ.COM; βόλοσ.com; ; xn--nxasmq6b.com; ; ;  # βόλοσ.com

--- a/unicodetools/src/main/java/org/unicode/idna/Uts46.java
+++ b/unicodetools/src/main/java/org/unicode/idna/Uts46.java
@@ -513,8 +513,17 @@ public class Uts46 extends Idna {
                     break;
                     // mapped: Replace the code point in the string by the value for the
                     // mapping in Section 5, IDNA Mapping Table.
+                    // Except, starting with 15.1:
+                    // If transitional and capital sharp s, then map to ss
+                    // to keep the mapping idempotent, and to
+                    // avoid the small sharp s failing the mode=transitional validity check.
                 case mapped:
-                    String mapped = mappings.get(cp);
+                    String mapped;
+                    if (idnaChoice == IdnaChoice.transitional && cp == 'ẞ') {
+                        mapped = "ss";
+                    } else {
+                        mapped = mappings.get(cp);
+                    }
                     buffer.append(mapped);
                     break;
                     // deviation:


### PR DESCRIPTION
... to keep the mapping idempotent, and to avoid the small sharp s failing the mode=transitional validity check

FYI @michelsu