### PR TITLE
change version placeholders so .md shows them

### DIFF
--- a/docs/data-workflow.md
+++ b/docs/data-workflow.md
@@ -136,14 +136,14 @@ script from an up-to-date repo workspace.
 
 Send the resulting zip file to Rick for posting to https://www.unicode.org/Public/ (not .../Public/draft/).
 Ask Rick to add other files that are not tracked in the unicodetools repo:
-*   Unihan.zip to .../<version>/ucd
-*   UCDXML files to .../<version>/ucdxml
-*   final charts to .../<version>/charts
+*   Unihan.zip to .../{version}/ucd
+*   UCDXML files to .../{version}/ucdxml
+*   final charts to .../{version}/charts
 
 This script works much like the beta script, except it:
 *   assembles all of the files for Public/ in their release folder structure,
     rather than for Public/draft/
-*   creates a zipped/<version> folder with UCD.zip
+*   creates a zipped/{version} folder with UCD.zip
 
 ### After a release
 


### PR DESCRIPTION
I realized that `<version>` strings don't render, presumably because they are interpreted as (undefined) HTML tags.

Compare
- https://github.com/unicode-org/unicodetools/blob/main/docs/data-workflow.md#publish-a-release
- https://github.com/markusicu/unicodetools/blob/workflow-md-dont-hide-versions/docs/data-workflow.md#publish-a-release