### PR TITLE
Show the Name_Alias in the absence of a name in the jsps

### DIFF
--- a/UnicodeJsps/src/main/java/org/unicode/jsp/CachedProps.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/CachedProps.java
@@ -29,7 +29,7 @@ import org.unicode.jsp.UnicodeDataInput.ItemReader;
 import org.unicode.props.UnicodeProperty;
 
 public class CachedProps {
-    public static final boolean IS_BETA = true;
+    public static final boolean IS_BETA = false;
 
     public static final Splitter HASH_SPLITTER = Splitter.on('#').trimResults();
     public static final Splitter SEMI_SPLITTER = Splitter.on(';').trimResults();

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
@@ -637,7 +637,7 @@ public class UnicodeUtilities {
             if (UnicodeUtilities.RTL.containsSome(literal)) {
                 literal = '\u200E' + literal + '\u200E';
             }
-            String name = UnicodeUtilities.getName(string, separator, false, "meow");
+            String name = UnicodeUtilities.getName(string, separator, false, false);
             literal = UnicodeSetUtilities.addEmojiVariation(literal);
             if (doTable) {
                 out.append(
@@ -792,7 +792,8 @@ public class UnicodeUtilities {
         //        }
     }
 
-    private static String getName(String string, String separator, boolean andCode, String noName) {
+    private static String getName(
+            String string, String separator, boolean andCode, boolean plainText) {
         StringBuilder result = new StringBuilder();
         int cp;
         for (int i = 0; i < string.length(); i += UTF16.getCharCount(cp)) {
@@ -816,7 +817,11 @@ public class UnicodeUtilities {
                 if (alias == null) {
                     alias = "no name";
                 }
-                result.append("<i>" + alias + "</i>");
+                if (plainText) {
+                    result.append("<i>" + alias + "</i>");
+                } else {
+                    result.append("(" + alias + ")");
+                }
             }
         }
         return result.toString();
@@ -1936,7 +1941,7 @@ public class UnicodeUtilities {
         writer.println("</tr><tr><th>Character</th>");
         for (int i = 0; i < str.length(); ++i) {
             final String s = str.substring(i, i + 1);
-            String title = toHTML.transform(getName(s, "", true, "meow"));
+            String title = toHTML.transform(getName(s, "", true, true));
             writer.println(
                     "<td class='bccell' title='"
                             + title
@@ -1987,7 +1992,7 @@ public class UnicodeUtilities {
             String title =
                     bidiChar.length() == 0
                             ? "deleted"
-                            : toHTML.transform(getName(bidiChar, "", true, "meow"));
+                            : toHTML.transform(getName(bidiChar, "", true, true));
             String td = bidiChar.length() == 0 ? "bxcell" : "bccell";
             writer.println(
                     "<td class='"

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
@@ -818,9 +818,9 @@ public class UnicodeUtilities {
                     alias = "no name";
                 }
                 if (plainText) {
-                    result.append("<i>" + alias + "</i>");
-                } else {
                     result.append("(" + alias + ")");
+                } else {
+                    result.append("<i>" + alias + "</i>");
                 }
             }
         }


### PR DESCRIPTION
Someday we could try being smarter and classify the name aliases by type, excluding figment, alternate, and abbreviation to cut down on the noise, and showing the correction ones even alongside the name. But until that day, this fixes #542.

[And we’re out of β, we’re releasing on time…](https://www.youtube.com/watch?v=Y6ljFaKRTrI)

![image](https://github.com/unicode-org/unicodetools/assets/2284290/6dea94b6-d02c-4918-968b-ee4ce25d242e)