### PR TITLE
Ignore conflict markers in UcdLineParser

### DIFF
--- a/unicodetools/src/main/java/org/unicode/props/UcdLineParser.java
+++ b/unicodetools/src/main/java/org/unicode/props/UcdLineParser.java
@@ -111,6 +111,11 @@ public final class UcdLineParser implements Iterable<UcdLineParser.UcdLine> {
                         return false;
                     }
                     line = line2 = rawLines.next();
+                    if (line.startsWith("<<<<<<<")
+                            || line.startsWith("=======")
+                            || line.startsWith(">>>>>>>")) {
+                        line2 = "";
+                    }
                     ++stats.lineCount;
                     final int hashPos = line2.indexOf('#');
                     if (hashPos >= 0) {


### PR DESCRIPTION
I think this fixes #419, at last.