### PR TITLE
Add an invariant relating Vowel_Dependent to Alphabetic

### DIFF
--- a/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
@@ -530,7 +530,10 @@ Show [\u20b9]
 # exceptions. Should such exceptions arise, they can be added to the definition of
 # $nonAlphabeticBindus to avoid a failure on this test.
 Let $nonAlphabeticBindus = []
-[\p{InSc=Bindu} - $nonAlphabeticBindus - \p{Alphabetic}] = [] 
+[\p{InSc=Bindu} - \p{Alphabetic}] = $nonAlphabeticBindus
+
+Let $nonAlphabeticDependentVowels = [\N{ORIYA SIGN OVERLINE}\N{THAI CHARACTER MAITAIKHU}\N{LIMBU SIGN KEMPHRENG}\N{SHARADA VOWEL MODIFIER MARK}\N{SHARADA EXTRA SHORT VOWEL MARK}]
+[\p{InSC=Vowel_Dependent} - \p{Alphabetic}] = $nonAlphabeticDependentVowels
 
 ##########################
 # LineBreak property


### PR DESCRIPTION
There are a handful of exceptions*, but most of them are alphabetic. See TUS on Alphabetic:

> **_Alphabetic._** The Alphabetic property is a derived informative property of the primary units of alphabets and/or syllabaries, whether combining or noncombining. Included in this group would be composite characters that are canonical equivalents to a combining character sequence of an alphabetic base character plus one or more combining characters; letter digraphs; contextual variants of alphabetic characters; ligatures of alphabetic characters; contextual variants of ligatures; modifier letters; letterlike symbols that are compatibility equivalents of single alphabetic letters; and miscellaneous letter elements. Notably, U+00AA feminine ordinal indicator and U+00BA masculine ordinal indicator are simply abbreviatory forms involving a Latin letter and should be considered alphabetic rather than nonalphabetic symbols.

(We flag Mc that are not Alphabetic in the invariants, but obviously we cannot flag Mn. This should help with some of those.)

\* The exceptions are [`[\N{ORIYA SIGN OVERLINE}\N{THAI CHARACTER MAITAIKHU}\N{LIMBU SIGN KEMPHRENG}\N{SHARADA VOWEL MODIFIER MARK}\N{SHARADA EXTRA SHORT VOWEL MARK}]
`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%5CN%7BORIYA+SIGN+OVERLINE%7D%5CN%7BTHAI+CHARACTER+MAITAIKHU%7D%5CN%7BLIMBU+SIGN+KEMPHRENG%7D%5CN%7BSHARADA+VOWEL+MODIFIER+MARK%7D%5CN%7BSHARADA+EXTRA+SHORT+VOWEL+MARK%7D%5D&g=&i=alpha+dia+ext) which are all diacritics.