### PR TITLE
UCA: new-script draft sample characters for 16+

### DIFF
--- a/unicodetools/src/main/java/org/unicode/text/UCA/ReorderCodes.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/ReorderCodes.java
@@ -139,9 +139,37 @@ public class ReorderCodes {
             // TODO:
             // - Remove scripts supported by ICU4J UScript and CLDR ScriptMetadata.
             // - Add scripts not yet supported there.
+            //
+            // See https://www.unicode.org/alloc/Pipeline.html
+            // and https://cldr.unicode.org/development/updating-codes/updating-script-metadata
             switch (reorderCode) {
                     //            case UCD_Types.Old_Hungarian:
                     //                return "𐲡";
+                    // Approved for Unicode 16:
+                case UCD_Types.Garay:
+                    return "\uD803\uDD5D";
+                case UCD_Types.Gurung_Khema:
+                    return "\uD818\uDD12";
+                case UCD_Types.Kirat_Rai:
+                    return "\uD81B\uDD4B";
+                case UCD_Types.Ol_Onal:
+                    return "\uD839\uDDD0";
+                case UCD_Types.Sunuwar:
+                    return "\uD806\uDFC4";
+                case UCD_Types.Todhri:
+                    return "\uD801\uDDC2";
+                case UCD_Types.Tulu_Tigalari:
+                    return "\uD804\uDF92";
+
+                    // Provisionally assigned so far:
+                case UCD_Types.Chisoi:
+                    return "\uD81B\uDD84";
+                case UCD_Types.Sidetic:
+                    return "\uD802\uDD50";
+                case UCD_Types.Tai_Yo:
+                    return "\uD839\uDED5";
+                case UCD_Types.Tolong_Siki:
+                    return "\uD807\uDDC6";
                 default:
                     throw new UnsupportedOperationException("unknown reorderCode " + reorderCode);
             }

--- a/unicodetools/src/main/java/org/unicode/text/UCA/ReorderCodes.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/ReorderCodes.java
@@ -149,9 +149,9 @@ public class ReorderCodes {
                 case UCD_Types.Garay:
                     return "\uD803\uDD5D";
                 case UCD_Types.Gurung_Khema:
-                    return "\uD818\uDD12";
+                    return "\uD818\uDD1C";
                 case UCD_Types.Kirat_Rai:
-                    return "\uD81B\uDD4B";
+                    return "\uD81B\uDD45";
                 case UCD_Types.Ol_Onal:
                     return "\uD839\uDDD0";
                 case UCD_Types.Sunuwar:
@@ -163,7 +163,7 @@ public class ReorderCodes {
 
                     // Provisionally assigned so far:
                 case UCD_Types.Chisoi:
-                    return "\uD81B\uDD84";
+                    return "\uD81B\uDD93";
                 case UCD_Types.Sidetic:
                     return "\uD802\uDD50";
                 case UCD_Types.Tai_Yo:


### PR DESCRIPTION
Add draft script sample characters (from the draft CLDR script metadata) for Unicode 16+ scripts.
Removes one hurdle for running UCA.Main for Unicode 16+.
UCA.Main still fails for lack of allkeys data for new characters.