### PR TITLE
Ignore conflict markers in ScriptExtensions

### DIFF
--- a/unicodetools/src/main/java/org/unicode/jsp/FileUtilities.java
+++ b/unicodetools/src/main/java/org/unicode/jsp/FileUtilities.java
@@ -76,6 +76,11 @@ public final class FileUtilities {
                     if (line == null) {
                         break;
                     }
+                    if (line.startsWith("<<<<<<<")
+                            || line.startsWith("=======")
+                            || line.startsWith(">>>>>>>")) {
+                        continue;
+                    }
                     final int comment = line.indexOf("#");
                     if (comment >= 0) {
                         processComment(line, comment);

--- a/unicodetools/src/main/java/org/unicode/jsp/FileUtilities.java
+++ b/unicodetools/src/main/java/org/unicode/jsp/FileUtilities.java
@@ -76,6 +76,7 @@ public final class FileUtilities {
                     if (line == null) {
                         break;
                     }
+                    // Ignore merge conflict markers.
                     if (line.startsWith("<<<<<<<")
                             || line.startsWith("=======")
                             || line.startsWith(">>>>>>>")) {


### PR DESCRIPTION
It just so happens that #419 is only _mostly_ fixed.