### PR TITLE
Indic_Positional_Category for Kirat Rai

### DIFF
--- a/unicodetools/data/ucd/dev/IndicPositionalCategory.txt
+++ b/unicodetools/data/ucd/dev/IndicPositionalCategory.txt
@@ -1,5 +1,5 @@
 # IndicPositionalCategory-16.0.0.txt
-# Date: 2023-11-09, 18:41:18 GMT
+# Date: 2023-11-09, 18:48:36 GMT
 # © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -69,7 +69,7 @@
 # Ahom, Balinese, Batak, Bengali, Bhaiksuki, Brahmi, Buginese, Buhid,
 # Chakma, Cham, Devanagari, Dives Akuru, Dogra, Grantha, Gujarati,
 # Gunjala Gondi, Gurmukhi, Hanunoo, Javanese, Kaithi, Kannada, Kawi,
-# Kayah Li, Kharoshthi, Khmer, Khojki, Khudawadi, Lao, Lepcha, Limbu,
+# Kayah Li, Kharoshthi, Khmer, Khojki, Khudawadi, Kirat Rai, Lao, Lepcha, Limbu,
 # Makasar, Malayalam, Marchen, Masaram Gondi, Meetei Mayek, Modi,
 # Myanmar, Nandinagari, Newa, New Tai Lue, Oriya, Rejang, Saurashtra,
 # Sharada, Siddham, Sinhala, Soyombo, Sundanese, Syloti Nagri,
@@ -83,7 +83,7 @@
 # list of Indic scripts, including those which do not have
 # positional characters. Currently, those additional
 # Indic scripts without positional characters are
-# Kirat Rai, Multani, Phags-pa, and Tai Le.
+# Multani, Phags-pa, and Tai Le.
 #
 # Notes:
 #

--- a/unicodetools/data/ucd/dev/IndicPositionalCategory.txt
+++ b/unicodetools/data/ucd/dev/IndicPositionalCategory.txt
@@ -1,5 +1,5 @@
 # IndicPositionalCategory-16.0.0.txt
-# Date: 2023-11-02, 22:55:33 GMT
+# Date: 2023-11-09, 18:41:18 GMT
 # © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -299,6 +299,9 @@ ABEC          ; Right # Mc       MEETEI MAYEK LUM IYEK
 11F03         ; Right # Mc       KAWI SIGN VISARGA
 11F34..11F35  ; Right # Mc   [2] KAWI VOWEL SIGN AA..KAWI VOWEL SIGN ALTERNATE AA
 11F41         ; Right # Mc       KAWI SIGN KILLER
+16D40..16D42  ; Right # Lm   [3] KIRAT RAI SIGN ANUSVARA..KIRAT RAI SIGN VISARGA
+16D63..16D6A  ; Right # Lo   [8] KIRAT RAI VOWEL SIGN AA..KIRAT RAI VOWEL SIGN AU
+16D6B..16D6C  ; Right # Lm   [2] KIRAT RAI SIGN VIRAMA..KIRAT RAI SIGN SAAT
 
 # Indic_Positional_Category=Left
 

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/MakeUnicodeFiles.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/MakeUnicodeFiles.txt
@@ -972,7 +972,7 @@ File:	IndicPositionalCategory
 # Ahom, Balinese, Batak, Bengali, Bhaiksuki, Brahmi, Buginese, Buhid,
 # Chakma, Cham, Devanagari, Dives Akuru, Dogra, Grantha, Gujarati,
 # Gunjala Gondi, Gurmukhi, Hanunoo, Javanese, Kaithi, Kannada, Kawi,
-# Kayah Li, Kharoshthi, Khmer, Khojki, Khudawadi, Lao, Lepcha, Limbu,
+# Kayah Li, Kharoshthi, Khmer, Khojki, Khudawadi, Kirat Rai, Lao, Lepcha, Limbu,
 # Makasar, Malayalam, Marchen, Masaram Gondi, Meetei Mayek, Modi,
 # Myanmar, Nandinagari, Newa, New Tai Lue, Oriya, Rejang, Saurashtra,
 # Sharada, Siddham, Sinhala, Soyombo, Sundanese, Syloti Nagri,
@@ -986,7 +986,7 @@ File:	IndicPositionalCategory
 # list of Indic scripts, including those which do not have
 # positional characters. Currently, those additional
 # Indic scripts without positional characters are
-# Kirat Rai, Multani, Phags-pa, and Tai Le.
+# Multani, Phags-pa, and Tai Le.
 #
 # Notes:
 #

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
@@ -896,7 +896,7 @@ Let $ideohack = [〆 〇 〡-〩]
 
 # InPC-InSC-gc invariants
 # See https://www.unicode.org/L2/L2023/23200-category-invariants.pdf.
-\p{InPC=/(Left|Right)/} ⊆ [\p{gc=Mc}\p{gc=Lo}]
+\p{InPC=/(Left|Right)/} ⊆ [\p{gc=Mc}\p{gc=Lo}\p{gc=Lm}]
 [\P{InPC=NA}&\p{gc=Mc}] ⊆ \p{InPC=/(Left|Right)/}
 [\P{InPC=NA}&\P{InPC=/(Left|Right)/}] ⊆ [\p{gc=Mn}\p{gc=Lo}]
 \p{gc=Mn} ⊆ \P{InPC=/(Left|Right)/}


### PR DESCRIPTION
It turns out we want it, see https://github.com/unicode-org/unicodetools/pull/445#issuecomment-1798359742.

This is consistent with Roozbeh’s file.

I will fix the linewrapping of the header later, in the Gurung Khema PR.