### PR TITLE
Fix JSP failures with scx

### DIFF
--- a/UnicodeJsps/src/main/java/org/unicode/jsp/XPropertyFactory.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/XPropertyFactory.java
@@ -4,7 +4,6 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.dev.util.UnicodeMap;
-import com.ibm.icu.dev.util.UnicodeMap.EntryRange;
 import com.ibm.icu.lang.CharSequences;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UProperty.NameChoice;
@@ -324,7 +323,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
         Set<String> localeSet = new TreeSet<>();
 
         for (ULocale ulocale : ULocale.getAvailableLocales()) {
-            if (!ulocale.getCountry().isEmpty()) {
+            if (!ulocale.getCountry().isEmpty() || !ulocale.getVariant().isEmpty()) {
                 continue;
                 // we want to skip cases where characters are in the parent locale, but there is no
                 // ULocale parentLocale = ulocale.getParent();
@@ -340,7 +339,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
                     continue;
                 }
             }
-            String locale = ulocale.toString();
+            String locale = ulocale.toLanguageTag();
             localeSet.add(locale);
             for (UnicodeSetIterator it = new UnicodeSetIterator(exemplarSet); it.nextRange(); ) {
                 if (it.codepoint == UnicodeSetIterator.IS_STRING) {
@@ -366,7 +365,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
         }
         if (DEBUG_MULTI) {
             System.out.println("\n" + propertyName);
-            for (EntryRange<String> entry : unicodeMap.entryRanges()) {
+            for (UnicodeMap.EntryRange<String> entry : unicodeMap.entryRanges()) {
                 System.out.println(
                         Utility.hex(entry.codepoint)
                                 + (entry.codepoint == entry.codepointEnd

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/XPropertyFactory.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/XPropertyFactory.java
@@ -381,7 +381,6 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
         String[] localeList = localeSet.toArray(new String[localeSet.size()]);
         String[][] locales = new String[][] {localeList, localeList}; // abbreviations are the same
 
-
         add(
                 new UnicodeProperty.UnicodeMapProperty()
                         .set(unicodeMap)
@@ -390,9 +389,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
                                 propertyAbbreviation,
                                 UnicodeProperty.ENUMERATED,
                                 "1.1")
-                        .addValueAliases(
-                                locales,
-                                AliasAddAction.ADD_MAIN_ALIAS)
+                        .addValueAliases(locales, AliasAddAction.ADD_MAIN_ALIAS)
                         .setMultivalued(true));
     }
 

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/XPropertyFactory.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/XPropertyFactory.java
@@ -96,6 +96,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
         add(
                 new CodepointTransformProperty(
                                 new Transform<Integer, String>() {
+                                    @Override
                                     public String transform(Integer source) {
                                         return Normalizer.normalize(source, Normalizer.NFC);
                                     }
@@ -105,6 +106,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
         add(
                 new CodepointTransformProperty(
                                 new Transform<Integer, String>() {
+                                    @Override
                                     public String transform(Integer source) {
                                         return Normalizer.normalize(source, Normalizer.NFD);
                                     }
@@ -114,6 +116,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
         add(
                 new CodepointTransformProperty(
                                 new Transform<Integer, String>() {
+                                    @Override
                                     public String transform(Integer source) {
                                         return Normalizer.normalize(source, Normalizer.NFKC);
                                     }
@@ -123,6 +126,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
         add(
                 new CodepointTransformProperty(
                                 new Transform<Integer, String>() {
+                                    @Override
                                     public String transform(Integer source) {
                                         return Normalizer.normalize(source, Normalizer.NFKD);
                                     }
@@ -133,6 +137,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
         add(
                 new StringTransformProperty(
                                 new StringTransform() {
+                                    @Override
                                     public String transform(String source) {
                                         return UCharacter.foldCase(source, true);
                                     }
@@ -142,6 +147,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
         add(
                 new StringTransformProperty(
                                 new StringTransform() {
+                                    @Override
                                     public String transform(String source) {
                                         return UCharacter.toLowerCase(ULocale.ROOT, source);
                                     }
@@ -151,6 +157,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
         add(
                 new StringTransformProperty(
                                 new StringTransform() {
+                                    @Override
                                     public String transform(String source) {
                                         return UCharacter.toUpperCase(ULocale.ROOT, source);
                                     }
@@ -160,6 +167,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
         add(
                 new StringTransformProperty(
                                 new StringTransform() {
+                                    @Override
                                     public String transform(String source) {
                                         return UCharacter.toTitleCase(ULocale.ROOT, source, null);
                                     }
@@ -170,6 +178,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
         add(
                 new StringTransformProperty(
                                 new StringTransform() {
+                                    @Override
                                     public String transform(String source) {
                                         StringBuilder b = new StringBuilder();
                                         for (int cp : CharSequences.codePoints(source)) {
@@ -184,6 +193,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
         add(
                 new StringTransformProperty(
                                 new StringTransform() {
+                                    @Override
                                     public String transform(String source) {
                                         String result = NFM.nfm.get(source);
                                         return result == null ? source : result;
@@ -201,6 +211,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
         add(
                 new CodepointTransformProperty(
                                 new Transform<Integer, String>() {
+                                    @Override
                                     public String transform(Integer source) {
                                         return UnicodeUtilities.getSubheader().getSubheader(source);
                                     }
@@ -251,7 +262,8 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
                         .setMain("Script_Extensions", "scx", UnicodeProperty.ENUMERATED, "1.1")
                         .addValueAliases(
                                 ScriptTester.getScriptSpecialsAlternates(),
-                                AliasAddAction.IGNORE_IF_MISSING));
+                                AliasAddAction.IGNORE_IF_MISSING)
+                        .setMultivalued(true));
 
         CachedProps cp = CachedProps.CACHED_PROPS;
         for (String prop : cp.getAvailable()) {
@@ -652,6 +664,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
             setUniformUnassigned(hasUniformUnassigned);
         }
 
+        @Override
         protected String _getValue(int codepoint) {
             return transform.transform(UTF16.valueOf(codepoint));
         }
@@ -666,6 +679,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
             setUniformUnassigned(hasUniformUnassigned);
         }
 
+        @Override
         protected String _getValue(int codepoint) {
             return transform.transform(codepoint);
         }
@@ -682,6 +696,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
             encoder = new CharEncoder(charset, false, false);
         }
 
+        @Override
         protected String _getValue(int codepoint) {
             int len = encoder.getValue(codepoint, temp, 0);
             if (len < 0) {
@@ -697,6 +712,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
             return result.toString();
         }
 
+        @Override
         public boolean isDefault(int codepoint) {
             int len = encoder.getValue(codepoint, temp, 0);
             return len < 0;
@@ -716,6 +732,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
             encoder = new CharEncoder(charset, true, true);
         }
 
+        @Override
         protected String _getValue(int codepoint) {
             return (encoder.getValue(codepoint, null, 0) > 0) ? "Yes" : "No";
         }
@@ -731,6 +748,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
             return this;
         }
 
+        @Override
         protected UnicodeMap<String> _getUnicodeMap() {
             UnicodeMap<String> result = new UnicodeMap<String>();
             result.putAll(unicodeSet, "Yes");
@@ -743,10 +761,12 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
             return set(new UnicodeSet(string).freeze());
         }
 
+        @Override
         protected String _getValue(int codepoint) {
             return YESNO_ARRAY[unicodeSet.contains(codepoint) ? 0 : 1];
         }
 
+        @Override
         protected List _getAvailableValues(List result) {
             return YESNO;
         }

--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestMultivalued.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestMultivalued.java
@@ -36,12 +36,12 @@ public class TestMultivalued extends TestFmwkMinusMinus {
                 "Multivalued property values can't contain commas.",
                 exceptionMessage);
     }
-    
+
     @Test
     public void TestExemplars() {
         String unicodeSetString = "\\p{exem=da}";
         UnicodeSet parsed = UnicodeSetUtilities.parseUnicodeSet(unicodeSetString);
-        
+
         UnicodeSet mustContain = new UnicodeSet("[æ]");
         assertTrue(unicodeSetString + " contains " + mustContain, parsed.containsAll(mustContain));
 

--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestMultivalued.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestMultivalued.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.unicode.jsp.UnicodeSetUtilities;
 import org.unicode.unittest.TestFmwkMinusMinus;
 
-public class TestScriptExtensions extends TestFmwkMinusMinus {
+public class TestMultivalued extends TestFmwkMinusMinus {
     @Test
     public void TestScx1Script() {
         // As of 2023-11-24, scx was not working properly
@@ -35,5 +35,19 @@ public class TestScriptExtensions extends TestFmwkMinusMinus {
                 "Expected exception",
                 "Multivalued property values can't contain commas.",
                 exceptionMessage);
+    }
+    
+    @Test
+    public void TestExemplars() {
+        String unicodeSetString = "\\p{exem=da}";
+        UnicodeSet parsed = UnicodeSetUtilities.parseUnicodeSet(unicodeSetString);
+        
+        UnicodeSet mustContain = new UnicodeSet("[æ]");
+        assertTrue(unicodeSetString + " contains " + mustContain, parsed.containsAll(mustContain));
+
+        UnicodeSet mustNotContain = new UnicodeSet("[ç]");
+        assertFalse(
+                unicodeSetString + " !contains " + mustNotContain,
+                parsed.containsAll(mustNotContain));
     }
 }

--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestMultivalued.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestMultivalued.java
@@ -14,7 +14,7 @@ public class TestMultivalued extends TestFmwkMinusMinus {
         UnicodeSet mustContain = new UnicodeSet("[ᳵ।]"); // one character B&D, other B&D&D&G&...
         assertTrue(unicodeSetString + " contains " + mustContain, parsed.containsAll(mustContain));
 
-        UnicodeSet mustNotContain = new UnicodeSet("[ক]"); // one Bengali character
+        UnicodeSet mustNotContain = new UnicodeSet("[ক]"); // one Bangla character
         assertFalse(
                 unicodeSetString + " !contains " + mustNotContain,
                 parsed.containsAll(mustNotContain));

--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestMultivalued.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestMultivalued.java
@@ -8,7 +8,6 @@ import org.unicode.unittest.TestFmwkMinusMinus;
 public class TestMultivalued extends TestFmwkMinusMinus {
     @Test
     public void TestScx1Script() {
-        // As of 2023-11-24, scx was not working properly
         String unicodeSetString = "\\p{scx=deva}";
         UnicodeSet parsed = UnicodeSetUtilities.parseUnicodeSet(unicodeSetString);
 
@@ -23,7 +22,6 @@ public class TestMultivalued extends TestFmwkMinusMinus {
 
     @Test
     public void TestScxMulti() {
-        // As of 2023-11-24, scx was not working properly
         String unicodeSetString = "\\p{scx=beng,deva}";
         String exceptionMessage = null;
         try {

--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestScriptExtensions.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestScriptExtensions.java
@@ -7,10 +7,33 @@ import org.unicode.unittest.TestFmwkMinusMinus;
 
 public class TestScriptExtensions extends TestFmwkMinusMinus {
     @Test
-    public void TestBasic() {
+    public void TestScx1Script() {
         // As of 2023-11-24, scx was not working properly
-        String setA = "\\p{scx=deva}";
-        UnicodeSet deva = UnicodeSetUtilities.parseUnicodeSet(setA);
-        assertTrue(setA + "contains \\u1CD5", deva.contains(0x1cd5));
+        String unicodeSetString = "\\p{scx=deva}";
+        UnicodeSet parsed = UnicodeSetUtilities.parseUnicodeSet(unicodeSetString);
+
+        UnicodeSet mustContain = new UnicodeSet("[ᳵ।]"); // one character B&D, other B&D&D&G&...
+        assertTrue(unicodeSetString + " contains " + mustContain, parsed.containsAll(mustContain));
+
+        UnicodeSet mustNotContain = new UnicodeSet("[ক]"); // one Bengali character
+        assertFalse(
+                unicodeSetString + " !contains " + mustNotContain,
+                parsed.containsAll(mustNotContain));
+    }
+
+    @Test
+    public void TestScxMulti() {
+        // As of 2023-11-24, scx was not working properly
+        String unicodeSetString = "\\p{scx=beng,deva}";
+        String exceptionMessage = null;
+        try {
+            UnicodeSet parsed = UnicodeSetUtilities.parseUnicodeSet(unicodeSetString);
+        } catch (Exception e) {
+            exceptionMessage = e.getMessage();
+        }
+        assertEquals(
+                "Expected exception",
+                "Multivalued property values can't contain commas.",
+                exceptionMessage);
     }
 }

--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestScriptExtensions.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestScriptExtensions.java
@@ -1,0 +1,16 @@
+package org.unicode.jsptest;
+
+import com.ibm.icu.text.UnicodeSet;
+import org.junit.jupiter.api.Test;
+import org.unicode.jsp.UnicodeSetUtilities;
+import org.unicode.unittest.TestFmwkMinusMinus;
+
+public class TestScriptExtensions extends TestFmwkMinusMinus {
+    @Test
+    public void TestBasic() {
+        // As of 2023-11-24, scx was not working properly
+        String setA = "\\p{scx=deva}";
+        UnicodeSet deva = UnicodeSetUtilities.parseUnicodeSet(setA);
+        assertTrue(setA + "contains \\u1CD5", deva.contains(0x1cd5));
+    }
+}

--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestUnicodeSet.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestUnicodeSet.java
@@ -414,14 +414,6 @@ public class TestUnicodeSet extends TestFmwk2 {
     }
 
     @Test
-    public void TestScriptSpecials() {
-        //        UnicodeSet set = UnicodeSetUtilities.parseUnicodeSet("[:scs=Hant:]");
-        //        assertNotEquals("Hant", 0, set.size());
-        UnicodeSet set2 = UnicodeSetUtilities.parseUnicodeSet("[:scx=Arab,Syrc:]");
-        assertNotEquals("Arab Syrc", 0, set2.size());
-    }
-
-    @Test
     public void TestGC() {
         Map<String, R2<String, UnicodeSet>> SPECIAL_GC =
                 new LinkedHashMap<String, R2<String, UnicodeSet>>();

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -152,9 +152,9 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     private Map<String, String> valueToFirstValueAlias = null;
 
     private boolean hasUniformUnassigned = true;
-    
+
     private boolean isMultivalued = false;
-    
+
     public UnicodeProperty setMultivalued(boolean value) {
         isMultivalued = value;
         return this;
@@ -387,10 +387,15 @@ public abstract class UnicodeProperty extends UnicodeLabel {
      * the original contents.
      */
     public final UnicodeSet getSet(String propertyValue, UnicodeSet result) {
-        return getSet(
-                new SimpleMatcher(
-                        propertyValue, isType(STRING_OR_MISC_MASK) ? null : PROPERTY_COMPARATOR),
-                result);
+        if (isMultivalued && propertyValue.contains(",")) {
+            throw new IllegalArgumentException("Multivalued property values can't contain commas.");
+        } else {
+            return getSet(
+                    new SimpleMatcher(
+                            propertyValue,
+                            isType(STRING_OR_MISC_MASK) ? null : PROPERTY_COMPARATOR),
+                    result);
+        }
     }
 
     private UnicodeMap<String> unicodeMap = null;
@@ -423,12 +428,12 @@ public abstract class UnicodeProperty extends UnicodeLabel {
                 String value2 = it2.next();
                 // System.out.println("Values:" + value2);
                 if (isMultivalued && value2.contains(",")) {
-                   for (String part : SPLIT_COMMAS.split(value2)) {
-                       if (matcher.test(part) || matcher.test(toSkeleton(part))) {
-                           um.keySet(value, result);
-                           continue main;
-                       }
-                   }
+                    for (String part : SPLIT_COMMAS.split(value2)) {
+                        if (matcher.test(part) || matcher.test(toSkeleton(part))) {
+                            um.keySet(value, result);
+                            continue main;
+                        }
+                    }
                 } else if (matcher.test(value2) || matcher.test(toSkeleton(value2))) {
                     um.keySet(value, result);
                     continue main;


### PR DESCRIPTION
Fixes https://github.com/unicode-org/unicodetools/issues/192

scx=deva has not been working; the results were essentially the same as sc=deva

As it turns out, the code really never accounted for multivalued properties. So when testing for values, an scx value like "Devanagari,Bengali" would be skipped. 

The code change was simple; to change the code so that a UnicodeProperty could be marked as multivalued, and when comparing values there would be an extra level: splitting the property value if there was a ",", and otherwise testing like a single value. Now, this is done on each unique value rather than on each code point, so it doesn't affect performance much (especially as there are not many unique multivalue property values).

Ideally we should revamp UnicodeProperty to support multivalued properties more directly, but that would be a much bigger overhaul.

UnicodeJsps/src/main/java/org/unicode/jsp/XPropertyFactory.java
- Set scx to be multivalued
- Add other examples of multivalued (namely exemplars, with new addExamplarProperty())
- The rest was Eclipse cleanup of `@Override`. There are a few other similar Eclipse cleanups in other files.

UnicodeJsps/src/test/java/org/unicode/jsptest/TestMultivalued.java
- Added tests
- Also verifies that \p{scx=beng,deva} doesn't work

UnicodeJsps/src/test/java/org/unicode/jsptest/TestUnicodeSet.java
- Removes test for Arab,Deva (since that is now disabled)

unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
- Makes small changes to enable multivalued properties, with comma between values
- Disables values like \p{scx=beng,deva}. These never worked right, and can always be computed with [\p{scx=beng}&\p{scx=deva}] if one wants restriction, and [\p{scx=beng}\p{scx=deva}] if one wants inclusion.