### PR TITLE
Fix remaining issues with multivalued

### DIFF
--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeSetUtilities.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeSetUtilities.java
@@ -150,6 +150,7 @@ public class UnicodeSetUtilities {
         //      return null;
         //    }
 
+        @Override
         public boolean applyPropertyAlias(
                 String propertyName, String propertyValue, UnicodeSet result) {
             boolean status = false;
@@ -201,9 +202,11 @@ public class UnicodeSetUtilities {
                     }
                     ;
                     if (!status) {
-                        try {
-                            status = applyPropertyAlias0(prop, "No", result, !invert);
-                        } catch (Exception e) {
+                        if (prop.isType(UnicodeProperty.BINARY_OR_ENUMERATED_OR_CATALOG_MASK)) {
+                            try {
+                                status = applyPropertyAlias0(prop, "No", result, !invert);
+                            } catch (Exception e) {
+                            }
                         }
                         ;
                         if (!status) {
@@ -336,6 +339,7 @@ public class UnicodeSetUtilities {
             this.pattern = pattern;
         }
 
+        @Override
         public boolean test(String value) {
             int comp = comparator.compare(pattern, value.toString());
             switch (relation) {
@@ -352,6 +356,7 @@ public class UnicodeSetUtilities {
             }
         }
 
+        @Override
         public PatternMatcher set(String pattern) {
             this.pattern = pattern;
             return this;

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/XPropertyFactory.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/XPropertyFactory.java
@@ -269,15 +269,19 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
 
         // set up the special script property
         UnicodeProperty scriptProp = base.getProperty("sc");
+
+        // Compose the function and add
         UnicodeMap<String> specialMap = new UnicodeMap<String>();
-        specialMap.putAll(scriptProp.getUnicodeMap());
+        specialMap.putAll(
+                scriptProp.getUnicodeMap()); // if there is no value, use the script property
         specialMap.putAll(ScriptTester.getScriptSpecialsNames());
         add(
                 new UnicodeProperty.UnicodeMapProperty()
                         .set(specialMap)
                         .setMain("Script_Extensions", "scx", UnicodeProperty.ENUMERATED, "1.1")
                         .addValueAliases(
-                                ScriptTester.getScriptSpecialsAlternates(),
+                                // valueArray,
+                                ScriptTester.getScriptSpecialsAlternates(scriptProp),
                                 AliasAddAction.IGNORE_IF_MISSING)
                         .setMultivalued(true));
 
@@ -359,6 +363,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
 
         // convert to UnicodeMap
         UnicodeMap<String> unicodeMap = new UnicodeMap<>();
+        unicodeMap.putAll(0, 0x10FFFF, ""); // default is empty string
         for (Entry<Integer, Collection<String>> entry : data.asMap().entrySet()) {
             String value = JOIN_COMMAS.join(entry.getValue()).intern();
             unicodeMap.put(entry.getKey(), value);
@@ -383,11 +388,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
         add(
                 new UnicodeProperty.UnicodeMapProperty()
                         .set(unicodeMap)
-                        .setMain(
-                                propertyName,
-                                propertyAbbreviation,
-                                UnicodeProperty.ENUMERATED,
-                                "1.1")
+                        .setMain(propertyName, propertyAbbreviation, UnicodeProperty.STRING, "1.1")
                         .addValueAliases(locales, AliasAddAction.ADD_MAIN_ALIAS)
                         .setMultivalued(true));
     }

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/XPropertyFactory.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/XPropertyFactory.java
@@ -280,7 +280,6 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
                         .set(specialMap)
                         .setMain("Script_Extensions", "scx", UnicodeProperty.ENUMERATED, "1.1")
                         .addValueAliases(
-                                // valueArray,
                                 ScriptTester.getScriptSpecialsAlternates(scriptProp),
                                 AliasAddAction.IGNORE_IF_MISSING)
                         .setMultivalued(true));

--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestMultivalued.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestMultivalued.java
@@ -3,15 +3,37 @@ package org.unicode.jsptest;
 import com.ibm.icu.text.UnicodeSet;
 import org.junit.jupiter.api.Test;
 import org.unicode.jsp.UnicodeSetUtilities;
+import org.unicode.jsp.XPropertyFactory;
+import org.unicode.props.UnicodeProperty;
 import org.unicode.unittest.TestFmwkMinusMinus;
 
 public class TestMultivalued extends TestFmwkMinusMinus {
+
+    UnicodeProperty exemplarProp = XPropertyFactory.make().getProperty("exemplar");
+    UnicodeProperty scxProp = XPropertyFactory.make().getProperty("scx");
+
     @Test
     public void TestScx1Script() {
+        String x = scxProp.getValue('।');
+
         String unicodeSetString = "\\p{scx=deva}";
         UnicodeSet parsed = UnicodeSetUtilities.parseUnicodeSet(unicodeSetString);
 
         UnicodeSet mustContain = new UnicodeSet("[ᳵ।]"); // one character B&D, other B&D&D&G&...
+        assertTrue(unicodeSetString + " contains " + mustContain, parsed.containsAll(mustContain));
+
+        UnicodeSet mustNotContain = new UnicodeSet("[ক]"); // one Bangla character
+        assertFalse(
+                unicodeSetString + " !contains " + mustNotContain,
+                parsed.containsAll(mustNotContain));
+    }
+
+    @Test
+    public void TestScx1ScriptB() {
+        String unicodeSetString = "\\p{scx=Arab}";
+        UnicodeSet parsed = UnicodeSetUtilities.parseUnicodeSet(unicodeSetString);
+
+        UnicodeSet mustContain = new UnicodeSet("[،ء]"); // one character single script, one multi
         assertTrue(unicodeSetString + " contains " + mustContain, parsed.containsAll(mustContain));
 
         UnicodeSet mustNotContain = new UnicodeSet("[ক]"); // one Bangla character
@@ -37,6 +59,8 @@ public class TestMultivalued extends TestFmwkMinusMinus {
 
     @Test
     public void TestExemplars() {
+        String x = exemplarProp.getValue('æ');
+
         String unicodeSetString = "\\p{exem=da}";
         UnicodeSet parsed = UnicodeSetUtilities.parseUnicodeSet(unicodeSetString);
 
@@ -47,5 +71,41 @@ public class TestMultivalued extends TestFmwkMinusMinus {
         assertFalse(
                 unicodeSetString + " !contains " + mustNotContain,
                 parsed.containsAll(mustNotContain));
+    }
+
+    @Test
+    public void TestEmpty() {
+        assertEquals("exemplar(0x0000)", "", exemplarProp.getValue(0x0000));
+        assertEquals("exemplar(α)", "el", exemplarProp.getValue('α'));
+
+        UnicodeSet exem = UnicodeSetUtilities.parseUnicodeSet("\\p{exem}");
+        assertTrue("\\p{exem} contains 0", exem.contains(0x0000));
+        assertFalse("\\p{exem} contains α", exem.contains('α'));
+        UnicodeSet exem3 = UnicodeSetUtilities.parseUnicodeSet("\\p{exem=el}");
+        assertFalse("\\p{exem=el} contains 0", exem3.contains(0x0000));
+        assertTrue("\\p{exem=el} contains α", exem3.contains('α'));
+
+        String unicodeSetString = "[\\p{Greek}&\\p{exem}]";
+        UnicodeSet parsed = UnicodeSetUtilities.parseUnicodeSet(unicodeSetString);
+
+        String first = parsed.iterator().next();
+        String firstValue = exemplarProp.getValue(first.codePointAt(0));
+        assertEquals(unicodeSetString, "", firstValue);
+
+        String unicodeSetString2 = "[\\p{Greek}&\\P{exem}]";
+        UnicodeSet parsed2 = UnicodeSetUtilities.parseUnicodeSet(unicodeSetString2);
+
+        String first2 = parsed2.iterator().next();
+        String firstValue2 = exemplarProp.getValue(first2.codePointAt(0));
+        assertEquals(unicodeSetString2, "el", firstValue2);
+
+        //        UnicodeSet mustContain = new UnicodeSet("[æ]");
+        //        assertTrue(unicodeSetString + " contains " + mustContain,
+        // parsed.containsAll(mustContain));
+        //
+        //        UnicodeSet mustNotContain = new UnicodeSet("[ç]");
+        //        assertFalse(
+        //                unicodeSetString + " !contains " + mustNotContain,
+        //                parsed.containsAll(mustNotContain));
     }
 }

--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestMultivalued.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestMultivalued.java
@@ -9,12 +9,16 @@ import org.unicode.unittest.TestFmwkMinusMinus;
 
 public class TestMultivalued extends TestFmwkMinusMinus {
 
+    private static final boolean DEBUG = false;
+
     UnicodeProperty exemplarProp = XPropertyFactory.make().getProperty("exemplar");
     UnicodeProperty scxProp = XPropertyFactory.make().getProperty("scx");
 
     @Test
     public void TestScx1Script() {
-        String x = scxProp.getValue('।');
+        if (DEBUG) {
+            String x = scxProp.getValue('।');
+        }
 
         String unicodeSetString = "\\p{scx=deva}";
         UnicodeSet parsed = UnicodeSetUtilities.parseUnicodeSet(unicodeSetString);
@@ -59,7 +63,9 @@ public class TestMultivalued extends TestFmwkMinusMinus {
 
     @Test
     public void TestExemplars() {
-        String x = exemplarProp.getValue('æ');
+        if (DEBUG) {
+            String x = exemplarProp.getValue('æ');
+        }
 
         String unicodeSetString = "\\p{exem=da}";
         UnicodeSet parsed = UnicodeSetUtilities.parseUnicodeSet(unicodeSetString);
@@ -98,14 +104,5 @@ public class TestMultivalued extends TestFmwkMinusMinus {
         String first2 = parsed2.iterator().next();
         String firstValue2 = exemplarProp.getValue(first2.codePointAt(0));
         assertEquals(unicodeSetString2, "el", firstValue2);
-
-        //        UnicodeSet mustContain = new UnicodeSet("[æ]");
-        //        assertTrue(unicodeSetString + " contains " + mustContain,
-        // parsed.containsAll(mustContain));
-        //
-        //        UnicodeSet mustNotContain = new UnicodeSet("[ç]");
-        //        assertFalse(
-        //                unicodeSetString + " !contains " + mustNotContain,
-        //                parsed.containsAll(mustNotContain));
     }
 }

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -190,7 +190,14 @@ public abstract class UnicodeProperty extends UnicodeLabel {
                     (1 << ENUMERATED)
                             | (1 << EXTENDED_ENUMERATED)
                             | (1 << CATALOG)
-                            | (1 << EXTENDED_CATALOG);
+                            | (1 << EXTENDED_CATALOG),
+            BINARY_OR_ENUMERATED_OR_CATALOG_MASK =
+                    (1 << ENUMERATED)
+                            | (1 << EXTENDED_ENUMERATED)
+                            | (1 << CATALOG)
+                            | (1 << EXTENDED_CATALOG)
+                            | (1 << BINARY)
+                            | (1 << EXTENDED_BINARY);
 
     private static final String[] TYPE_NAMES = {
         "Unknown",
@@ -405,7 +412,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     public UnicodeSet getSet(PatternMatcher matcher, UnicodeSet result) {
         if (result == null) result = new UnicodeSet();
         boolean uniformUnassigned = hasUniformUnassigned();
-        if (isType(STRING_OR_MISC_MASK)) {
+        if (isType(STRING_OR_MISC_MASK) && !isMultivalued) {
             for (UnicodeSetIterator usi = getStuffToTest(uniformUnassigned);
                     usi.next(); ) { // int i = 0; i <= 0x10FFFF; ++i
                 int i = usi.codepoint;
@@ -423,7 +430,8 @@ public abstract class UnicodeProperty extends UnicodeLabel {
         while (it.hasNext()) {
             String value = it.next();
             temp.clear();
-            Iterator<String> it2 = getValueAliases(value, temp).iterator();
+            final List<String> valueAliases = getValueAliases(value, temp);
+            Iterator<String> it2 = valueAliases.iterator();
             while (it2.hasNext()) {
                 String value2 = it2.next();
                 // System.out.println("Values:" + value2);


### PR DESCRIPTION
There were two further problems with multivalued support

1. \p{exemplar} (has no exemplar value) returned the reverse of what was expected
2. \p{scx=Arab} didn't work right.

The solution to these was to (1) allow for "" properly as a string value, and (2) allow script values that were not present in ScriptExtensions.txt as single values.

UnicodeJsps/src/main/java/org/unicode/jsp/ScriptTester.java
- Supply the Script values in addition to the Script_Extension values as valid alternate aliases.

UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeSetUtilities.java
- Expand an empty value to be "No" only for binary, enumerated, and catalogue properties

UnicodeJsps/src/main/java/org/unicode/jsp/XPropertyFactory.java
- main change is to allow "" as the default value in the scx map

UnicodeJsps/src/test/java/org/unicode/jsptest/TestMultivalued.java
- Add some tests for the problems seen above

unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
- add a mask for  BINARY_OR_ENUMERATED_OR_CATALOG_MASK
- if a property is multivalued, don't skip over string values.

Notes:

1. As before, Eclipse helpfully adds missing @Override annotations
2. The exemplars really should be treated like enumerations (over locales), but that was a bit too complicated for a first run.
