### PR TITLE
UTC-178-A13: jg long alias Teh_Marbuta_Goal

### DIFF
--- a/unicodetools/data/ucd/dev/PropertyValueAliases.txt
+++ b/unicodetools/data/ucd/dev/PropertyValueAliases.txt
@@ -1,5 +1,5 @@
 # PropertyValueAliases-16.0.0.txt
-# Date: 2024-01-23, 01:51:24 GMT
+# Date: 2024-01-31
 # © 2023 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -1085,7 +1085,7 @@ jg ; Syriac_Waw                       ; Syriac_Waw
 jg ; Tah                              ; Tah
 jg ; Taw                              ; Taw
 jg ; Teh_Marbuta                      ; Teh_Marbuta
-jg ; Teh_Marbuta_Goal                 ; Hamza_On_Heh_Goal
+jg ; Teh_Marbuta_Goal                 ; Teh_Marbuta_Goal                 ; Hamza_On_Heh_Goal
 jg ; Teth                             ; Teth
 jg ; Thin_Yeh                         ; Thin_Yeh
 jg ; Vertical_Tail                    ; Vertical_Tail

--- a/unicodetools/src/main/java/org/unicode/props/UcdPropertyValues.java
+++ b/unicodetools/src/main/java/org/unicode/props/UcdPropertyValues.java
@@ -1305,7 +1305,7 @@ public class UcdPropertyValues {
         Tah("Tah"),
         Taw("Taw"),
         Teh_Marbuta("Teh_Marbuta"),
-        Hamza_On_Heh_Goal("Teh_Marbuta_Goal"),
+        Teh_Marbuta_Goal("Teh_Marbuta_Goal", "Hamza_On_Heh_Goal"),
         Teth("Teth"),
         Thin_Yeh("Thin_Yeh"),
         Vertical_Tail("Vertical_Tail"),

--- a/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
@@ -1054,13 +1054,10 @@ public class MakeUnicodeFiles {
                     // HACK
                     Tabber mt = mt2;
                     if (l.size() == 1) {
-                        if (propName.equals("Canonical_Combining_Class")) {
-                            continue;
-                        }
                         l.add(0, l.get(0)); // double up
                     } else if (propName.equals("Canonical_Combining_Class")) {
-                        if (l.size() == 2) {
-                            l.add(l.get(1)); // double up final value
+                        if (l.get(1).equals(l.get(0)) && l.get(2).equals(l.get(0))) {
+                            continue;
                         }
                         mt = mt3;
                     } else if (l.size() == 2 && propName.equals("Decomposition_Type")) {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/ToolUnicodePropertySource.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/ToolUnicodePropertySource.java
@@ -2007,19 +2007,15 @@ public class ToolUnicodePropertySource extends UnicodeProperty.Factory {
                                         UCD_Names.EXTRA_GENERAL_CATEGORY,
                                         result);
                             case UCD_Types.COMBINING_CLASS >> 8:
-                                addUnique(
-                                        String.valueOf(
-                                                Utility.lookupShort(
-                                                        valueAlias,
-                                                        UCD_Names.LONG_COMBINING_CLASS,
-                                                        true)),
-                                        result);
-                                return lookup(
-                                        valueAlias,
-                                        UCD_Names.LONG_COMBINING_CLASS,
-                                        UCD_Names.COMBINING_CLASS,
-                                        null,
-                                        result);
+                                // The `lookup` function does lookup by long value, and returns
+                                // (long, short, additional aliases).
+                                // For CCC we want to support lookup by long value here, but to
+                                // return (numeric, short, long).
+                                short numericCCC = Utility.lookupShort(valueAlias, UCD_Names.LONG_COMBINING_CLASS, true);
+                                result.add(Short.toString(numericCCC));
+                                result.add(Utility.getUnskeleton(UCD_Names.COMBINING_CLASS[numericCCC], true));
+                                result.add(Utility.getUnskeleton(UCD_Names.LONG_COMBINING_CLASS[numericCCC], true));
+                                return result;
                             case UCD_Types.BIDI_CLASS >> 8:
                                 return lookup(
                                         valueAlias,
@@ -2028,17 +2024,11 @@ public class ToolUnicodePropertySource extends UnicodeProperty.Factory {
                                         null,
                                         result);
                             case UCD_Types.DECOMPOSITION_TYPE >> 8:
-                                lookup(
-                                        valueAlias,
-                                        UCD_Names.LONG_DECOMPOSITION_TYPE,
-                                        FIXED_DECOMPOSITION_TYPE,
-                                        null,
-                                        result);
                                 return lookup(
                                         valueAlias,
                                         UCD_Names.LONG_DECOMPOSITION_TYPE,
-                                        UCD_Names.DECOMPOSITION_TYPE,
-                                        null,
+                                        TITLECASE_SHORT_DECOMPOSITION_TYPE,
+                                        LONG_TO_LOWERCASE_SHORT_DECOMPOSITION_TYPE,
                                         result);
                             case UCD_Types.NUMERIC_TYPE >> 8:
                                 return lookup(
@@ -2285,9 +2275,9 @@ public class ToolUnicodePropertySource extends UnicodeProperty.Factory {
         // System.out.println("=>" + aux[pos]);
         if (aux != null) {
             final int pos = Utility.lookupShort(valueAlias, main, true);
-            UnicodeProperty.addUnique(aux[pos], result);
+            result.add(aux[pos]);
         }
-        UnicodeProperty.addUnique(valueAlias, result);
+        result.add(valueAlias);
         if (aux2 != null) {
             final Set<String> xtra = aux2.getAll(valueAlias);
             if (xtra != null) {
@@ -2384,13 +2374,16 @@ public class ToolUnicodePropertySource extends UnicodeProperty.Factory {
         YNTF.putAll("Maybe", Arrays.asList(MAYBE_VALUES));
     }
 
-    private static final String[] FIXED_DECOMPOSITION_TYPE =
+    private static final String[] TITLECASE_SHORT_DECOMPOSITION_TYPE =
             new String[UCD_Names.DECOMPOSITION_TYPE.length];
+    private static final Relation<String, String> LONG_TO_LOWERCASE_SHORT_DECOMPOSITION_TYPE =
+            new Relation<String, String>(new HashMap<String, Set<String>>(), LinkedHashSet.class);
 
     static {
         for (int i = 0; i < UCD_Names.DECOMPOSITION_TYPE.length; ++i) {
-            FIXED_DECOMPOSITION_TYPE[i] =
+            TITLECASE_SHORT_DECOMPOSITION_TYPE[i] =
                     Utility.getUnskeleton(UCD_Names.DECOMPOSITION_TYPE[i], true);
+            LONG_TO_LOWERCASE_SHORT_DECOMPOSITION_TYPE.put(UCD_Names.LONG_DECOMPOSITION_TYPE[i], UCD_Names.DECOMPOSITION_TYPE[i]);
         }
     }
 

--- a/unicodetools/src/main/java/org/unicode/text/UCD/ToolUnicodePropertySource.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/ToolUnicodePropertySource.java
@@ -2011,10 +2011,16 @@ public class ToolUnicodePropertySource extends UnicodeProperty.Factory {
                                 // (long, short, additional aliases).
                                 // For CCC we want to support lookup by long value here, but to
                                 // return (numeric, short, long).
-                                short numericCCC = Utility.lookupShort(valueAlias, UCD_Names.LONG_COMBINING_CLASS, true);
+                                short numericCCC =
+                                        Utility.lookupShort(
+                                                valueAlias, UCD_Names.LONG_COMBINING_CLASS, true);
                                 result.add(Short.toString(numericCCC));
-                                result.add(Utility.getUnskeleton(UCD_Names.COMBINING_CLASS[numericCCC], true));
-                                result.add(Utility.getUnskeleton(UCD_Names.LONG_COMBINING_CLASS[numericCCC], true));
+                                result.add(
+                                        Utility.getUnskeleton(
+                                                UCD_Names.COMBINING_CLASS[numericCCC], true));
+                                result.add(
+                                        Utility.getUnskeleton(
+                                                UCD_Names.LONG_COMBINING_CLASS[numericCCC], true));
                                 return result;
                             case UCD_Types.BIDI_CLASS >> 8:
                                 return lookup(
@@ -2383,7 +2389,8 @@ public class ToolUnicodePropertySource extends UnicodeProperty.Factory {
         for (int i = 0; i < UCD_Names.DECOMPOSITION_TYPE.length; ++i) {
             TITLECASE_SHORT_DECOMPOSITION_TYPE[i] =
                     Utility.getUnskeleton(UCD_Names.DECOMPOSITION_TYPE[i], true);
-            LONG_TO_LOWERCASE_SHORT_DECOMPOSITION_TYPE.put(UCD_Names.LONG_DECOMPOSITION_TYPE[i], UCD_Names.DECOMPOSITION_TYPE[i]);
+            LONG_TO_LOWERCASE_SHORT_DECOMPOSITION_TYPE.put(
+                    UCD_Names.LONG_DECOMPOSITION_TYPE[i], UCD_Names.DECOMPOSITION_TYPE[i]);
         }
     }
 


### PR DESCRIPTION
UTC-178-A13 Action Item for Mark Davis, PAG: Make the proposed change to PropertyValueAliases.txt to fix the long value alias for jg=Teh_Marbuta_Goal. For Unicode 16.0. See L2/24-009 item 2.6.

The code (with a function called "add unique") had inadvertently put the third alias into the slot for the long=second one because that happened to be the same as the first one.