### PR TITLE
Miscellaneous fixes to IUP

### DIFF
--- a/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
@@ -686,7 +686,8 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
                 for (UnicodeMap.EntryRange<String> range : raw.entryRanges()) {
                     if (range.codepoint == -1) {
                         newMap.put(range.string, range.value);
-                    } else if (DefaultValueType.forString(range.value) == DefaultValueType.CODE_POINT
+                    } else if (DefaultValueType.forString(range.value)
+                                    == DefaultValueType.CODE_POINT
                             || (prop == UcdProperty.Name && range.value.endsWith("#"))) {
                         for (int c = range.codepoint; c <= range.codepointEnd; ++c) {
                             newMap.put(c, resolveValue(range.value, c));

--- a/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
@@ -688,7 +688,7 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
                     if (DefaultValueType.forString(range.value) == DefaultValueType.CODE_POINT
                             || (prop == UcdProperty.Name && range.value.endsWith("#"))) {
                         for (int c = range.codepoint; c <= range.codepointEnd; ++c) {
-                            newMap.put(c, _getValue(c));
+                            newMap.put(c, resolveValue(range.value, c));
                         }
                     } else {
                         newMap.putAll(range.codepoint, range.codepointEnd, range.value);
@@ -707,16 +707,16 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
         @Override
         protected String _getValue(int codepoint) {
             final String result = _getRawUnicodeMap().get(codepoint);
-            if (!seen.contains(prop)) {
-                seen.add(prop);
-                System.out.println(prop);
-            }
-            if (DefaultValueType.forString(result) == DefaultValueType.CODE_POINT) {
+            return resolveValue(result, codepoint);
+        }
+
+        private String resolveValue(String rawValue, int codepoint) {
+            if (DefaultValueType.forString(rawValue) == DefaultValueType.CODE_POINT) {
                 return Character.toString(codepoint);
-            } else if (prop == UcdProperty.Name && result != null && result.endsWith("#")) {
-                return result.substring(0, result.length() - 1) + Utility.hex(codepoint);
+            } else if (prop == UcdProperty.Name && rawValue != null && result.endsWith("#")) {
+                return rawValue.substring(0, rawValue.length() - 1) + Utility.hex(codepoint);
             } else {
-                return result;
+                return rawValue;
             }
         }
 
@@ -770,6 +770,4 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
     public UnicodeSet loadBinary(UcdProperty ucdProp) {
         return load(ucdProp).getSet(Binary.Yes.toString());
     }
-
-    static Set<UcdProperty> seen = new HashSet<>();
 }

--- a/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
@@ -755,7 +755,7 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
                 result.addAll(enumValueNames);
                 return result;
             }
-            return _getUnicodeMap().getAvailableValues(result);
+            return _getRawUnicodeMap().getAvailableValues(result);
         }
 
         @Override
@@ -767,7 +767,7 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
                 }
             }
             if (!result.contains(valueAlias)) {
-                if (_getUnicodeMap().containsValue(valueAlias)) {
+                if (_getRawUnicodeMap().containsValue(valueAlias)) {
                     result.add(valueAlias);
                 }
             }

--- a/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
@@ -677,19 +677,6 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
         }
 
         @Override
-        public UnicodeSet getSet(PatternMatcher matcher, UnicodeSet result) {
-            final long start = System.currentTimeMillis();
-            result = getSet(matcher, result, () -> _getRawUnicodeMap());
-            final long stop = System.currentTimeMillis();
-            final long Δt_in_ms = stop - start;
-            if (Δt_in_ms > 500) {
-                System.out.println("Long getSet for " + prop + " " + ucdVersion + " " + matcher + ": " + Δt_in_ms + " ms");
-                new Throwable().printStackTrace();
-            }
-            return result;
-        }
-
-        @Override
         public boolean isTrivial() {
             return _getRawUnicodeMap().isEmpty() || _getRawUnicodeMap().keySet("").equals(UnicodeSet.ALL_CODE_POINTS);
         }
@@ -758,7 +745,7 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
                 result.addAll(enumValueNames);
                 return result;
             }
-            return _getRawUnicodeMap().getAvailableValues(result);
+            return _getUnicodeMap().getAvailableValues(result);
         }
 
         @Override
@@ -770,7 +757,8 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
                 }
             }
             if (!result.contains(valueAlias)) {
-                if (_getRawUnicodeMap().containsValue(valueAlias)) {
+                // TODO(egg): We should not be constructing this map for this.
+                if (_getUnicodeMap().containsValue(valueAlias)) {
                     result.add(valueAlias);
                 }
             }

--- a/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
@@ -713,9 +713,7 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
                 final long stop = System.currentTimeMillis();
                 final long Δt_in_ms = stop - start;
                 System.out.println("Built " + prop + " " + ucdVersion + " map in " + Δt_in_ms + " ms");
-                if (Δt_in_ms > 500) {
-                    new Throwable().printStackTrace();
-                }
+                new Throwable().printStackTrace(System.out);
 
                 return newMap;
             } else {

--- a/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
@@ -713,7 +713,7 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
         private String resolveValue(String rawValue, int codepoint) {
             if (DefaultValueType.forString(rawValue) == DefaultValueType.CODE_POINT) {
                 return Character.toString(codepoint);
-            } else if (prop == UcdProperty.Name && rawValue != null && result.endsWith("#")) {
+            } else if (prop == UcdProperty.Name && rawValue != null && rawValue.endsWith("#")) {
                 return rawValue.substring(0, rawValue.length() - 1) + Utility.hex(codepoint);
             } else {
                 return rawValue;

--- a/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
@@ -690,6 +690,11 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
         }
 
         @Override
+        public boolean isTrivial() {
+            return _getRawUnicodeMap().isEmpty() || _getRawUnicodeMap().keySet("").equals(UnicodeSet.ALL_CODE_POINTS);
+        }
+
+        @Override
         protected UnicodeMap<String> _getUnicodeMap() {
             var raw = _getRawUnicodeMap();
             if (prop == UcdProperty.Name

--- a/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
@@ -679,7 +679,7 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
         @Override
         public UnicodeSet getSet(PatternMatcher matcher, UnicodeSet result) {
             final long start = System.currentTimeMillis();
-            result = super.getSet(matcher, result);
+            result = getSet(matcher, result, () -> _getRawUnicodeMap());
             final long stop = System.currentTimeMillis();
             final long Δt_in_ms = stop - start;
             if (Δt_in_ms > 500) {
@@ -691,7 +691,36 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
 
         @Override
         protected UnicodeMap<String> _getUnicodeMap() {
-            return _getRawUnicodeMap();
+            var raw = _getRawUnicodeMap();
+            if (prop == UcdProperty.Name
+                    || raw.containsValue("<code point>")
+                    || raw.containsValue("<codepoint>")) {
+                final long start = System.currentTimeMillis();
+                UnicodeMap<String> newMap = new UnicodeMap<>();
+                for (UnicodeMap.EntryRange<String> range : raw.entryRanges()) {
+                    if (range.codepoint == -1) {
+                        newMap.put(range.string, range.value);
+                    } else if (DefaultValueType.forString(range.value)
+                                    == DefaultValueType.CODE_POINT
+                            || (prop == UcdProperty.Name && range.value.endsWith("#"))) {
+                        for (int c = range.codepoint; c <= range.codepointEnd; ++c) {
+                            newMap.put(c, resolveValue(range.value, c));
+                        }
+                    } else {
+                        newMap.putAll(range.codepoint, range.codepointEnd, range.value);
+                    }
+                }
+                final long stop = System.currentTimeMillis();
+                final long Δt_in_ms = stop - start;
+                System.out.println("Built " + prop + " " + ucdVersion + " map in " + Δt_in_ms + " ms");
+                if (Δt_in_ms > 500) {
+                    new Throwable().printStackTrace();
+                }
+
+                return newMap;
+            } else {
+                return raw;
+            }
         }
 
         protected UnicodeMap<String> _getRawUnicodeMap() {

--- a/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
@@ -678,7 +678,8 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
 
         @Override
         public boolean isTrivial() {
-            return _getRawUnicodeMap().isEmpty() || _getRawUnicodeMap().keySet("").equals(UnicodeSet.ALL_CODE_POINTS);
+            return _getRawUnicodeMap().isEmpty()
+                    || _getRawUnicodeMap().keySet("").equals(UnicodeSet.ALL_CODE_POINTS);
         }
 
         @Override
@@ -704,7 +705,8 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
                 }
                 final long stop = System.currentTimeMillis();
                 final long Δt_in_ms = stop - start;
-                System.out.println("Built " + prop + " " + ucdVersion + " map in " + Δt_in_ms + " ms");
+                System.out.println(
+                        "Built " + prop + " " + ucdVersion + " map in " + Δt_in_ms + " ms");
                 new Throwable().printStackTrace(System.out);
 
                 return newMap;

--- a/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -685,7 +684,9 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
                     || raw.containsValue("<codepoint>")) {
                 UnicodeMap<String> newMap = new UnicodeMap<>();
                 for (UnicodeMap.EntryRange<String> range : raw.entryRanges()) {
-                    if (DefaultValueType.forString(range.value) == DefaultValueType.CODE_POINT
+                    if (range.codepoint == -1) {
+                        newMap.put(range.string, range.value);
+                    } else if (DefaultValueType.forString(range.value) == DefaultValueType.CODE_POINT
                             || (prop == UcdProperty.Name && range.value.endsWith("#"))) {
                         for (int c = range.codepoint; c <= range.codepointEnd; ++c) {
                             newMap.put(c, resolveValue(range.value, c));

--- a/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
@@ -682,6 +682,7 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
             if (prop == UcdProperty.Name
                     || raw.containsValue("<code point>")
                     || raw.containsValue("<codepoint>")) {
+                final long start = System.currentTimeMillis();
                 UnicodeMap<String> newMap = new UnicodeMap<>();
                 for (UnicodeMap.EntryRange<String> range : raw.entryRanges()) {
                     if (range.codepoint == -1) {
@@ -696,6 +697,13 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
                         newMap.putAll(range.codepoint, range.codepointEnd, range.value);
                     }
                 }
+                final long stop = System.currentTimeMillis();
+                final long Δt_in_ms = stop - start;
+                System.out.println("Built " + prop + " " + ucdVersion + " map in " + Δt_in_ms + " ms");
+                if (Δt_in_ms > 500) {
+                    new Throwable().printStackTrace();
+                }
+
                 return newMap;
             } else {
                 return raw;

--- a/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
@@ -751,15 +751,25 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
 
         @Override
         protected List<String> _getAvailableValues(List result) {
+            final long start = System.currentTimeMillis();
             if (stringToNamedEnum != null) {
                 result.addAll(enumValueNames);
                 return result;
+            } else {
+                _getUnicodeMap().getAvailableValues(result);
             }
-            return _getUnicodeMap().getAvailableValues(result);
+            final long stop = System.currentTimeMillis();
+            final long Δt_in_ms = stop - start;
+            if (Δt_in_ms > 500) {
+                System.out.println("Long _getAvailableValues for " + prop + " " + ucdVersion + ": " + Δt_in_ms + " ms");
+                new Throwable().printStackTrace();
+            }
+            return result;
         }
 
         @Override
         protected List _getValueAliases(String valueAlias, List result) {
+            final long start = System.currentTimeMillis();
             if (stringToNamedEnum != null) {
                 PropertyNames valueName = stringToNamedEnum.get(valueAlias);
                 if (valueName != null) {
@@ -770,6 +780,12 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
                 if (_getUnicodeMap().containsValue(valueAlias)) {
                     result.add(valueAlias);
                 }
+            }
+            final long stop = System.currentTimeMillis();
+            final long Δt_in_ms = stop - start;
+            if (Δt_in_ms > 500) {
+                System.out.println("Long _getValueAliases for " + prop + " " + ucdVersion + " " + valueAlias + ": " + Δt_in_ms + " ms");
+                new Throwable().printStackTrace();
             }
             return result;
         }

--- a/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
@@ -677,6 +677,19 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
         }
 
         @Override
+        public UnicodeSet getSet(PatternMatcher matcher, UnicodeSet result) {
+            final long start = System.currentTimeMillis();
+            super.getSet(matcher, result);
+            final long stop = System.currentTimeMillis();
+            final long Δt_in_ms = stop - start;
+            if (Δt_in_ms > 500) {
+                System.out.println("Long getSet for " + prop + " " + ucdVersion + " " + matcher + ": " + Δt_in_ms + " ms");
+                new Throwable().printStackTrace();
+            }
+            return result;
+        }
+
+        @Override
         protected UnicodeMap<String> _getUnicodeMap() {
             var raw = _getRawUnicodeMap();
             if (prop == UcdProperty.Name

--- a/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
@@ -688,7 +688,7 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
                     if (DefaultValueType.forString(range.value) == DefaultValueType.CODE_POINT
                             || (prop == UcdProperty.Name && range.value.endsWith("#"))) {
                         for (int c = range.codepoint; c <= range.codepointEnd; ++c) {
-                            newMap.putAll(c, c, _getValue(c));
+                            newMap.put(c, _getValue(c));
                         }
                     } else {
                         newMap.putAll(range.codepoint, range.codepointEnd, range.value);

--- a/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
@@ -679,7 +679,7 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
         @Override
         public UnicodeSet getSet(PatternMatcher matcher, UnicodeSet result) {
             final long start = System.currentTimeMillis();
-            super.getSet(matcher, result);
+            result = super.getSet(matcher, result);
             final long stop = System.currentTimeMillis();
             final long Δt_in_ms = stop - start;
             if (Δt_in_ms > 500) {

--- a/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
@@ -691,36 +691,7 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
 
         @Override
         protected UnicodeMap<String> _getUnicodeMap() {
-            var raw = _getRawUnicodeMap();
-            if (prop == UcdProperty.Name
-                    || raw.containsValue("<code point>")
-                    || raw.containsValue("<codepoint>")) {
-                final long start = System.currentTimeMillis();
-                UnicodeMap<String> newMap = new UnicodeMap<>();
-                for (UnicodeMap.EntryRange<String> range : raw.entryRanges()) {
-                    if (range.codepoint == -1) {
-                        newMap.put(range.string, range.value);
-                    } else if (DefaultValueType.forString(range.value)
-                                    == DefaultValueType.CODE_POINT
-                            || (prop == UcdProperty.Name && range.value.endsWith("#"))) {
-                        for (int c = range.codepoint; c <= range.codepointEnd; ++c) {
-                            newMap.put(c, resolveValue(range.value, c));
-                        }
-                    } else {
-                        newMap.putAll(range.codepoint, range.codepointEnd, range.value);
-                    }
-                }
-                final long stop = System.currentTimeMillis();
-                final long Δt_in_ms = stop - start;
-                System.out.println("Built " + prop + " " + ucdVersion + " map in " + Δt_in_ms + " ms");
-                if (Δt_in_ms > 500) {
-                    new Throwable().printStackTrace();
-                }
-
-                return newMap;
-            } else {
-                return raw;
-            }
+            return _getRawUnicodeMap();
         }
 
         protected UnicodeMap<String> _getRawUnicodeMap() {

--- a/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
@@ -705,6 +705,10 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
                 }
                 final long stop = System.currentTimeMillis();
                 final long Δt_in_ms = stop - start;
+                // We do not want to construct these UnicodeMaps that map most of the code space to
+                // itself, not so much because building them is costly, but because whatever we do
+                // on them is almost certainly a bad idea (for instance calling `values()` will be
+                // extremely slow).  Log a trace so we can figure out where we are using this.
                 System.out.println(
                         "Built " + prop + " " + ucdVersion + " map in " + Δt_in_ms + " ms");
                 new Throwable().printStackTrace(System.out);

--- a/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
@@ -751,25 +751,15 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
 
         @Override
         protected List<String> _getAvailableValues(List result) {
-            final long start = System.currentTimeMillis();
             if (stringToNamedEnum != null) {
                 result.addAll(enumValueNames);
                 return result;
-            } else {
-                _getUnicodeMap().getAvailableValues(result);
             }
-            final long stop = System.currentTimeMillis();
-            final long Δt_in_ms = stop - start;
-            if (Δt_in_ms > 500) {
-                System.out.println("Long _getAvailableValues for " + prop + " " + ucdVersion + ": " + Δt_in_ms + " ms");
-                new Throwable().printStackTrace();
-            }
-            return result;
+            return _getUnicodeMap().getAvailableValues(result);
         }
 
         @Override
         protected List _getValueAliases(String valueAlias, List result) {
-            final long start = System.currentTimeMillis();
             if (stringToNamedEnum != null) {
                 PropertyNames valueName = stringToNamedEnum.get(valueAlias);
                 if (valueName != null) {
@@ -780,12 +770,6 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
                 if (_getUnicodeMap().containsValue(valueAlias)) {
                     result.add(valueAlias);
                 }
-            }
-            final long stop = System.currentTimeMillis();
-            final long Δt_in_ms = stop - start;
-            if (Δt_in_ms > 500) {
-                System.out.println("Long _getValueAliases for " + prop + " " + ucdVersion + " " + valueAlias + ": " + Δt_in_ms + " ms");
-                new Throwable().printStackTrace();
             }
             return result;
         }

--- a/unicodetools/src/main/java/org/unicode/props/ShimUnicodePropertyFactory.java
+++ b/unicodetools/src/main/java/org/unicode/props/ShimUnicodePropertyFactory.java
@@ -57,6 +57,8 @@ public class ShimUnicodePropertyFactory extends UnicodeProperty.Factory {
         for (String propName : factory.getAvailableNames()) {
             UnicodeProperty prop = factory.getProperty(propName);
             switch (propName) {
+                // The default is <none> in BidiMirroring.txt, but TUP incorrectly has it as
+                // <code point>.
                 case "Bidi_Mirroring_Glyph":
                     prop =
                             replaceCpValues(
@@ -72,12 +74,6 @@ public class ShimUnicodePropertyFactory extends UnicodeProperty.Factory {
                             replaceCpValues(
                                     prop, (cp, oldValue) -> fixFC_NFKC_Closure(cp, oldValue));
 
-                    break;
-                case "Joining_Type":
-                    prop = replaceCpValues(prop, (cp, oldValue) -> fixJoining_Type(cp, oldValue));
-                    break;
-                case "Joining_Group":
-                    prop = modifyJoining_Group(prop);
                     break;
                 case "Jamo_Short_Name":
                     prop = modifyJamo_Short_Name(prop);
@@ -316,23 +312,9 @@ public class ShimUnicodePropertyFactory extends UnicodeProperty.Factory {
         }
     }
 
-    // Joining_Type needs fix in IUP
-    private String fixJoining_Type(int cp, String oldValue) {
-        if (defaultTransparent.contains(cp) && "Non_Joining".equals(oldValue)) {
-            return "Transparent";
-        } else {
-            return oldValue;
-        }
-    }
-
     // Jamo_Short_Name needs fix in IUP
     private UnicodeProperty modifyJamo_Short_Name(UnicodeProperty prop) {
         return copyPropReplacingMap(prop, prop.getUnicodeMap().put('ᄋ', ""));
-    }
-
-    // Joining_Group needs fix in IUP (really, in UCD data)
-    private UnicodeProperty modifyJoining_Group(UnicodeProperty prop) {
-        return copyPropReplacingMap(prop, prop.getUnicodeMap().put('ۃ', "Teh_Marbuta_Goal"));
     }
 
     /** Very useful. May already be in ICU, but not sure. */

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import org.unicode.cldr.util.props.UnicodeLabel;
 
@@ -553,7 +552,8 @@ public abstract class UnicodeProperty extends UnicodeLabel {
 
     public boolean isTrivial() {
         final var map = getUnicodeMap();
-        return map.isEmpty() || map.keySet("").equals(UnicodeSet.ALL_CODE_POINTS) && map.stringKeys().isEmpty();
+        return map.isEmpty()
+                || map.keySet("").equals(UnicodeSet.ALL_CODE_POINTS) && map.stringKeys().isEmpty();
     }
 
     /**

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -555,6 +555,11 @@ public abstract class UnicodeProperty extends UnicodeLabel {
         return getUnicodeMap(false);
     }
 
+    public boolean isTrivial() {
+        final var map = getUnicodeMap();
+        return map.isEmpty() || map.keySet("").equals(UnicodeSet.ALL_CODE_POINTS) && map.stringKeys().isEmpty();
+    }
+
     /**
      * @return the unicode map
      */

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import org.unicode.cldr.util.props.UnicodeLabel;
 
@@ -443,6 +444,10 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     public static final String UNUSED = "??";
 
     public UnicodeSet getSet(PatternMatcher matcher, UnicodeSet result) {
+        return getSet(matcher, result, () -> getUnicodeMap_internal());
+    }
+
+    protected final UnicodeSet getSet(PatternMatcher matcher, UnicodeSet result, Supplier<UnicodeMap<String>> unicodeMap) {
         if (result == null) result = new UnicodeSet();
         boolean uniformUnassigned = hasUniformUnassigned();
         if (isType(STRING_OR_MISC_MASK) && !isMultivalued) {
@@ -458,7 +463,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
         }
         List<String> valueAliases = new ArrayList<>(1); // to avoid reallocating...
         List<String> partAliases = new ArrayList<>(1);
-        UnicodeMap<String> um = getUnicodeMap_internal();
+        UnicodeMap<String> um = unicodeMap.get();
         Iterator<String> it = um.getAvailableValues(null).iterator();
         main:
         while (it.hasNext()) {

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -444,10 +444,6 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     public static final String UNUSED = "??";
 
     public UnicodeSet getSet(PatternMatcher matcher, UnicodeSet result) {
-        return getSet(matcher, result, () -> getUnicodeMap_internal());
-    }
-
-    protected final UnicodeSet getSet(PatternMatcher matcher, UnicodeSet result, Supplier<UnicodeMap<String>> unicodeMap) {
         if (result == null) result = new UnicodeSet();
         boolean uniformUnassigned = hasUniformUnassigned();
         if (isType(STRING_OR_MISC_MASK) && !isMultivalued) {
@@ -463,7 +459,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
         }
         List<String> valueAliases = new ArrayList<>(1); // to avoid reallocating...
         List<String> partAliases = new ArrayList<>(1);
-        UnicodeMap<String> um = unicodeMap.get();
+        UnicodeMap<String> um = getUnicodeMap_internal();
         Iterator<String> it = um.getAvailableValues(null).iterator();
         main:
         while (it.hasNext()) {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedProperty.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedProperty.java
@@ -64,10 +64,7 @@ public class VersionedProperty {
             Set.of("toNFC", "toNFD", "toNFKC", "toNFKD");
 
     private static boolean isTrivial(UnicodeMap<String> map) {
-        return map.isEmpty()
-                || (map.values().size() == 1
-                        && map.getSet(map.values().iterator().next())
-                                .equals(UnicodeSet.ALL_CODE_POINTS));
+        return map.isEmpty() || map.getSet("").equals(UnicodeSet.ALL_CODE_POINTS);
     }
 
     public UnicodeProperty getProperty() {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedProperty.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedProperty.java
@@ -1,6 +1,5 @@
 package org.unicode.text.UCD;
 
-import com.ibm.icu.dev.util.UnicodeMap;
 import com.ibm.icu.text.SymbolTable;
 import com.ibm.icu.text.UnicodeSet;
 import java.text.ParsePosition;

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedProperty.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedProperty.java
@@ -109,11 +109,11 @@ public class VersionedProperty {
         propSource = getIndexedProperties(version);
         property = propSource.getProperty(xPropertyName);
         if ((property == null && TOOL_ONLY_PROPERTIES.contains(xPropertyName))
-                || (property != null && isTrivial(property.getUnicodeMap()) && allowRetroactive)) {
+                || (property != null && property.isTrivial() && allowRetroactive)) {
             propSource = ToolUnicodePropertySource.make(version);
             property = propSource.getProperty(xPropertyName);
         }
-        if (property == null || isTrivial(property.getUnicodeMap())) {
+        if (property == null || property.isTrivial()) {
             if (!throwOnUnknownProperty) {
                 return null;
             }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedProperty.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedProperty.java
@@ -63,10 +63,6 @@ public class VersionedProperty {
     private static final Set<String> TOOL_ONLY_PROPERTIES =
             Set.of("toNFC", "toNFD", "toNFKC", "toNFKD");
 
-    private static boolean isTrivial(UnicodeMap<String> map) {
-        return map.isEmpty() || map.getSet("").equals(UnicodeSet.ALL_CODE_POINTS);
-    }
-
     public UnicodeProperty getProperty() {
         return property;
     }


### PR DESCRIPTION
Resolve `#` in Name as well as `<code point>`, and return a correct UnicodeMap instead of one with unresolved defaults.
Factor out some other paths that had some other resolution logic.

Remove the corresponding shim, as well as the shims for the properties fixed in in #657 and #676.