### PR TITLE
Fewer regices

### DIFF
--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeSetUtilities.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeSetUtilities.java
@@ -368,7 +368,7 @@ public class UnicodeSetUtilities {
 
         @Override
         public boolean test(String value) {
-            int comp = comparator.compare(pattern, value.toString());
+            int comp = comparator.compare(pattern, value);
             switch (relation) {
                 case less:
                     return comp < 0;

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -462,10 +462,14 @@ public abstract class UnicodeProperty extends UnicodeLabel {
         if (matcher.test(null)) {
             int previousNullStart = 0;
             for (var range : um.entryRanges()) {
-                result.addAll(previousNullStart, range.codepoint - 1);
+                if (range.codepoint > 0) {
+                    result.addAll(previousNullStart, range.codepoint - 1);
+                }
                 previousNullStart = range.codepointEnd + 1;
             }
-            result.addAll(previousNullStart, 0x10FFFF);
+            if (previousNullStart <= 0x10FFFF) {
+                result.addAll(previousNullStart, 0x10FFFF);
+            }
         }
         if (matcher == UnicodeProperty.NULL_MATCHER) {
             // Optimization: The null matcher matches only null, no need to look

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -470,11 +470,11 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             if (previousNullStart <= 0x10FFFF) {
                 result.addAll(previousNullStart, 0x10FFFF);
             }
-        }
-        if (matcher == UnicodeProperty.NULL_MATCHER) {
-            // Optimization: The null matcher matches only null, no need to look
-            // at the non-null values.
-            return result;
+            if (matcher == UnicodeProperty.NULL_MATCHER) {
+                // Optimization: The null matcher matches only null, no need to
+                // look at the non-null values.
+                return result;
+            }
         }
         Iterator<String> it = um.getAvailableValues(null).iterator();
         main:

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -1199,17 +1199,17 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     }
 
     public static final UnicodeProperty.PatternMatcher NULL_MATCHER =
-        new UnicodeProperty.PatternMatcher() {
-            @Override
-            public boolean test(String o) {
-                return o == null;
-            }
+            new UnicodeProperty.PatternMatcher() {
+                @Override
+                public boolean test(String o) {
+                    return o == null;
+                }
 
-            @Override
-            public PatternMatcher set(String pattern) {
-                return this;
-            }
-        };
+                @Override
+                public PatternMatcher set(String pattern) {
+                    return this;
+                }
+            };
 
     public static class SimpleMatcher implements PatternMatcher {
         Comparator<String> comparator;

--- a/unicodetools/src/main/java/org/unicode/props/UnicodePropertySymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodePropertySymbolTable.java
@@ -259,7 +259,7 @@ public class UnicodePropertySymbolTable extends UnicodeSet.XSymbolTable {
 
         @Override
         public boolean test(String value) {
-            int comp = comparator.compare(pattern, value.toString());
+            int comp = comparator.compare(pattern, value);
             switch (relation) {
                 case less:
                     return comp < 0;

--- a/unicodetools/src/main/java/org/unicode/props/UnicodePropertySymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodePropertySymbolTable.java
@@ -287,22 +287,30 @@ public class UnicodePropertySymbolTable extends UnicodeSet.XSymbolTable {
 
                 @Override
                 public int compare(String o1, String o2) {
-                    int f1 = o1.codePointAt(0);
-                    int f2 = o2.codePointAt(0);
-                    boolean n1 = f1 < '0' || f1 > '9';
-                    boolean n2 = f2 < '0' || f2 > '9';
-                    if (n1) {
-                        return n2 ? o1.compareTo(o2) : 1;
-                    } else if (n2) {
+                    if (o1 == o2) {
+                        return 0;
+                    } else if (o1 == null) {
                         return -1;
-                    }
-                    double d1 = Double.parseDouble(o1);
-                    double d2 = Double.parseDouble(o2);
-                    if (Double.isNaN(d1) || Double.isNaN(d2)) {
-                        throw new IllegalArgumentException();
-                    }
+                    } else if (o2 == null) {
+                        return 1;
+                    } else {
+                        int f1 = o1.codePointAt(0);
+                        int f2 = o2.codePointAt(0);
+                        boolean n1 = f1 < '0' || f1 > '9';
+                        boolean n2 = f2 < '0' || f2 > '9';
+                        if (n1) {
+                            return n2 ? o1.compareTo(o2) : 1;
+                        } else if (n2) {
+                            return -1;
+                        }
+                        double d1 = Double.parseDouble(o1);
+                        double d2 = Double.parseDouble(o2);
+                        if (Double.isNaN(d1) || Double.isNaN(d2)) {
+                            throw new IllegalArgumentException();
+                        }
 
-                    return d1 > d2 ? 1 : d1 < d2 ? -1 : 0;
+                        return d1 > d2 ? 1 : d1 < d2 ? -1 : 0;
+                    }
                 }
             };
 }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedProperty.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedProperty.java
@@ -147,8 +147,8 @@ public class VersionedProperty {
             }
             matcher.set(body);
             set = property.getSet(matcher);
-        } else if (propertyValue.equals("∅")) {
-            set = property.getSet(NULL_MATCHER, null);
+        } else if (propertyValue.equals("@none@")) {
+            set = property.getSet(UnicodeProperty.NULL_MATCHER, null);
         } else {
             set = property.getSet(propertyValue);
         }
@@ -172,17 +172,4 @@ public class VersionedProperty {
         }
         return result;
     }
-
-    static final UnicodeProperty.PatternMatcher NULL_MATCHER =
-            new UnicodeProperty.PatternMatcher() {
-                @Override
-                public boolean test(String o) {
-                    return o == null || "".equals(o);
-                }
-
-                @Override
-                public PatternMatcher set(String pattern) {
-                    return this;
-                }
-            };
 }

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
@@ -950,7 +950,7 @@ Let $ideohack = [〆 〇 〡-〩]
 \P{kRSUnicode=@none@} = \P{kTotalStrokes=@none@}
 
 # TODO(eggrobin): Should those two have a kMandarin, or this not actually an invariant?
-# TODO(macchiati): The kHanyuPinyin UnicodeSet is excruciatingly slow.
+# See https://www.unicode.org/review/pri483/feedback.html#ID20240118004124.
 [\P{kHanyuPinyin=@none@} - \P{kMandarin=@none@}] = [\x{228F5}\x{2574C}]
 
 Let $strokesAndRadicals = [\p{Name=/^CJK STROKE /}\p{Name=/^(CJK|KANGXI) RADICAL /}]-\p{gc=Cn}

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
@@ -951,7 +951,9 @@ Let $ideohack = [〆 〇 〡-〩]
 
 # TODO(eggrobin): Should those two have a kMandarin, or this not actually an invariant?
 # See https://www.unicode.org/review/pri483/feedback.html#ID20240118004124.
-[\P{kHanyuPinyin=@none@} - \P{kMandarin=@none@}] = [\x{228F5}\x{2574C}]
+# Change to \P{kHanyuPinyin=@none@} ⊆ \P{kMandarin=@none@} once this gets fixed.
+Let $ideographsMissingkMandarin = [\x{228F5}\x{2574C}]
+[\P{kHanyuPinyin=@none@} - \P{kMandarin=@none@}] = $ideographsMissingkMandarin
 
 Let $strokesAndRadicals = [\p{Name=/^CJK STROKE /}\p{Name=/^(CJK|KANGXI) RADICAL /}]-\p{gc=Cn}
 Let $nonIdeographicRadicals = \N{CJK RADICAL REPEAT}

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
@@ -945,13 +945,13 @@ Let $ideohack = [〆 〇 〡-〩]
 # 10.0 added Nushu
 # 13.0 added Khitan_Small_Script
 
-\p{Unified_Ideograph} ⊂ \p{kRSUnicode=/./}
-\p{kRSUnicode=/./} = [\p{Block=/^CJK.(Unified|Compatibility).Ideographs/} - \p{gc=Cn}]
-\p{kRSUnicode=/./} = \p{kTotalStrokes=/./}
+\p{Unified_Ideograph} ⊂ \P{kRSUnicode=@none@}
+\P{kRSUnicode=@none@} = [\p{Block=/^CJK.(Unified|Compatibility).Ideographs/} - \p{gc=Cn}]
+\P{kRSUnicode=@none@} = \P{kTotalStrokes=@none@}
 
 # TODO(eggrobin): Should those two have a kMandarin, or this not actually an invariant?
 # TODO(macchiati): The kHanyuPinyin UnicodeSet is excruciatingly slow.
-# \p{kHanyuPinyin=/./} - \p{kMandarin=/./} = [\{228F5}\x{2574C}]
+[\P{kHanyuPinyin=@none@} - \P{kMandarin=@none@}] = [\x{228F5}\x{2574C}]
 
 Let $strokesAndRadicals = [\p{Name=/^CJK STROKE /}\p{Name=/^(CJK|KANGXI) RADICAL /}]-\p{gc=Cn}
 Let $nonIdeographicRadicals = \N{CJK RADICAL REPEAT}
@@ -959,11 +959,11 @@ Let $nonIdeographicRadicals = \N{CJK RADICAL REPEAT}
 # It can also shrink, if single-stroke ideographs are encoded.
 Let $nonIdeographicStrokes = \p{Name=/^CJK STROKE (T|WG|XG|BXG|SW|HZZ|HP|HZWG|SZWG|HZT|HZZP|HPWG|HZW|HZZZ|PG|Q|HZXG|SZP)$/}
 
-\p{Equivalent_Unified_Ideograph=/./} ⊆ $strokesAndRadicals
-[$strokesAndRadicals - \p{Equivalent_Unified_Ideograph=/./}] = [$nonIdeographicStrokes $nonIdeographicRadicals]
+\P{Equivalent_Unified_Ideograph=@none@} ⊆ $strokesAndRadicals
+[$strokesAndRadicals - \P{Equivalent_Unified_Ideograph=@none@}] = [$nonIdeographicStrokes $nonIdeographicRadicals]
 # TODO(egg): NFC_Quick_Check is a stupid way to get a Yes here; we are checking
 # that Equivalent_Unified_Ideograph values are single unified ideographs.
-In \p{Equivalent_Unified_Ideograph=/./} Unified_Ideograph * Equivalent_Unified_Ideograph = NFC_Quick_Check
+In \P{Equivalent_Unified_Ideograph=@none@} Unified_Ideograph * Equivalent_Unified_Ideograph = NFC_Quick_Check
 
 # InPC-InSC-gc invariants
 # See https://www.unicode.org/L2/L2023/23200-category-invariants.pdf.


### PR DESCRIPTION
Fix `getSet` so it correctly handles matchers that match `null`.
Make the `NULL_MATCHER` strict now that we distinguish `<none>` from empty strings.
Make the `NULL_MATCHER` public and special-case it for performance.
Make the syntax for the null matcher more consistent with already-sort-of-reserved syntax in UTS18 and UAX44 instead of making ∅ special. See unicode-org/properties#240.
Instead of `\p{Meow=/./}` for the set of code points for which `Meow` has a nonempty value, use `\P{Meow=@none@}` (the set of code points for which `Meow` has a value. This would include empty values, if there were any, though that is not relevant here.