### PR TITLE
Add Unihan properties from Unicode 14.0, 15.0, 15.1, and 16.0

### DIFF
--- a/unicodetools/src/main/java/org/unicode/props/UcdProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UcdProperty.java
@@ -88,6 +88,7 @@ public enum UcdProperty {
     Named_Sequences_Prov(PropertyType.Miscellaneous, "NSP"),
     Standardized_Variant(PropertyType.Miscellaneous, null, ValueCardinality.Unordered, "SV"),
     Unicode_1_Name(PropertyType.Miscellaneous, "na1"),
+    kAlternateTotalStrokes(PropertyType.Miscellaneous, "cjkAlternateTotalStrokes"),
     kBigFive(PropertyType.Miscellaneous, "cjkBigFive"),
     kCCCII(PropertyType.Miscellaneous, "cjkCCCII"),
     kCNS1986(PropertyType.Miscellaneous, "cjkCNS1986"),
@@ -102,6 +103,7 @@ public enum UcdProperty {
     kDaeJaweon(PropertyType.Miscellaneous, "cjkDaeJaweon"),
     kDefinition(PropertyType.Miscellaneous, "cjkDefinition"),
     kEACC(PropertyType.Miscellaneous, "cjkEACC"),
+    kFanqie(PropertyType.Miscellaneous, "cjkFanqie"),
     kFenn(PropertyType.Miscellaneous, null, ValueCardinality.Unordered, "cjkFenn"),
     kFennIndex(PropertyType.Miscellaneous, null, ValueCardinality.Unordered, "cjkFennIndex"),
     kFourCornerCode(
@@ -141,6 +143,7 @@ public enum UcdProperty {
     kIRG_VSource(PropertyType.Miscellaneous, "cjkIRG_VSource"),
     kJIS0213(PropertyType.Miscellaneous, "cjkJIS0213"),
     kJa(PropertyType.Miscellaneous, "cjkJa"),
+    kJapanese(PropertyType.Miscellaneous, "cjkJapanese"),
     kJapaneseKun(PropertyType.Miscellaneous, null, ValueCardinality.Unordered, "cjkJapaneseKun"),
     kJapaneseOn(PropertyType.Miscellaneous, null, ValueCardinality.Unordered, "cjkJapaneseOn"),
     kJinmeiyoKanji(
@@ -166,6 +169,7 @@ public enum UcdProperty {
     kMandarin(PropertyType.Miscellaneous, null, ValueCardinality.Ordered, "cjkMandarin"),
     kMatthews(PropertyType.Miscellaneous, "cjkMatthews"),
     kMeyerWempe(PropertyType.Miscellaneous, null, ValueCardinality.Unordered, "cjkMeyerWempe"),
+    kMojiJoho(PropertyType.Miscellaneous, "cjkMojiJoho"),
     kMorohashi(PropertyType.Miscellaneous, "cjkMorohashi"),
     kNelson(PropertyType.Miscellaneous, null, ValueCardinality.Unordered, "cjkNelson"),
     kPhonetic(PropertyType.Miscellaneous, null, ValueCardinality.Unordered, "cjkPhonetic"),
@@ -184,6 +188,8 @@ public enum UcdProperty {
             "Unicode_Radical_Stroke",
             "URS"),
     kSBGY(PropertyType.Miscellaneous, null, ValueCardinality.Unordered, "cjkSBGY"),
+    kSMSZD2003Index(PropertyType.Miscellaneous, "cjkSMSZD2003Index"),
+    kSMSZD2003Readings(PropertyType.Miscellaneous, "cjkSMSZD2003Readings"),
     kSemanticVariant(
             PropertyType.Miscellaneous, null, ValueCardinality.Unordered, "cjkSemanticVariant"),
     kSpecializedSemanticVariant(
@@ -192,6 +198,7 @@ public enum UcdProperty {
             ValueCardinality.Unordered,
             "cjkSpecializedSemanticVariant"),
     kSpoofingVariant(PropertyType.Miscellaneous, "cjkSpoofingVariant"),
+    kStrange(PropertyType.Miscellaneous, "cjkStrange"),
     kTGH(PropertyType.Miscellaneous, null, ValueCardinality.Unordered, "cjkTGH"),
     kTGHZ2013(PropertyType.Miscellaneous, "cjkTGHZ2013"),
     kTaiwanTelegraph(PropertyType.Miscellaneous, "cjkTaiwanTelegraph"),
@@ -199,9 +206,11 @@ public enum UcdProperty {
     kTotalStrokes(PropertyType.Miscellaneous, null, ValueCardinality.Ordered, "cjkTotalStrokes"),
     kUnihanCore2020(PropertyType.Miscellaneous, "cjkUnihanCore2020"),
     kVietnamese(PropertyType.Miscellaneous, null, ValueCardinality.Unordered, "cjkVietnamese"),
+    kVietnameseNumeric(PropertyType.Miscellaneous, "cjkVietnameseNumeric"),
     kXHC1983(PropertyType.Miscellaneous, null, ValueCardinality.Unordered, "cjkXHC1983"),
     kXerox(PropertyType.Miscellaneous, "cjkXerox"),
     kZVariant(PropertyType.Miscellaneous, "cjkZVariant"),
+    kZhuangNumeric(PropertyType.Miscellaneous, "cjkZhuangNumeric"),
 
     // Catalog
     Age(PropertyType.Catalog, Age_Values.class, null, "age"),

--- a/unicodetools/src/main/java/org/unicode/props/UcdPropertyValues.java
+++ b/unicodetools/src/main/java/org/unicode/props/UcdPropertyValues.java
@@ -1377,6 +1377,7 @@ public class UcdPropertyValues {
     }
 
     // kAccountingNumeric
+    // kAlternateTotalStrokes
     // kBigFive
     // kCangjie
     // kCantonese
@@ -1391,6 +1392,7 @@ public class UcdPropertyValues {
     // kDaeJaweon
     // kDefinition
     // kEACC
+    // kFanqie
     // kFenn
     // kFennIndex
     // kFourCornerCode
@@ -1428,6 +1430,7 @@ public class UcdPropertyValues {
     // kIRGHanyuDaZidian
     // kIRGKangXi
     // kJa
+    // kJapanese
     // kJapaneseKun
     // kJapaneseOn
     // kJinmeiyoKanji
@@ -1449,6 +1452,7 @@ public class UcdPropertyValues {
     // kMandarin
     // kMatthews
     // kMeyerWempe
+    // kMojiJoho
     // kMorohashi
     // kNelson
     // kOtherNumeric
@@ -1464,8 +1468,11 @@ public class UcdPropertyValues {
     // kSBGY
     // kSemanticVariant
     // kSimplifiedVariant
+    // kSMSZD2003Index
+    // kSMSZD2003Readings
     // kSpecializedSemanticVariant
     // kSpoofingVariant
+    // kStrange
     // kTaiwanTelegraph
     // kTang
     // kTGH
@@ -1474,8 +1481,10 @@ public class UcdPropertyValues {
     // kTraditionalVariant
     // kUnihanCore2020
     // kVietnamese
+    // kVietnameseNumeric
     // kXerox
     // kXHC1983
+    // kZhuangNumeric
     // kZVariant
     public enum Line_Break_Values implements Named {
         Ambiguous("AI"),

--- a/unicodetools/src/main/resources/org/unicode/props/ExtraPropertyAliases.txt
+++ b/unicodetools/src/main/resources/org/unicode/props/ExtraPropertyAliases.txt
@@ -141,7 +141,20 @@ cjkJoyoKanji ; kJoyoKanji
 cjkKoreanEducationHanja ; kKoreanEducationHanja
 cjkKoreanName ; kKoreanName
 cjkTGH ; kTGH
-#13.0
+# 13.0
 cjkSpoofingVariant       ; kSpoofingVariant
 cjkTGHZ2013              ; kTGHZ2013
 cjkUnihanCore2020        ; kUnihanCore2020
+# 14.0
+cjkStrange               ; kStrange
+# 15.0
+cjkAlternateTotalStrokes ; kAlternateTotalStrokes
+# 15.1
+cjkJapanese              ; kJapanese
+cjkMojiJoho              ; kMojiJoho
+cjkSMSZD2003Index        ; kSMSZD2003Index
+cjkSMSZD2003Readings     ; kSMSZD2003Readings
+cjkVietnameseNumeric     ; kVietnameseNumeric
+cjkZhuangNumeric         ; kZhuangNumeric
+# 16.0
+cjkFanqie                ; kFanqie


### PR DESCRIPTION
While playing with the staging JSPs which have Unihan properties since #659, @Manishearth had lamented the lack of kStrange.