### PR TITLE
Fix pre-5.0 Grapheme_Link parsing

### DIFF
--- a/unicodetools/src/main/resources/org/unicode/props/IndexUnicodeProperties.txt
+++ b/unicodetools/src/main/resources/org/unicode/props/IndexUnicodeProperties.txt
@@ -137,7 +137,9 @@ DerivedCoreProperties ; Alphabetic
 DerivedCoreProperties ; Default_Ignorable_Code_Point
 DerivedCoreProperties ; Grapheme_Base
 DerivedCoreProperties ; Grapheme_Extend
+# Deprecated and made derived in 5.0.
 DerivedCoreProperties ; Grapheme_Link
+PropList ; Grapheme_Link ; v4.1
 DerivedCoreProperties ; Math
 DerivedCoreProperties ; ID_Start
 DerivedCoreProperties ; ID_Continue


### PR DESCRIPTION
…thereby fixing the parsing of 17 properties in 3.2..4.1; see the 17 `3.2..4.1: null` in https://unicode-jsps-staging-o2ookmn2oq-uc.a.run.app/UnicodeJsps/character.jsp?a=3400&history=assigned&showDevProperties=1 for properties that were in PropList.txt.

Towards #650.