### PR TITLE
An alternative format for ScriptExtensions.txt

### DIFF
--- a/unicodetools/data/ucd/dev/ScriptExtensions.txt
+++ b/unicodetools/data/ucd/dev/ScriptExtensions.txt
@@ -1,5 +1,5 @@
 # ScriptExtensions-16.0.0.txt
-# Date: 2024-02-29, 13:02:44 GMT
+# Date: 2024-02-29, 13:02:59 GMT
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -51,7 +51,7 @@
 0951          ; Beng Deva Gran Gujr Guru Knda Latn Mlym Orya Shrd Taml Telu Tirh #Mn DEVANAGARI STRESS SIGN UDATTA
 0952          ; Beng Deva Gran Gujr Guru Knda Latn Mlym Orya Taml Telu Tirh #Mn DEVANAGARI STRESS SIGN ANUDATTA
 0964          ; Beng Deva Dogr Gong Gonm Gran Gujr Guru Knda Mahj Mlym Nand Onao Orya Sind Sinh Sylo Takr Taml Telu Tirh #Po DEVANAGARI DANDA
-0965          ; Beng Deva Dogr Gong Gonm Gran Gujr Guru Knda Limb Mahj Mlym Nand Onao Orya Sind Sinh Sylo Takr Taml Telu Tirh #Po DEVANAGARI DOUBLE DANDA
+0965          ; Beng Deva Dogr Gong Gonm Gran Gujr Gukh Guru Knda Limb Mahj Mlym Nand Onao Orya Sind Sinh Sylo Takr Taml Telu Tirh #Po DEVANAGARI DOUBLE DANDA
 0966..096F    ; Deva Dogr Kthi Mahj            # Nd [10] DEVANAGARI DIGIT ZERO..DEVANAGARI DIGIT NINE
 09E6..09EF    ; Beng Cakm Sylo                 # Nd [10] BENGALI DIGIT ZERO..BENGALI DIGIT NINE
 0A66..0A6F    ; Guru Mult                      # Nd [10] GURMUKHI DIGIT ZERO..GURMUKHI DIGIT NINE

--- a/unicodetools/data/ucd/dev/ScriptExtensions.txt
+++ b/unicodetools/data/ucd/dev/ScriptExtensions.txt
@@ -1,5 +1,5 @@
 # ScriptExtensions-16.0.0.txt
-# Date: 2024-02-29, 13:01:56 GMT
+# Date: 2024-02-29, 13:02:04 GMT
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/ucd/dev/ScriptExtensions.txt
+++ b/unicodetools/data/ucd/dev/ScriptExtensions.txt
@@ -1,5 +1,5 @@
 # ScriptExtensions-16.0.0.txt
-# Date: 2024-02-29, 13:02:04 GMT
+# Date: 2024-02-29, 13:02:14 GMT
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -86,7 +86,7 @@
 1CEB..1CEC    ; Deva                           # Lo  [2] VEDIC SIGN ANUSVARA VAMAGOMUKHA..VEDIC SIGN ANUSVARA VAMAGOMUKHA WITH TAIL
 1CED          ; Beng Deva                      # Mn      VEDIC SIGN TIRYAK
 1CEE..1CF1    ; Deva                           # Lo  [4] VEDIC SIGN HEXIFORM LONG ANUSVARA..VEDIC SIGN ANUSVARA UBHAYATO MUKHA
-1CF2          ; Beng Deva Gran Knda Nand Orya Telu Tirh #Lo VEDIC SIGN ARDHAVISARGA
+1CF2          ; Beng Deva Gran Knda Mlym Nand Orya Sinh Telu Tirh #Lo VEDIC SIGN ARDHAVISARGA
 1CF3          ; Deva Gran                      # Lo      VEDIC SIGN ROTATED ARDHAVISARGA
 1CF4          ; Deva Gran Knda                 # Mn      VEDIC TONE CANDRA ABOVE
 1CF5..1CF6    ; Beng Deva                      # Lo  [2] VEDIC SIGN JIHVAMULIYA..VEDIC SIGN UPADHMANIYA
@@ -151,10 +151,10 @@
 33E0..33FE    ; Hani                           # So [31] IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY ONE..IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY THIRTY-ONE
 A66F          ; Cyrl Glag                      # Mn      COMBINING CYRILLIC VZMET
 A700..A707    ; Hani Latn                      # Sk  [8] MODIFIER LETTER CHINESE TONE YIN PING..MODIFIER LETTER CHINESE TONE YANG RU
-A830..A832    ; Deva Dogr Gujr Guru Khoj Knda Kthi Mahj Mlym Modi Nand Sind Takr Tirh #No [3] NORTH INDIC FRACTION ONE QUARTER..NORTH INDIC FRACTION THREE QUARTERS
-A833..A835    ; Deva Dogr Gujr Guru Khoj Knda Kthi Mahj Modi Nand Sind Takr Tirh #No [3] NORTH INDIC FRACTION ONE SIXTEENTH..NORTH INDIC FRACTION THREE SIXTEENTHS
+A830..A832    ; Deva Dogr Gujr Guru Khoj Knda Kthi Mahj Mlym Modi Nand Shrd Sind Takr Tirh #No [3] NORTH INDIC FRACTION ONE QUARTER..NORTH INDIC FRACTION THREE QUARTERS
+A833..A835    ; Deva Dogr Gujr Guru Khoj Knda Kthi Mahj Modi Nand Shrd Sind Takr Tirh #No [3] NORTH INDIC FRACTION ONE SIXTEENTH..NORTH INDIC FRACTION THREE SIXTEENTHS
 A836..A837    ; Deva Dogr Gujr Guru Khoj Kthi Mahj Modi Sind Takr Tirh #So [2] NORTH INDIC QUARTER MARK..NORTH INDIC PLACEHOLDER MARK
-A838          ; Deva Dogr Gujr Guru Khoj Kthi Mahj Modi Sind Takr Tirh #Sc NORTH INDIC RUPEE MARK
+A838          ; Deva Dogr Gujr Guru Khoj Kthi Mahj Modi Shrd Sind Takr Tirh #Sc NORTH INDIC RUPEE MARK
 A839          ; Deva Dogr Gujr Guru Khoj Kthi Mahj Modi Sind Takr Tirh #So NORTH INDIC QUANTITY MARK
 A8F1          ; Beng Deva                      # Mn      COMBINING DEVANAGARI SIGN AVAGRAHA
 A8F3          ; Deva Taml                      # Lo      DEVANAGARI SIGN CANDRABINDU VIRAMA

--- a/unicodetools/data/ucd/dev/ScriptExtensions.txt
+++ b/unicodetools/data/ucd/dev/ScriptExtensions.txt
@@ -1,5 +1,5 @@
 # ScriptExtensions-16.0.0.txt
-# Date: 2024-02-29, 13:02:59 GMT
+# Date: 2024-02-29, 13:03:13 GMT
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -59,7 +59,7 @@
 0BE6..0BEF    ; Gran Taml                      # Nd [10] TAMIL DIGIT ZERO..TAMIL DIGIT NINE
 0BF0..0BF2    ; Gran Taml                      # No  [3] TAMIL NUMBER TEN..TAMIL NUMBER ONE THOUSAND
 0BF3          ; Gran Taml                      # So      TAMIL DAY SIGN
-0CE6..0CEF    ; Knda Nand                      # Nd [10] KANNADA DIGIT ZERO..KANNADA DIGIT NINE
+0CE6..0CEF    ; Knda Nand Tutg                 # Nd [10] KANNADA DIGIT ZERO..KANNADA DIGIT NINE
 1040..1049    ; Cakm Mymr Tale                 # Nd [10] MYANMAR DIGIT ZERO..MYANMAR DIGIT NINE
 10FB          ; Geor Latn                      # Po      GEORGIAN PARAGRAPH SEPARATOR
 1735..1736    ; Buhd Hano Tagb Tglg            # Po  [2] PHILIPPINE SINGLE PUNCTUATION..PHILIPPINE DOUBLE PUNCTUATION
@@ -86,9 +86,9 @@
 1CEB..1CEC    ; Deva                           # Lo  [2] VEDIC SIGN ANUSVARA VAMAGOMUKHA..VEDIC SIGN ANUSVARA VAMAGOMUKHA WITH TAIL
 1CED          ; Beng Deva                      # Mn      VEDIC SIGN TIRYAK
 1CEE..1CF1    ; Deva                           # Lo  [4] VEDIC SIGN HEXIFORM LONG ANUSVARA..VEDIC SIGN ANUSVARA UBHAYATO MUKHA
-1CF2          ; Beng Deva Gran Knda Mlym Nand Orya Sinh Telu Tirh #Lo VEDIC SIGN ARDHAVISARGA
+1CF2          ; Beng Deva Gran Knda Mlym Nand Orya Sinh Telu Tirh Tutg #Lo VEDIC SIGN ARDHAVISARGA
 1CF3          ; Deva Gran                      # Lo      VEDIC SIGN ROTATED ARDHAVISARGA
-1CF4          ; Deva Gran Knda                 # Mn      VEDIC TONE CANDRA ABOVE
+1CF4          ; Deva Gran Knda Tutg            # Mn      VEDIC TONE CANDRA ABOVE
 1CF5..1CF6    ; Beng Deva                      # Lo  [2] VEDIC SIGN JIHVAMULIYA..VEDIC SIGN UPADHMANIYA
 1CF7          ; Beng                           # Mc      VEDIC SIGN ATIKRAMA
 1CF8..1CF9    ; Deva Gran                      # Mn  [2] VEDIC TONE RING ABOVE..VEDIC TONE DOUBLE RING ABOVE
@@ -151,12 +151,12 @@
 33E0..33FE    ; Hani                           # So [31] IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY ONE..IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY THIRTY-ONE
 A66F          ; Cyrl Glag                      # Mn      COMBINING CYRILLIC VZMET
 A700..A707    ; Hani Latn                      # Sk  [8] MODIFIER LETTER CHINESE TONE YIN PING..MODIFIER LETTER CHINESE TONE YANG RU
-A830..A832    ; Deva Dogr Gujr Guru Khoj Knda Kthi Mahj Mlym Modi Nand Shrd Sind Takr Tirh #No [3] NORTH INDIC FRACTION ONE QUARTER..NORTH INDIC FRACTION THREE QUARTERS
-A833..A835    ; Deva Dogr Gujr Guru Khoj Knda Kthi Mahj Modi Nand Shrd Sind Takr Tirh #No [3] NORTH INDIC FRACTION ONE SIXTEENTH..NORTH INDIC FRACTION THREE SIXTEENTHS
+A830..A832    ; Deva Dogr Gujr Guru Khoj Knda Kthi Mahj Mlym Modi Nand Shrd Sind Takr Tirh Tutg #No [3] NORTH INDIC FRACTION ONE QUARTER..NORTH INDIC FRACTION THREE QUARTERS
+A833..A835    ; Deva Dogr Gujr Guru Khoj Knda Kthi Mahj Modi Nand Shrd Sind Takr Tirh Tutg #No [3] NORTH INDIC FRACTION ONE SIXTEENTH..NORTH INDIC FRACTION THREE SIXTEENTHS
 A836..A837    ; Deva Dogr Gujr Guru Khoj Kthi Mahj Modi Sind Takr Tirh #So [2] NORTH INDIC QUARTER MARK..NORTH INDIC PLACEHOLDER MARK
 A838          ; Deva Dogr Gujr Guru Khoj Kthi Mahj Modi Shrd Sind Takr Tirh #Sc NORTH INDIC RUPEE MARK
 A839          ; Deva Dogr Gujr Guru Khoj Kthi Mahj Modi Sind Takr Tirh #So NORTH INDIC QUANTITY MARK
-A8F1          ; Beng Deva                      # Mn      COMBINING DEVANAGARI SIGN AVAGRAHA
+A8F1          ; Beng Deva Tutg                 # Mn      COMBINING DEVANAGARI SIGN AVAGRAHA
 A8F3          ; Deva Taml                      # Lo      DEVANAGARI SIGN CANDRABINDU VIRAMA
 A92E          ; Kali Latn Mymr                 # Po      KAYAH LI SIGN CWI
 A9CF          ; Bugi Java                      # Lm      JAVANESE PANGRANGKEP

--- a/unicodetools/data/ucd/dev/ScriptExtensions.txt
+++ b/unicodetools/data/ucd/dev/ScriptExtensions.txt
@@ -1,5 +1,5 @@
 # ScriptExtensions-16.0.0.txt
-# Date: 2024-02-29, 13:03:28 GMT
+# Date: 2024-02-29, 13:03:45 GMT
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -32,13 +32,49 @@
 # have as their value the corresponding Script property value
 #
 # @missing: 0000..10FFFF; <script>
+00B7          ; Avst Cari Copt Elba Geor Glag Gong Goth Grek Hani Latn Lydi Mahj Perm Shaw #Po MIDDLE DOT
+02BC          ; Beng Cyrl Deva Latn Lisu Thai Toto #Lm   MODIFIER LETTER APOSTROPHE
+02C7          ; Bopo Latn                      # Lm      CARON
+02C9..02CB    ; Bopo Latn                      # Lm  [3] MODIFIER LETTER MACRON..MODIFIER LETTER GRAVE ACCENT
+02CD          ; Latn Lisu                      # Lm      MODIFIER LETTER LOW MACRON
+02D7          ; Latn Thai                      # Sk      MODIFIER LETTER MINUS SIGN
+02D9          ; Bopo Latn                      # Sk      DOT ABOVE
+0301          ; Cher Cyrl Grek Latn Osge Sunu Tale Todr #Mn COMBINING ACUTE ACCENT
+0302          ; Cher Cyrl Latn Tfng            # Mn      COMBINING CIRCUMFLEX ACCENT
+0303          ; Glag Latn Sunu Syrc Thai       # Mn      COMBINING TILDE
+0304          ; Aghb Cher Copt Cyrl Goth Grek Latn Osge Syrc Tfng Todr #Mn COMBINING MACRON
+0305          ; Copt Elba Glag Goth Kana Latn  # Mn      COMBINING OVERLINE
+0306          ; Cyrl Grek Latn Perm            # Mn      COMBINING BREVE
+0307          ; Copt Hebr Latn Perm Syrc Tale Tfng Todr #Mn COMBINING DOT ABOVE
+0309          ; Latn Tfng                      # Mn      COMBINING HOOK ABOVE
+030A          ; Latn Syrc                      # Mn      COMBINING RING ABOVE
+030B          ; Cher Cyrl Latn Osge            # Mn      COMBINING DOUBLE ACUTE ACCENT
+030C          ; Cher Latn Tale                 # Mn      COMBINING CARON
+030D          ; Latn Sunu                      # Mn      COMBINING VERTICAL LINE ABOVE
+030E          ; Ethi Latn                      # Mn      COMBINING DOUBLE VERTICAL LINE ABOVE
+0310          ; Latn Sunu                      # Mn      COMBINING CANDRABINDU
+0311          ; Cyrl Latn Todr                 # Mn      COMBINING INVERTED BREVE
+0313          ; Grek Latn Perm Todr            # Mn      COMBINING COMMA ABOVE
+0320          ; Latn Syrc                      # Mn      COMBINING MINUS SIGN BELOW
+0323          ; Cher Kana Latn Syrc            # Mn      COMBINING DOT BELOW
+0324          ; Cher Latn Syrc                 # Mn      COMBINING DIAERESIS BELOW
+0325          ; Latn Syrc                      # Mn      COMBINING RING BELOW
+032D          ; Latn Sunu Syrc                 # Mn      COMBINING CIRCUMFLEX ACCENT BELOW
+032E          ; Latn Syrc                      # Mn      COMBINING BREVE BELOW
+0330          ; Cher Latn Syrc                 # Mn      COMBINING TILDE BELOW
+0331          ; Aghb Cher Goth Latn Sunu Thai  # Mn      COMBINING MACRON BELOW
 0342          ; Grek                           # Mn      COMBINING GREEK PERISPOMENI
 0345          ; Grek                           # Mn      COMBINING GREEK YPOGEGRAMMENI
+0358          ; Latn Osge                      # Mn      COMBINING DOT ABOVE RIGHT
+035E          ; Aghb Latn Todr                 # Mn      COMBINING DOUBLE MACRON
 0363..036F    ; Latn                           # Mn [13] COMBINING LATIN SMALL LETTER A..COMBINING LATIN SMALL LETTER X
+0374          ; Copt Grek                      # Lm      GREEK NUMERAL SIGN
+0375          ; Copt Grek                      # Sk      GREEK LOWER NUMERAL SIGN
 0483          ; Cyrl Perm                      # Mn      COMBINING CYRILLIC TITLO
 0484          ; Cyrl Glag                      # Mn      COMBINING CYRILLIC PALATALIZATION
 0485..0486    ; Cyrl Latn                      # Mn  [2] COMBINING CYRILLIC DASIA PNEUMATA..COMBINING CYRILLIC PSILI PNEUMATA
 0487          ; Cyrl Glag                      # Mn      COMBINING CYRILLIC POKRYTIE
+0589          ; Armn Geor Glag                 # Po      ARMENIAN FULL STOP
 060C          ; Arab Gara Nkoo Rohg Syrc Thaa Yezi #Po   ARABIC COMMA
 061B          ; Arab Gara Nkoo Rohg Syrc Thaa Yezi #Po   ARABIC SEMICOLON
 061C          ; Arab Syrc Thaa                 # Cf      ARABIC LETTER MARK
@@ -61,7 +97,7 @@
 0BF3          ; Gran Taml                      # So      TAMIL DAY SIGN
 0CE6..0CEF    ; Knda Nand Tutg                 # Nd [10] KANNADA DIGIT ZERO..KANNADA DIGIT NINE
 1040..1049    ; Cakm Mymr Tale                 # Nd [10] MYANMAR DIGIT ZERO..MYANMAR DIGIT NINE
-10FB          ; Geor Latn                      # Po      GEORGIAN PARAGRAPH SEPARATOR
+10FB          ; Geor Glag Latn                 # Po      GEORGIAN PARAGRAPH SEPARATOR
 1735..1736    ; Buhd Hano Tagb Tglg            # Po  [2] PHILIPPINE SINGLE PUNCTUATION..PHILIPPINE DOUBLE PUNCTUATION
 1802..1803    ; Mong Phag                      # Po  [2] MONGOLIAN COMMA..MONGOLIAN FULL STOP
 1805          ; Mong Phag                      # Po      MONGOLIAN FOUR DOTS
@@ -96,16 +132,25 @@
 1DC0..1DC1    ; Grek                           # Mn  [2] COMBINING DOTTED GRAVE ACCENT..COMBINING DOTTED ACUTE ACCENT
 1DF8          ; Cyrl Syrc                      # Mn      COMBINING DOT ABOVE LEFT
 1DFA          ; Syrc                           # Mn      COMBINING DOT BELOW LEFT
-202F          ; Latn Mong                      # Zs      NARROW NO-BREAK SPACE
+202F          ; Latn Mong Phag                 # Zs      NARROW NO-BREAK SPACE
+204F          ; Adlm Arab                      # Po      REVERSED SEMICOLON
+205A          ; Cari Geor Glag Hung Lyci Orkh  # Po      TWO DOT PUNCTUATION
+205D          ; Cari Grek Hung Mero            # Po      TRICOLON
 20F0          ; Deva Gran Latn                 # Mn      COMBINING ASTERISK ABOVE
+2E17          ; Copt Latn                      # Pd      DOUBLE OBLIQUE HYPHEN
+2E30          ; Avst Orkh                      # Po      RING POINT
+2E31          ; Avst Cari Geor Hung Kthi Lydi Samr #Po   WORD SEPARATOR MIDDLE DOT
+2E41          ; Adlm Arab Hung                 # Po      REVERSED COMMA
 2E43          ; Cyrl Glag                      # Po      DASH WITH LEFT UPTURN
-3001..3002    ; Bopo Hang Hani Hira Kana Yiii  # Po  [2] IDEOGRAPHIC COMMA..IDEOGRAPHIC FULL STOP
+2FF0..2FFF    ; Hani Tang                      # So [16] IDEOGRAPHIC DESCRIPTION CHARACTER LEFT TO RIGHT..IDEOGRAPHIC DESCRIPTION CHARACTER ROTATION
+3001          ; Bopo Hang Hani Hira Kana Mong Yiii #Po   IDEOGRAPHIC COMMA
+3002          ; Bopo Hang Hani Hira Kana Mong Phag Yiii #Po IDEOGRAPHIC FULL STOP
 3003          ; Bopo Hang Hani Hira Kana       # Po      DITTO MARK
 3006          ; Hani                           # Lo      IDEOGRAPHIC CLOSING MARK
 3008          ; Bopo Hang Hani Hira Kana Yiii  # Ps      LEFT ANGLE BRACKET
 3009          ; Bopo Hang Hani Hira Kana Yiii  # Pe      RIGHT ANGLE BRACKET
-300A          ; Bopo Hang Hani Hira Kana Yiii  # Ps      LEFT DOUBLE ANGLE BRACKET
-300B          ; Bopo Hang Hani Hira Kana Yiii  # Pe      RIGHT DOUBLE ANGLE BRACKET
+300A          ; Bopo Hang Hani Hira Kana Lisu Mong Yiii #Ps LEFT DOUBLE ANGLE BRACKET
+300B          ; Bopo Hang Hani Hira Kana Lisu Mong Yiii #Pe RIGHT DOUBLE ANGLE BRACKET
 300C          ; Bopo Hang Hani Hira Kana Yiii  # Ps      LEFT CORNER BRACKET
 300D          ; Bopo Hang Hani Hira Kana Yiii  # Pe      RIGHT CORNER BRACKET
 300E          ; Bopo Hang Hani Hira Kana Yiii  # Ps      LEFT WHITE CORNER BRACKET
@@ -140,6 +185,7 @@
 3192..3195    ; Hani                           # No  [4] IDEOGRAPHIC ANNOTATION ONE MARK..IDEOGRAPHIC ANNOTATION FOUR MARK
 3196..319F    ; Hani                           # So [10] IDEOGRAPHIC ANNOTATION TOP MARK..IDEOGRAPHIC ANNOTATION MAN MARK
 31C0..31E3    ; Hani                           # So [36] CJK STROKE T..CJK STROKE Q
+31EF          ; Hani Tang                      # So      IDEOGRAPHIC DESCRIPTION CHARACTER SUBTRACTION
 3220..3229    ; Hani                           # No [10] PARENTHESIZED IDEOGRAPH ONE..PARENTHESIZED IDEOGRAPH TEN
 322A..3247    ; Hani                           # So [30] PARENTHESIZED IDEOGRAPH MOON..CIRCLED IDEOGRAPH KOTO
 3280..3289    ; Hani                           # No [10] CIRCLED IDEOGRAPH ONE..CIRCLED IDEOGRAPH TEN

--- a/unicodetools/data/ucd/dev/ScriptExtensions.txt
+++ b/unicodetools/data/ucd/dev/ScriptExtensions.txt
@@ -1,5 +1,5 @@
 # ScriptExtensions-16.0.0.txt
-# Date: 2024-02-29, 13:03:13 GMT
+# Date: 2024-02-29, 13:03:28 GMT
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html

--- a/unicodetools/data/ucd/dev/ScriptExtensions.txt
+++ b/unicodetools/data/ucd/dev/ScriptExtensions.txt
@@ -1,5 +1,5 @@
 # ScriptExtensions-16.0.0.txt
-# Date: 2024-02-29, 00:08:00 GMT
+# Date: 2024-02-29, 13:01:56 GMT
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -32,930 +32,159 @@
 # have as their value the corresponding Script property value
 #
 # @missing: 0000..10FFFF; <script>
-
-# ================================================
-
-# Property:	Script_Extensions
-
-# ================================================
-
-# Script_Extensions=Beng
-
-1CF7          ; Beng # Mc       VEDIC SIGN ATIKRAMA
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Deva
-
-1CD1          ; Deva # Mn       VEDIC TONE SHARA
-1CD4          ; Deva # Mn       VEDIC SIGN YAJURVEDIC MIDLINE SVARITA
-1CDB          ; Deva # Mn       VEDIC TONE TRIPLE SVARITA
-1CDE..1CDF    ; Deva # Mn   [2] VEDIC TONE TWO DOTS BELOW..VEDIC TONE THREE DOTS BELOW
-1CE2..1CE8    ; Deva # Mn   [7] VEDIC SIGN VISARGA SVARITA..VEDIC SIGN VISARGA ANUDATTA WITH TAIL
-1CEB..1CEC    ; Deva # Lo   [2] VEDIC SIGN ANUSVARA VAMAGOMUKHA..VEDIC SIGN ANUSVARA VAMAGOMUKHA WITH TAIL
-1CEE..1CF1    ; Deva # Lo   [4] VEDIC SIGN HEXIFORM LONG ANUSVARA..VEDIC SIGN ANUSVARA UBHAYATO MUKHA
-
-# Total code points: 18
-
-# ================================================
-
-# Script_Extensions=Dupl
-
-1BCA0..1BCA3  ; Dupl # Cf   [4] SHORTHAND FORMAT LETTER OVERLAP..SHORTHAND FORMAT UP STEP
-
-# Total code points: 4
-
-# ================================================
-
-# Script_Extensions=Grek
-
-0342          ; Grek # Mn       COMBINING GREEK PERISPOMENI
-0345          ; Grek # Mn       COMBINING GREEK YPOGEGRAMMENI
-1DC0..1DC1    ; Grek # Mn   [2] COMBINING DOTTED GRAVE ACCENT..COMBINING DOTTED ACUTE ACCENT
-
-# Total code points: 4
-
-# ================================================
-
-# Script_Extensions=Hani
-
-3006          ; Hani # Lo       IDEOGRAPHIC CLOSING MARK
-303E..303F    ; Hani # So   [2] IDEOGRAPHIC VARIATION INDICATOR..IDEOGRAPHIC HALF FILL SPACE
-3190..3191    ; Hani # So   [2] IDEOGRAPHIC ANNOTATION LINKING MARK..IDEOGRAPHIC ANNOTATION REVERSE MARK
-3192..3195    ; Hani # No   [4] IDEOGRAPHIC ANNOTATION ONE MARK..IDEOGRAPHIC ANNOTATION FOUR MARK
-3196..319F    ; Hani # So  [10] IDEOGRAPHIC ANNOTATION TOP MARK..IDEOGRAPHIC ANNOTATION MAN MARK
-31C0..31E3    ; Hani # So  [36] CJK STROKE T..CJK STROKE Q
-3220..3229    ; Hani # No  [10] PARENTHESIZED IDEOGRAPH ONE..PARENTHESIZED IDEOGRAPH TEN
-322A..3247    ; Hani # So  [30] PARENTHESIZED IDEOGRAPH MOON..CIRCLED IDEOGRAPH KOTO
-3280..3289    ; Hani # No  [10] CIRCLED IDEOGRAPH ONE..CIRCLED IDEOGRAPH TEN
-328A..32B0    ; Hani # So  [39] CIRCLED IDEOGRAPH MOON..CIRCLED IDEOGRAPH NIGHT
-32C0..32CB    ; Hani # So  [12] IDEOGRAPHIC TELEGRAPH SYMBOL FOR JANUARY..IDEOGRAPHIC TELEGRAPH SYMBOL FOR DECEMBER
-32FF          ; Hani # So       SQUARE ERA NAME REIWA
-3358..3370    ; Hani # So  [25] IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR ZERO..IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR TWENTY-FOUR
-337B..337F    ; Hani # So   [5] SQUARE ERA NAME HEISEI..SQUARE CORPORATION
-33E0..33FE    ; Hani # So  [31] IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY ONE..IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY THIRTY-ONE
-1D360..1D371  ; Hani # No  [18] COUNTING ROD UNIT DIGIT ONE..COUNTING ROD TENS DIGIT NINE
-1F250..1F251  ; Hani # So   [2] CIRCLED IDEOGRAPH ADVANTAGE..CIRCLED IDEOGRAPH ACCEPT
-
-# Total code points: 238
-
-# ================================================
-
-# Script_Extensions=Latn
-
-0363..036F    ; Latn # Mn  [13] COMBINING LATIN SMALL LETTER A..COMBINING LATIN SMALL LETTER X
-
-# Total code points: 13
-
-# ================================================
-
-# Script_Extensions=Nand
-
-1CFA          ; Nand # Lo       VEDIC SIGN DOUBLE ANUSVARA ANTARGOMUKHA
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Syrc
-
-1DFA          ; Syrc # Mn       COMBINING DOT BELOW LEFT
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Adlm Arab
-
-204F          ; Adlm Arab # Po       REVERSED SEMICOLON
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Arab Copt
-
-102E0         ; Arab Copt # Mn       COPTIC EPACT THOUSANDS MARK
-102E1..102FB  ; Arab Copt # No  [27] COPTIC EPACT DIGIT ONE..COPTIC EPACT NUMBER NINE HUNDRED
-
-# Total code points: 28
-
-# ================================================
-
-# Script_Extensions=Arab Nkoo
-
-FD3E          ; Arab Nkoo # Pe       ORNATE LEFT PARENTHESIS
-FD3F          ; Arab Nkoo # Ps       ORNATE RIGHT PARENTHESIS
-
-# Total code points: 2
-
-# ================================================
-
-# Script_Extensions=Arab Rohg
-
-06D4          ; Arab Rohg # Po       ARABIC FULL STOP
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Arab Syrc
-
-064B..0655    ; Arab Syrc # Mn  [11] ARABIC FATHATAN..ARABIC HAMZA BELOW
-0670          ; Arab Syrc # Mn       ARABIC LETTER SUPERSCRIPT ALEF
-
-# Total code points: 12
-
-# ================================================
-
-# Script_Extensions=Arab Thaa
-
-FDF2          ; Arab Thaa # Lo       ARABIC LIGATURE ALLAH ISOLATED FORM
-FDFD          ; Arab Thaa # So       ARABIC LIGATURE BISMILLAH AR-RAHMAN AR-RAHEEM
-
-# Total code points: 2
-
-# ================================================
-
-# Script_Extensions=Avst Orkh
-
-2E30          ; Avst Orkh # Po       RING POINT
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Beng Deva
-
-1CD5..1CD6    ; Beng Deva # Mn   [2] VEDIC TONE YAJURVEDIC AGGRAVATED INDEPENDENT SVARITA..VEDIC TONE YAJURVEDIC INDEPENDENT SVARITA
-1CD8          ; Beng Deva # Mn       VEDIC TONE CANDRA BELOW
-1CE1          ; Beng Deva # Mc       VEDIC TONE ATHARVAVEDIC INDEPENDENT SVARITA
-1CEA          ; Beng Deva # Lo       VEDIC SIGN ANUSVARA BAHIRGOMUKHA
-1CED          ; Beng Deva # Mn       VEDIC SIGN TIRYAK
-1CF5..1CF6    ; Beng Deva # Lo   [2] VEDIC SIGN JIHVAMULIYA..VEDIC SIGN UPADHMANIYA
-
-# Total code points: 8
-
-# ================================================
-
-# Script_Extensions=Bopo Hani
-
-302A..302D    ; Bopo Hani # Mn   [4] IDEOGRAPHIC LEVEL TONE MARK..IDEOGRAPHIC ENTERING TONE MARK
-
-# Total code points: 4
-
-# ================================================
-
-# Script_Extensions=Bopo Latn
-
-02C7          ; Bopo Latn # Lm       CARON
-02C9..02CB    ; Bopo Latn # Lm   [3] MODIFIER LETTER MACRON..MODIFIER LETTER GRAVE ACCENT
-02D9          ; Bopo Latn # Sk       DOT ABOVE
-
-# Total code points: 5
-
-# ================================================
-
-# Script_Extensions=Bugi Java
-
-A9CF          ; Bugi Java # Lm       JAVANESE PANGRANGKEP
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Copt Grek
-
-0374          ; Copt Grek # Lm       GREEK NUMERAL SIGN
-0375          ; Copt Grek # Sk       GREEK LOWER NUMERAL SIGN
-
-# Total code points: 2
-
-# ================================================
-
-# Script_Extensions=Copt Latn
-
-2E17          ; Copt Latn # Pd       DOUBLE OBLIQUE HYPHEN
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Cprt Linb
-
-10102         ; Cprt Linb # Po       AEGEAN CHECK MARK
-10137..1013F  ; Cprt Linb # So   [9] AEGEAN WEIGHT BASE UNIT..AEGEAN MEASURE THIRD SUBUNIT
-
-# Total code points: 10
-
-# ================================================
-
-# Script_Extensions=Cyrl Glag
-
-0484          ; Cyrl Glag # Mn       COMBINING CYRILLIC PALATALIZATION
-0487          ; Cyrl Glag # Mn       COMBINING CYRILLIC POKRYTIE
-2E43          ; Cyrl Glag # Po       DASH WITH LEFT UPTURN
-A66F          ; Cyrl Glag # Mn       COMBINING CYRILLIC VZMET
-
-# Total code points: 4
-
-# ================================================
-
-# Script_Extensions=Cyrl Latn
-
-0485..0486    ; Cyrl Latn # Mn   [2] COMBINING CYRILLIC DASIA PNEUMATA..COMBINING CYRILLIC PSILI PNEUMATA
-
-# Total code points: 2
-
-# ================================================
-
-# Script_Extensions=Cyrl Perm
-
-0483          ; Cyrl Perm # Mn       COMBINING CYRILLIC TITLO
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Cyrl Syrc
-
-1DF8          ; Cyrl Syrc # Mn       COMBINING DOT ABOVE LEFT
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Deva Gran
-
-1CD3          ; Deva Gran # Po       VEDIC SIGN NIHSHVASA
-1CF3          ; Deva Gran # Lo       VEDIC SIGN ROTATED ARDHAVISARGA
-1CF8..1CF9    ; Deva Gran # Mn   [2] VEDIC TONE RING ABOVE..VEDIC TONE DOUBLE RING ABOVE
-
-# Total code points: 4
-
-# ================================================
-
-# Script_Extensions=Deva Nand
-
-1CE9          ; Deva Nand # Lo       VEDIC SIGN ANUSVARA ANTARGOMUKHA
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Deva Shrd
-
-1CD7          ; Deva Shrd # Mn       VEDIC TONE YAJURVEDIC KATHAKA INDEPENDENT SVARITA
-1CD9          ; Deva Shrd # Mn       VEDIC TONE YAJURVEDIC KATHAKA INDEPENDENT SVARITA SCHROEDER
-1CDC..1CDD    ; Deva Shrd # Mn   [2] VEDIC TONE KATHAKA ANUDATTA..VEDIC TONE DOT BELOW
-1CE0          ; Deva Shrd # Mn       VEDIC TONE RIGVEDIC KASHMIRI INDEPENDENT SVARITA
-
-# Total code points: 5
-
-# ================================================
-
-# Script_Extensions=Deva Taml
-
-A8F3          ; Deva Taml # Lo       DEVANAGARI SIGN CANDRABINDU VIRAMA
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Ethi Latn
-
-030E          ; Ethi Latn # Mn       COMBINING DOUBLE VERTICAL LINE ABOVE
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Gran Taml
-
-0BE6..0BEF    ; Gran Taml # Nd  [10] TAMIL DIGIT ZERO..TAMIL DIGIT NINE
-0BF0..0BF2    ; Gran Taml # No   [3] TAMIL NUMBER TEN..TAMIL NUMBER ONE THOUSAND
-0BF3          ; Gran Taml # So       TAMIL DAY SIGN
-11301         ; Gran Taml # Mn       GRANTHA SIGN CANDRABINDU
-11303         ; Gran Taml # Mc       GRANTHA SIGN VISARGA
-1133B..1133C  ; Gran Taml # Mn   [2] COMBINING BINDU BELOW..GRANTHA SIGN NUKTA
-11FD0..11FD1  ; Gran Taml # No   [2] TAMIL FRACTION ONE QUARTER..TAMIL FRACTION ONE HALF-1
-11FD3         ; Gran Taml # No       TAMIL FRACTION THREE QUARTERS
-
-# Total code points: 21
-
-# ================================================
-
-# Script_Extensions=Gujr Khoj
-
-0AE6..0AEF    ; Gujr Khoj # Nd  [10] GUJARATI DIGIT ZERO..GUJARATI DIGIT NINE
-
-# Total code points: 10
-
-# ================================================
-
-# Script_Extensions=Guru Mult
-
-0A66..0A6F    ; Guru Mult # Nd  [10] GURMUKHI DIGIT ZERO..GURMUKHI DIGIT NINE
-
-# Total code points: 10
-
-# ================================================
-
-# Script_Extensions=Hani Latn
-
-A700..A707    ; Hani Latn # Sk   [8] MODIFIER LETTER CHINESE TONE YIN PING..MODIFIER LETTER CHINESE TONE YANG RU
-
-# Total code points: 8
-
-# ================================================
-
-# Script_Extensions=Hani Tang
-
-2FF0..2FFF    ; Hani Tang # So  [16] IDEOGRAPHIC DESCRIPTION CHARACTER LEFT TO RIGHT..IDEOGRAPHIC DESCRIPTION CHARACTER ROTATION
-31EF          ; Hani Tang # So       IDEOGRAPHIC DESCRIPTION CHARACTER SUBTRACTION
-
-# Total code points: 17
-
-# ================================================
-
-# Script_Extensions=Hira Kana
-
-3031..3035    ; Hira Kana # Lm   [5] VERTICAL KANA REPEAT MARK..VERTICAL KANA REPEAT MARK LOWER HALF
-3099..309A    ; Hira Kana # Mn   [2] COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK..COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
-309B..309C    ; Hira Kana # Sk   [2] KATAKANA-HIRAGANA VOICED SOUND MARK..KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
-30A0          ; Hira Kana # Pd       KATAKANA-HIRAGANA DOUBLE HYPHEN
-30FC          ; Hira Kana # Lm       KATAKANA-HIRAGANA PROLONGED SOUND MARK
-FF70          ; Hira Kana # Lm       HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK
-FF9E..FF9F    ; Hira Kana # Lm   [2] HALFWIDTH KATAKANA VOICED SOUND MARK..HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK
-
-# Total code points: 14
-
-# ================================================
-
-# Script_Extensions=Latn Lisu
-
-02CD          ; Latn Lisu # Lm       MODIFIER LETTER LOW MACRON
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Latn Osge
-
-0358          ; Latn Osge # Mn       COMBINING DOT ABOVE RIGHT
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Latn Sunu
-
-030D          ; Latn Sunu # Mn       COMBINING VERTICAL LINE ABOVE
-0310          ; Latn Sunu # Mn       COMBINING CANDRABINDU
-
-# Total code points: 2
-
-# ================================================
-
-# Script_Extensions=Latn Syrc
-
-030A          ; Latn Syrc # Mn       COMBINING RING ABOVE
-0320          ; Latn Syrc # Mn       COMBINING MINUS SIGN BELOW
-0325          ; Latn Syrc # Mn       COMBINING RING BELOW
-032E          ; Latn Syrc # Mn       COMBINING BREVE BELOW
-
-# Total code points: 4
-
-# ================================================
-
-# Script_Extensions=Latn Tfng
-
-0309          ; Latn Tfng # Mn       COMBINING HOOK ABOVE
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Latn Thai
-
-02D7          ; Latn Thai # Sk       MODIFIER LETTER MINUS SIGN
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Mani Ougr
-
-10AF2         ; Mani Ougr # Po       MANICHAEAN PUNCTUATION DOUBLE DOT WITHIN DOT
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Mong Phag
-
-1802..1803    ; Mong Phag # Po   [2] MONGOLIAN COMMA..MONGOLIAN FULL STOP
-1805          ; Mong Phag # Po       MONGOLIAN FOUR DOTS
-
-# Total code points: 3
-
-# ================================================
-
-# Script_Extensions=Adlm Arab Hung
-
-2E41          ; Adlm Arab Hung # Po       REVERSED COMMA
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Aghb Latn Todr
-
-035E          ; Aghb Latn Todr # Mn       COMBINING DOUBLE MACRON
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Arab Syrc Thaa
-
-061C          ; Arab Syrc Thaa # Cf       ARABIC LETTER MARK
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Arab Thaa Yezi
-
-0660..0669    ; Arab Thaa Yezi # Nd  [10] ARABIC-INDIC DIGIT ZERO..ARABIC-INDIC DIGIT NINE
-
-# Total code points: 10
-
-# ================================================
-
-# Script_Extensions=Armn Geor Glag
-
-0589          ; Armn Geor Glag # Po       ARMENIAN FULL STOP
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Beng Cakm Sylo
-
-09E6..09EF    ; Beng Cakm Sylo # Nd  [10] BENGALI DIGIT ZERO..BENGALI DIGIT NINE
-
-# Total code points: 10
-
-# ================================================
-
-# Script_Extensions=Beng Deva Tutg
-
-A8F1          ; Beng Deva Tutg # Mn       COMBINING DEVANAGARI SIGN AVAGRAHA
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Cakm Mymr Tale
-
-1040..1049    ; Cakm Mymr Tale # Nd  [10] MYANMAR DIGIT ZERO..MYANMAR DIGIT NINE
-
-# Total code points: 10
-
-# ================================================
-
-# Script_Extensions=Cher Latn Syrc
-
-0324          ; Cher Latn Syrc # Mn       COMBINING DIAERESIS BELOW
-0330          ; Cher Latn Syrc # Mn       COMBINING TILDE BELOW
-
-# Total code points: 2
-
-# ================================================
-
-# Script_Extensions=Cher Latn Tale
-
-030C          ; Cher Latn Tale # Mn       COMBINING CARON
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Cpmn Cprt Linb
-
-10100..10101  ; Cpmn Cprt Linb # Po   [2] AEGEAN WORD SEPARATOR LINE..AEGEAN WORD SEPARATOR DOT
-
-# Total code points: 2
-
-# ================================================
-
-# Script_Extensions=Cprt Lina Linb
-
-10107..10133  ; Cprt Lina Linb # No  [45] AEGEAN NUMBER ONE..AEGEAN NUMBER NINETY THOUSAND
-
-# Total code points: 45
-
-# ================================================
-
-# Script_Extensions=Cyrl Latn Todr
-
-0311          ; Cyrl Latn Todr # Mn       COMBINING INVERTED BREVE
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Deva Gran Latn
-
-20F0          ; Deva Gran Latn # Mn       COMBINING ASTERISK ABOVE
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Geor Glag Latn
-
-10FB          ; Geor Glag Latn # Po       GEORGIAN PARAGRAPH SEPARATOR
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Hani Hira Kana
-
-303C          ; Hani Hira Kana # Lo       MASU MARK
-303D          ; Hani Hira Kana # Po       PART ALTERNATION MARK
-
-# Total code points: 2
-
-# ================================================
-
-# Script_Extensions=Kali Latn Mymr
-
-A92E          ; Kali Latn Mymr # Po       KAYAH LI SIGN CWI
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Knda Nand Tutg
-
-0CE6..0CEF    ; Knda Nand Tutg # Nd  [10] KANNADA DIGIT ZERO..KANNADA DIGIT NINE
-
-# Total code points: 10
-
-# ================================================
-
-# Script_Extensions=Latn Mong Phag
-
-202F          ; Latn Mong Phag # Zs       NARROW NO-BREAK SPACE
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Latn Sunu Syrc
-
-032D          ; Latn Sunu Syrc # Mn       COMBINING CIRCUMFLEX ACCENT BELOW
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Beng Deva Gran Knda
-
-1CD0          ; Beng Deva Gran Knda # Mn       VEDIC TONE KARSHANA
-1CD2          ; Beng Deva Gran Knda # Mn       VEDIC TONE PRENKHA
-
-# Total code points: 2
-
-# ================================================
-
-# Script_Extensions=Buhd Hano Tagb Tglg
-
-1735..1736    ; Buhd Hano Tagb Tglg # Po   [2] PHILIPPINE SINGLE PUNCTUATION..PHILIPPINE DOUBLE PUNCTUATION
-
-# Total code points: 2
-
-# ================================================
-
-# Script_Extensions=Cari Grek Hung Mero
-
-205D          ; Cari Grek Hung Mero # Po       TRICOLON
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Cher Cyrl Latn Osge
-
-030B          ; Cher Cyrl Latn Osge # Mn       COMBINING DOUBLE ACUTE ACCENT
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Cher Cyrl Latn Tfng
-
-0302          ; Cher Cyrl Latn Tfng # Mn       COMBINING CIRCUMFLEX ACCENT
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Cher Kana Latn Syrc
-
-0323          ; Cher Kana Latn Syrc # Mn       COMBINING DOT BELOW
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Cyrl Grek Latn Perm
-
-0306          ; Cyrl Grek Latn Perm # Mn       COMBINING BREVE
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Deva Dogr Kthi Mahj
-
-0966..096F    ; Deva Dogr Kthi Mahj # Nd  [10] DEVANAGARI DIGIT ZERO..DEVANAGARI DIGIT NINE
-
-# Total code points: 10
-
-# ================================================
-
-# Script_Extensions=Deva Gran Knda Tutg
-
-1CF4          ; Deva Gran Knda Tutg # Mn       VEDIC TONE CANDRA ABOVE
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Grek Latn Perm Todr
-
-0313          ; Grek Latn Perm Todr # Mn       COMBINING COMMA ABOVE
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Bopo Hang Hani Hira Kana
-
-3003          ; Bopo Hang Hani Hira Kana # Po       DITTO MARK
-3013          ; Bopo Hang Hani Hira Kana # So       GETA MARK
-301C          ; Bopo Hang Hani Hira Kana # Pd       WAVE DASH
-301D          ; Bopo Hang Hani Hira Kana # Ps       REVERSED DOUBLE PRIME QUOTATION MARK
-301E..301F    ; Bopo Hang Hani Hira Kana # Pe   [2] DOUBLE PRIME QUOTATION MARK..LOW DOUBLE PRIME QUOTATION MARK
-3030          ; Bopo Hang Hani Hira Kana # Pd       WAVY DASH
-3037          ; Bopo Hang Hani Hira Kana # So       IDEOGRAPHIC TELEGRAPH LINE FEED SEPARATOR SYMBOL
-FE45..FE46    ; Bopo Hang Hani Hira Kana # Po   [2] SESAME DOT..WHITE SESAME DOT
-
-# Total code points: 10
-
-# ================================================
-
-# Script_Extensions=Glag Latn Sunu Syrc Thai
-
-0303          ; Glag Latn Sunu Syrc Thai # Mn       COMBINING TILDE
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Aghb Cher Goth Latn Sunu Thai
-
-0331          ; Aghb Cher Goth Latn Sunu Thai # Mn       COMBINING MACRON BELOW
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Bopo Hang Hani Hira Kana Yiii
-
-3008          ; Bopo Hang Hani Hira Kana Yiii # Ps       LEFT ANGLE BRACKET
-3009          ; Bopo Hang Hani Hira Kana Yiii # Pe       RIGHT ANGLE BRACKET
-300C          ; Bopo Hang Hani Hira Kana Yiii # Ps       LEFT CORNER BRACKET
-300D          ; Bopo Hang Hani Hira Kana Yiii # Pe       RIGHT CORNER BRACKET
-300E          ; Bopo Hang Hani Hira Kana Yiii # Ps       LEFT WHITE CORNER BRACKET
-300F          ; Bopo Hang Hani Hira Kana Yiii # Pe       RIGHT WHITE CORNER BRACKET
-3010          ; Bopo Hang Hani Hira Kana Yiii # Ps       LEFT BLACK LENTICULAR BRACKET
-3011          ; Bopo Hang Hani Hira Kana Yiii # Pe       RIGHT BLACK LENTICULAR BRACKET
-3014          ; Bopo Hang Hani Hira Kana Yiii # Ps       LEFT TORTOISE SHELL BRACKET
-3015          ; Bopo Hang Hani Hira Kana Yiii # Pe       RIGHT TORTOISE SHELL BRACKET
-3016          ; Bopo Hang Hani Hira Kana Yiii # Ps       LEFT WHITE LENTICULAR BRACKET
-3017          ; Bopo Hang Hani Hira Kana Yiii # Pe       RIGHT WHITE LENTICULAR BRACKET
-3018          ; Bopo Hang Hani Hira Kana Yiii # Ps       LEFT WHITE TORTOISE SHELL BRACKET
-3019          ; Bopo Hang Hani Hira Kana Yiii # Pe       RIGHT WHITE TORTOISE SHELL BRACKET
-301A          ; Bopo Hang Hani Hira Kana Yiii # Ps       LEFT WHITE SQUARE BRACKET
-301B          ; Bopo Hang Hani Hira Kana Yiii # Pe       RIGHT WHITE SQUARE BRACKET
-30FB          ; Bopo Hang Hani Hira Kana Yiii # Po       KATAKANA MIDDLE DOT
-FF61          ; Bopo Hang Hani Hira Kana Yiii # Po       HALFWIDTH IDEOGRAPHIC FULL STOP
-FF62          ; Bopo Hang Hani Hira Kana Yiii # Ps       HALFWIDTH LEFT CORNER BRACKET
-FF63          ; Bopo Hang Hani Hira Kana Yiii # Pe       HALFWIDTH RIGHT CORNER BRACKET
-FF64..FF65    ; Bopo Hang Hani Hira Kana Yiii # Po   [2] HALFWIDTH IDEOGRAPHIC COMMA..HALFWIDTH KATAKANA MIDDLE DOT
-
-# Total code points: 22
-
-# ================================================
-
-# Script_Extensions=Cari Geor Glag Hung Lyci Orkh
-
-205A          ; Cari Geor Glag Hung Lyci Orkh # Po       TWO DOT PUNCTUATION
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Copt Elba Glag Goth Kana Latn
-
-0305          ; Copt Elba Glag Goth Kana Latn # Mn       COMBINING OVERLINE
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Deva Knda Mlym Orya Taml Telu
-
-1CDA          ; Deva Knda Mlym Orya Taml Telu # Mn       VEDIC TONE DOUBLE SVARITA
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Arab Gara Nkoo Rohg Syrc Thaa Yezi
-
-060C          ; Arab Gara Nkoo Rohg Syrc Thaa Yezi # Po       ARABIC COMMA
-061B          ; Arab Gara Nkoo Rohg Syrc Thaa Yezi # Po       ARABIC SEMICOLON
-
-# Total code points: 2
-
-# ================================================
-
-# Script_Extensions=Avst Cari Geor Hung Kthi Lydi Samr
-
-2E31          ; Avst Cari Geor Hung Kthi Lydi Samr # Po       WORD SEPARATOR MIDDLE DOT
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Beng Cyrl Deva Latn Lisu Thai Toto
-
-02BC          ; Beng Cyrl Deva Latn Lisu Thai Toto # Lm       MODIFIER LETTER APOSTROPHE
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Bopo Hang Hani Hira Kana Mong Yiii
-
-3001          ; Bopo Hang Hani Hira Kana Mong Yiii # Po       IDEOGRAPHIC COMMA
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Adlm Arab Gara Nkoo Rohg Syrc Thaa Yezi
-
-061F          ; Adlm Arab Gara Nkoo Rohg Syrc Thaa Yezi # Po       ARABIC QUESTION MARK
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Bopo Hang Hani Hira Kana Lisu Mong Yiii
-
-300A          ; Bopo Hang Hani Hira Kana Lisu Mong Yiii # Ps       LEFT DOUBLE ANGLE BRACKET
-300B          ; Bopo Hang Hani Hira Kana Lisu Mong Yiii # Pe       RIGHT DOUBLE ANGLE BRACKET
-
-# Total code points: 2
-
-# ================================================
-
-# Script_Extensions=Bopo Hang Hani Hira Kana Mong Phag Yiii
-
-3002          ; Bopo Hang Hani Hira Kana Mong Phag Yiii # Po       IDEOGRAPHIC FULL STOP
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Cher Cyrl Grek Latn Osge Sunu Tale Todr
-
-0301          ; Cher Cyrl Grek Latn Osge Sunu Tale Todr # Mn       COMBINING ACUTE ACCENT
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Copt Hebr Latn Perm Syrc Tale Tfng Todr
-
-0307          ; Copt Hebr Latn Perm Syrc Tale Tfng Todr # Mn       COMBINING DOT ABOVE
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Adlm Arab Mand Mani Ougr Phlp Rohg Sogd Syrc
-
-0640          ; Adlm Arab Mand Mani Ougr Phlp Rohg Sogd Syrc # Lm       ARABIC TATWEEL
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Aghb Cher Copt Cyrl Goth Grek Latn Osge Syrc Tfng Todr
-
-0304          ; Aghb Cher Copt Cyrl Goth Grek Latn Osge Syrc Tfng Todr # Mn       COMBINING MACRON
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Beng Deva Gran Knda Mlym Nand Orya Sinh Telu Tirh Tutg
-
-1CF2          ; Beng Deva Gran Knda Mlym Nand Orya Sinh Telu Tirh Tutg # Lo       VEDIC SIGN ARDHAVISARGA
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Deva Dogr Gujr Guru Khoj Kthi Mahj Modi Sind Takr Tirh
-
-A836..A837    ; Deva Dogr Gujr Guru Khoj Kthi Mahj Modi Sind Takr Tirh # So   [2] NORTH INDIC QUARTER MARK..NORTH INDIC PLACEHOLDER MARK
-A839          ; Deva Dogr Gujr Guru Khoj Kthi Mahj Modi Sind Takr Tirh # So       NORTH INDIC QUANTITY MARK
-
-# Total code points: 3
-
-# ================================================
-
-# Script_Extensions=Beng Deva Gran Gujr Guru Knda Latn Mlym Orya Taml Telu Tirh
-
-0952          ; Beng Deva Gran Gujr Guru Knda Latn Mlym Orya Taml Telu Tirh # Mn       DEVANAGARI STRESS SIGN ANUDATTA
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Deva Dogr Gujr Guru Khoj Kthi Mahj Modi Shrd Sind Takr Tirh
-
-A838          ; Deva Dogr Gujr Guru Khoj Kthi Mahj Modi Shrd Sind Takr Tirh # Sc       NORTH INDIC RUPEE MARK
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Beng Deva Gran Gujr Guru Knda Latn Mlym Orya Shrd Taml Telu Tirh
-
-0951          ; Beng Deva Gran Gujr Guru Knda Latn Mlym Orya Shrd Taml Telu Tirh # Mn       DEVANAGARI STRESS SIGN UDATTA
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Avst Cari Copt Elba Geor Glag Gong Goth Grek Hani Latn Lydi Mahj Perm Shaw
-
-00B7          ; Avst Cari Copt Elba Geor Glag Gong Goth Grek Hani Latn Lydi Mahj Perm Shaw # Po       MIDDLE DOT
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Deva Dogr Gujr Guru Khoj Knda Kthi Mahj Modi Nand Shrd Sind Takr Tirh Tutg
-
-A833..A835    ; Deva Dogr Gujr Guru Khoj Knda Kthi Mahj Modi Nand Shrd Sind Takr Tirh Tutg # No   [3] NORTH INDIC FRACTION ONE SIXTEENTH..NORTH INDIC FRACTION THREE SIXTEENTHS
-
-# Total code points: 3
-
-# ================================================
-
-# Script_Extensions=Deva Dogr Gujr Guru Khoj Knda Kthi Mahj Mlym Modi Nand Shrd Sind Takr Tirh Tutg
-
-A830..A832    ; Deva Dogr Gujr Guru Khoj Knda Kthi Mahj Mlym Modi Nand Shrd Sind Takr Tirh Tutg # No   [3] NORTH INDIC FRACTION ONE QUARTER..NORTH INDIC FRACTION THREE QUARTERS
-
-# Total code points: 3
-
-# ================================================
-
-# Script_Extensions=Beng Deva Dogr Gong Gonm Gran Gujr Guru Knda Mahj Mlym Nand Onao Orya Sind Sinh Sylo Takr Taml Telu Tirh
-
-0964          ; Beng Deva Dogr Gong Gonm Gran Gujr Guru Knda Mahj Mlym Nand Onao Orya Sind Sinh Sylo Takr Taml Telu Tirh # Po       DEVANAGARI DANDA
-
-# Total code points: 1
-
-# ================================================
-
-# Script_Extensions=Beng Deva Dogr Gong Gonm Gran Gujr Gukh Guru Knda Limb Mahj Mlym Nand Onao Orya Sind Sinh Sylo Takr Taml Telu Tirh
-
-0965          ; Beng Deva Dogr Gong Gonm Gran Gujr Gukh Guru Knda Limb Mahj Mlym Nand Onao Orya Sind Sinh Sylo Takr Taml Telu Tirh # Po       DEVANAGARI DOUBLE DANDA
-
-# Total code points: 1
+0342          ; Grek                           # Mn      COMBINING GREEK PERISPOMENI
+0345          ; Grek                           # Mn      COMBINING GREEK YPOGEGRAMMENI
+0363..036F    ; Latn                           # Mn [13] COMBINING LATIN SMALL LETTER A..COMBINING LATIN SMALL LETTER X
+0483          ; Cyrl Perm                      # Mn      COMBINING CYRILLIC TITLO
+0484          ; Cyrl Glag                      # Mn      COMBINING CYRILLIC PALATALIZATION
+0485..0486    ; Cyrl Latn                      # Mn  [2] COMBINING CYRILLIC DASIA PNEUMATA..COMBINING CYRILLIC PSILI PNEUMATA
+0487          ; Cyrl Glag                      # Mn      COMBINING CYRILLIC POKRYTIE
+060C          ; Arab Nkoo Rohg Syrc Thaa Yezi  # Po      ARABIC COMMA
+061B          ; Arab Nkoo Rohg Syrc Thaa Yezi  # Po      ARABIC SEMICOLON
+061C          ; Arab Syrc Thaa                 # Cf      ARABIC LETTER MARK
+061F          ; Adlm Arab Nkoo Rohg Syrc Thaa Yezi #Po   ARABIC QUESTION MARK
+0640          ; Adlm Arab Mand Mani Ougr Phlp Rohg Sogd Syrc #Lm ARABIC TATWEEL
+064B..0655    ; Arab Syrc                      # Mn [11] ARABIC FATHATAN..ARABIC HAMZA BELOW
+0660..0669    ; Arab Thaa Yezi                 # Nd [10] ARABIC-INDIC DIGIT ZERO..ARABIC-INDIC DIGIT NINE
+0670          ; Arab Syrc                      # Mn      ARABIC LETTER SUPERSCRIPT ALEF
+06D4          ; Arab Rohg                      # Po      ARABIC FULL STOP
+0951          ; Beng Deva Gran Gujr Guru Knda Latn Mlym Orya Shrd Taml Telu Tirh #Mn DEVANAGARI STRESS SIGN UDATTA
+0952          ; Beng Deva Gran Gujr Guru Knda Latn Mlym Orya Taml Telu Tirh #Mn DEVANAGARI STRESS SIGN ANUDATTA
+0964          ; Beng Deva Dogr Gong Gonm Gran Gujr Guru Knda Mahj Mlym Nand Orya Sind Sinh Sylo Takr Taml Telu Tirh #Po DEVANAGARI DANDA
+0965          ; Beng Deva Dogr Gong Gonm Gran Gujr Guru Knda Limb Mahj Mlym Nand Orya Sind Sinh Sylo Takr Taml Telu Tirh #Po DEVANAGARI DOUBLE DANDA
+0966..096F    ; Deva Dogr Kthi Mahj            # Nd [10] DEVANAGARI DIGIT ZERO..DEVANAGARI DIGIT NINE
+09E6..09EF    ; Beng Cakm Sylo                 # Nd [10] BENGALI DIGIT ZERO..BENGALI DIGIT NINE
+0A66..0A6F    ; Guru Mult                      # Nd [10] GURMUKHI DIGIT ZERO..GURMUKHI DIGIT NINE
+0AE6..0AEF    ; Gujr Khoj                      # Nd [10] GUJARATI DIGIT ZERO..GUJARATI DIGIT NINE
+0BE6..0BEF    ; Gran Taml                      # Nd [10] TAMIL DIGIT ZERO..TAMIL DIGIT NINE
+0BF0..0BF2    ; Gran Taml                      # No  [3] TAMIL NUMBER TEN..TAMIL NUMBER ONE THOUSAND
+0BF3          ; Gran Taml                      # So      TAMIL DAY SIGN
+0CE6..0CEF    ; Knda Nand                      # Nd [10] KANNADA DIGIT ZERO..KANNADA DIGIT NINE
+1040..1049    ; Cakm Mymr Tale                 # Nd [10] MYANMAR DIGIT ZERO..MYANMAR DIGIT NINE
+10FB          ; Geor Latn                      # Po      GEORGIAN PARAGRAPH SEPARATOR
+1735..1736    ; Buhd Hano Tagb Tglg            # Po  [2] PHILIPPINE SINGLE PUNCTUATION..PHILIPPINE DOUBLE PUNCTUATION
+1802..1803    ; Mong Phag                      # Po  [2] MONGOLIAN COMMA..MONGOLIAN FULL STOP
+1805          ; Mong Phag                      # Po      MONGOLIAN FOUR DOTS
+1CD0          ; Beng Deva Gran Knda            # Mn      VEDIC TONE KARSHANA
+1CD1          ; Deva                           # Mn      VEDIC TONE SHARA
+1CD2          ; Beng Deva Gran Knda            # Mn      VEDIC TONE PRENKHA
+1CD3          ; Deva Gran                      # Po      VEDIC SIGN NIHSHVASA
+1CD4          ; Deva                           # Mn      VEDIC SIGN YAJURVEDIC MIDLINE SVARITA
+1CD5..1CD6    ; Beng Deva                      # Mn  [2] VEDIC TONE YAJURVEDIC AGGRAVATED INDEPENDENT SVARITA..VEDIC TONE YAJURVEDIC INDEPENDENT SVARITA
+1CD7          ; Deva Shrd                      # Mn      VEDIC TONE YAJURVEDIC KATHAKA INDEPENDENT SVARITA
+1CD8          ; Beng Deva                      # Mn      VEDIC TONE CANDRA BELOW
+1CD9          ; Deva Shrd                      # Mn      VEDIC TONE YAJURVEDIC KATHAKA INDEPENDENT SVARITA SCHROEDER
+1CDA          ; Deva Knda Mlym Orya Taml Telu  # Mn      VEDIC TONE DOUBLE SVARITA
+1CDB          ; Deva                           # Mn      VEDIC TONE TRIPLE SVARITA
+1CDC..1CDD    ; Deva Shrd                      # Mn  [2] VEDIC TONE KATHAKA ANUDATTA..VEDIC TONE DOT BELOW
+1CDE..1CDF    ; Deva                           # Mn  [2] VEDIC TONE TWO DOTS BELOW..VEDIC TONE THREE DOTS BELOW
+1CE0          ; Deva Shrd                      # Mn      VEDIC TONE RIGVEDIC KASHMIRI INDEPENDENT SVARITA
+1CE1          ; Beng Deva                      # Mc      VEDIC TONE ATHARVAVEDIC INDEPENDENT SVARITA
+1CE2..1CE8    ; Deva                           # Mn  [7] VEDIC SIGN VISARGA SVARITA..VEDIC SIGN VISARGA ANUDATTA WITH TAIL
+1CE9          ; Deva Nand                      # Lo      VEDIC SIGN ANUSVARA ANTARGOMUKHA
+1CEA          ; Beng Deva                      # Lo      VEDIC SIGN ANUSVARA BAHIRGOMUKHA
+1CEB..1CEC    ; Deva                           # Lo  [2] VEDIC SIGN ANUSVARA VAMAGOMUKHA..VEDIC SIGN ANUSVARA VAMAGOMUKHA WITH TAIL
+1CED          ; Beng Deva                      # Mn      VEDIC SIGN TIRYAK
+1CEE..1CF1    ; Deva                           # Lo  [4] VEDIC SIGN HEXIFORM LONG ANUSVARA..VEDIC SIGN ANUSVARA UBHAYATO MUKHA
+1CF2          ; Beng Deva Gran Knda Nand Orya Telu Tirh #Lo VEDIC SIGN ARDHAVISARGA
+1CF3          ; Deva Gran                      # Lo      VEDIC SIGN ROTATED ARDHAVISARGA
+1CF4          ; Deva Gran Knda                 # Mn      VEDIC TONE CANDRA ABOVE
+1CF5..1CF6    ; Beng Deva                      # Lo  [2] VEDIC SIGN JIHVAMULIYA..VEDIC SIGN UPADHMANIYA
+1CF7          ; Beng                           # Mc      VEDIC SIGN ATIKRAMA
+1CF8..1CF9    ; Deva Gran                      # Mn  [2] VEDIC TONE RING ABOVE..VEDIC TONE DOUBLE RING ABOVE
+1CFA          ; Nand                           # Lo      VEDIC SIGN DOUBLE ANUSVARA ANTARGOMUKHA
+1DC0..1DC1    ; Grek                           # Mn  [2] COMBINING DOTTED GRAVE ACCENT..COMBINING DOTTED ACUTE ACCENT
+1DF8          ; Cyrl Syrc                      # Mn      COMBINING DOT ABOVE LEFT
+1DFA          ; Syrc                           # Mn      COMBINING DOT BELOW LEFT
+202F          ; Latn Mong                      # Zs      NARROW NO-BREAK SPACE
+20F0          ; Deva Gran Latn                 # Mn      COMBINING ASTERISK ABOVE
+2E43          ; Cyrl Glag                      # Po      DASH WITH LEFT UPTURN
+3001..3002    ; Bopo Hang Hani Hira Kana Yiii  # Po  [2] IDEOGRAPHIC COMMA..IDEOGRAPHIC FULL STOP
+3003          ; Bopo Hang Hani Hira Kana       # Po      DITTO MARK
+3006          ; Hani                           # Lo      IDEOGRAPHIC CLOSING MARK
+3008          ; Bopo Hang Hani Hira Kana Yiii  # Ps      LEFT ANGLE BRACKET
+3009          ; Bopo Hang Hani Hira Kana Yiii  # Pe      RIGHT ANGLE BRACKET
+300A          ; Bopo Hang Hani Hira Kana Yiii  # Ps      LEFT DOUBLE ANGLE BRACKET
+300B          ; Bopo Hang Hani Hira Kana Yiii  # Pe      RIGHT DOUBLE ANGLE BRACKET
+300C          ; Bopo Hang Hani Hira Kana Yiii  # Ps      LEFT CORNER BRACKET
+300D          ; Bopo Hang Hani Hira Kana Yiii  # Pe      RIGHT CORNER BRACKET
+300E          ; Bopo Hang Hani Hira Kana Yiii  # Ps      LEFT WHITE CORNER BRACKET
+300F          ; Bopo Hang Hani Hira Kana Yiii  # Pe      RIGHT WHITE CORNER BRACKET
+3010          ; Bopo Hang Hani Hira Kana Yiii  # Ps      LEFT BLACK LENTICULAR BRACKET
+3011          ; Bopo Hang Hani Hira Kana Yiii  # Pe      RIGHT BLACK LENTICULAR BRACKET
+3013          ; Bopo Hang Hani Hira Kana       # So      GETA MARK
+3014          ; Bopo Hang Hani Hira Kana Yiii  # Ps      LEFT TORTOISE SHELL BRACKET
+3015          ; Bopo Hang Hani Hira Kana Yiii  # Pe      RIGHT TORTOISE SHELL BRACKET
+3016          ; Bopo Hang Hani Hira Kana Yiii  # Ps      LEFT WHITE LENTICULAR BRACKET
+3017          ; Bopo Hang Hani Hira Kana Yiii  # Pe      RIGHT WHITE LENTICULAR BRACKET
+3018          ; Bopo Hang Hani Hira Kana Yiii  # Ps      LEFT WHITE TORTOISE SHELL BRACKET
+3019          ; Bopo Hang Hani Hira Kana Yiii  # Pe      RIGHT WHITE TORTOISE SHELL BRACKET
+301A          ; Bopo Hang Hani Hira Kana Yiii  # Ps      LEFT WHITE SQUARE BRACKET
+301B          ; Bopo Hang Hani Hira Kana Yiii  # Pe      RIGHT WHITE SQUARE BRACKET
+301C          ; Bopo Hang Hani Hira Kana       # Pd      WAVE DASH
+301D          ; Bopo Hang Hani Hira Kana       # Ps      REVERSED DOUBLE PRIME QUOTATION MARK
+301E..301F    ; Bopo Hang Hani Hira Kana       # Pe  [2] DOUBLE PRIME QUOTATION MARK..LOW DOUBLE PRIME QUOTATION MARK
+302A..302D    ; Bopo Hani                      # Mn  [4] IDEOGRAPHIC LEVEL TONE MARK..IDEOGRAPHIC ENTERING TONE MARK
+3030          ; Bopo Hang Hani Hira Kana       # Pd      WAVY DASH
+3031..3035    ; Hira Kana                      # Lm  [5] VERTICAL KANA REPEAT MARK..VERTICAL KANA REPEAT MARK LOWER HALF
+3037          ; Bopo Hang Hani Hira Kana       # So      IDEOGRAPHIC TELEGRAPH LINE FEED SEPARATOR SYMBOL
+303C          ; Hani Hira Kana                 # Lo      MASU MARK
+303D          ; Hani Hira Kana                 # Po      PART ALTERNATION MARK
+303E..303F    ; Hani                           # So  [2] IDEOGRAPHIC VARIATION INDICATOR..IDEOGRAPHIC HALF FILL SPACE
+3099..309A    ; Hira Kana                      # Mn  [2] COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK..COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
+309B..309C    ; Hira Kana                      # Sk  [2] KATAKANA-HIRAGANA VOICED SOUND MARK..KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
+30A0          ; Hira Kana                      # Pd      KATAKANA-HIRAGANA DOUBLE HYPHEN
+30FB          ; Bopo Hang Hani Hira Kana Yiii  # Po      KATAKANA MIDDLE DOT
+30FC          ; Hira Kana                      # Lm      KATAKANA-HIRAGANA PROLONGED SOUND MARK
+3190..3191    ; Hani                           # So  [2] IDEOGRAPHIC ANNOTATION LINKING MARK..IDEOGRAPHIC ANNOTATION REVERSE MARK
+3192..3195    ; Hani                           # No  [4] IDEOGRAPHIC ANNOTATION ONE MARK..IDEOGRAPHIC ANNOTATION FOUR MARK
+3196..319F    ; Hani                           # So [10] IDEOGRAPHIC ANNOTATION TOP MARK..IDEOGRAPHIC ANNOTATION MAN MARK
+31C0..31E3    ; Hani                           # So [36] CJK STROKE T..CJK STROKE Q
+3220..3229    ; Hani                           # No [10] PARENTHESIZED IDEOGRAPH ONE..PARENTHESIZED IDEOGRAPH TEN
+322A..3247    ; Hani                           # So [30] PARENTHESIZED IDEOGRAPH MOON..CIRCLED IDEOGRAPH KOTO
+3280..3289    ; Hani                           # No [10] CIRCLED IDEOGRAPH ONE..CIRCLED IDEOGRAPH TEN
+328A..32B0    ; Hani                           # So [39] CIRCLED IDEOGRAPH MOON..CIRCLED IDEOGRAPH NIGHT
+32C0..32CB    ; Hani                           # So [12] IDEOGRAPHIC TELEGRAPH SYMBOL FOR JANUARY..IDEOGRAPHIC TELEGRAPH SYMBOL FOR DECEMBER
+32FF          ; Hani                           # So      SQUARE ERA NAME REIWA
+3358..3370    ; Hani                           # So [25] IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR ZERO..IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR TWENTY-FOUR
+337B..337F    ; Hani                           # So  [5] SQUARE ERA NAME HEISEI..SQUARE CORPORATION
+33E0..33FE    ; Hani                           # So [31] IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY ONE..IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY THIRTY-ONE
+A66F          ; Cyrl Glag                      # Mn      COMBINING CYRILLIC VZMET
+A700..A707    ; Hani Latn                      # Sk  [8] MODIFIER LETTER CHINESE TONE YIN PING..MODIFIER LETTER CHINESE TONE YANG RU
+A830..A832    ; Deva Dogr Gujr Guru Khoj Knda Kthi Mahj Mlym Modi Nand Sind Takr Tirh #No [3] NORTH INDIC FRACTION ONE QUARTER..NORTH INDIC FRACTION THREE QUARTERS
+A833..A835    ; Deva Dogr Gujr Guru Khoj Knda Kthi Mahj Modi Nand Sind Takr Tirh #No [3] NORTH INDIC FRACTION ONE SIXTEENTH..NORTH INDIC FRACTION THREE SIXTEENTHS
+A836..A837    ; Deva Dogr Gujr Guru Khoj Kthi Mahj Modi Sind Takr Tirh #So [2] NORTH INDIC QUARTER MARK..NORTH INDIC PLACEHOLDER MARK
+A838          ; Deva Dogr Gujr Guru Khoj Kthi Mahj Modi Sind Takr Tirh #Sc NORTH INDIC RUPEE MARK
+A839          ; Deva Dogr Gujr Guru Khoj Kthi Mahj Modi Sind Takr Tirh #So NORTH INDIC QUANTITY MARK
+A8F1          ; Beng Deva                      # Mn      COMBINING DEVANAGARI SIGN AVAGRAHA
+A8F3          ; Deva Taml                      # Lo      DEVANAGARI SIGN CANDRABINDU VIRAMA
+A92E          ; Kali Latn Mymr                 # Po      KAYAH LI SIGN CWI
+A9CF          ; Bugi Java                      # Lm      JAVANESE PANGRANGKEP
+FD3E          ; Arab Nkoo                      # Pe      ORNATE LEFT PARENTHESIS
+FD3F          ; Arab Nkoo                      # Ps      ORNATE RIGHT PARENTHESIS
+FDF2          ; Arab Thaa                      # Lo      ARABIC LIGATURE ALLAH ISOLATED FORM
+FDFD          ; Arab Thaa                      # So      ARABIC LIGATURE BISMILLAH AR-RAHMAN AR-RAHEEM
+FE45..FE46    ; Bopo Hang Hani Hira Kana       # Po  [2] SESAME DOT..WHITE SESAME DOT
+FF61          ; Bopo Hang Hani Hira Kana Yiii  # Po      HALFWIDTH IDEOGRAPHIC FULL STOP
+FF62          ; Bopo Hang Hani Hira Kana Yiii  # Ps      HALFWIDTH LEFT CORNER BRACKET
+FF63          ; Bopo Hang Hani Hira Kana Yiii  # Pe      HALFWIDTH RIGHT CORNER BRACKET
+FF64..FF65    ; Bopo Hang Hani Hira Kana Yiii  # Po  [2] HALFWIDTH IDEOGRAPHIC COMMA..HALFWIDTH KATAKANA MIDDLE DOT
+FF70          ; Hira Kana                      # Lm      HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK
+FF9E..FF9F    ; Hira Kana                      # Lm  [2] HALFWIDTH KATAKANA VOICED SOUND MARK..HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK
+10100..10101  ; Cpmn Cprt Linb                 # Po  [2] AEGEAN WORD SEPARATOR LINE..AEGEAN WORD SEPARATOR DOT
+10102         ; Cprt Linb                      # Po      AEGEAN CHECK MARK
+10107..10133  ; Cprt Lina Linb                 # No [45] AEGEAN NUMBER ONE..AEGEAN NUMBER NINETY THOUSAND
+10137..1013F  ; Cprt Linb                      # So  [9] AEGEAN WEIGHT BASE UNIT..AEGEAN MEASURE THIRD SUBUNIT
+102E0         ; Arab Copt                      # Mn      COPTIC EPACT THOUSANDS MARK
+102E1..102FB  ; Arab Copt                      # No [27] COPTIC EPACT DIGIT ONE..COPTIC EPACT NUMBER NINE HUNDRED
+10AF2         ; Mani Ougr                      # Po      MANICHAEAN PUNCTUATION DOUBLE DOT WITHIN DOT
+11301         ; Gran Taml                      # Mn      GRANTHA SIGN CANDRABINDU
+11303         ; Gran Taml                      # Mc      GRANTHA SIGN VISARGA
+1133B..1133C  ; Gran Taml                      # Mn  [2] COMBINING BINDU BELOW..GRANTHA SIGN NUKTA
+11FD0..11FD1  ; Gran Taml                      # No  [2] TAMIL FRACTION ONE QUARTER..TAMIL FRACTION ONE HALF-1
+11FD3         ; Gran Taml                      # No      TAMIL FRACTION THREE QUARTERS
+1BCA0..1BCA3  ; Dupl                           # Cf  [4] SHORTHAND FORMAT LETTER OVERLAP..SHORTHAND FORMAT UP STEP
+1D360..1D371  ; Hani                           # No [18] COUNTING ROD UNIT DIGIT ONE..COUNTING ROD TENS DIGIT NINE
+1F250..1F251  ; Hani                           # So  [2] CIRCLED IDEOGRAPH ADVANTAGE..CIRCLED IDEOGRAPH ACCEPT
 
 # EOF

--- a/unicodetools/data/ucd/dev/ScriptExtensions.txt
+++ b/unicodetools/data/ucd/dev/ScriptExtensions.txt
@@ -1,5 +1,5 @@
 # ScriptExtensions-16.0.0.txt
-# Date: 2024-02-29, 13:02:29 GMT
+# Date: 2024-02-29, 13:02:44 GMT
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -50,8 +50,8 @@
 06D4          ; Arab Rohg                      # Po      ARABIC FULL STOP
 0951          ; Beng Deva Gran Gujr Guru Knda Latn Mlym Orya Shrd Taml Telu Tirh #Mn DEVANAGARI STRESS SIGN UDATTA
 0952          ; Beng Deva Gran Gujr Guru Knda Latn Mlym Orya Taml Telu Tirh #Mn DEVANAGARI STRESS SIGN ANUDATTA
-0964          ; Beng Deva Dogr Gong Gonm Gran Gujr Guru Knda Mahj Mlym Nand Orya Sind Sinh Sylo Takr Taml Telu Tirh #Po DEVANAGARI DANDA
-0965          ; Beng Deva Dogr Gong Gonm Gran Gujr Guru Knda Limb Mahj Mlym Nand Orya Sind Sinh Sylo Takr Taml Telu Tirh #Po DEVANAGARI DOUBLE DANDA
+0964          ; Beng Deva Dogr Gong Gonm Gran Gujr Guru Knda Mahj Mlym Nand Onao Orya Sind Sinh Sylo Takr Taml Telu Tirh #Po DEVANAGARI DANDA
+0965          ; Beng Deva Dogr Gong Gonm Gran Gujr Guru Knda Limb Mahj Mlym Nand Onao Orya Sind Sinh Sylo Takr Taml Telu Tirh #Po DEVANAGARI DOUBLE DANDA
 0966..096F    ; Deva Dogr Kthi Mahj            # Nd [10] DEVANAGARI DIGIT ZERO..DEVANAGARI DIGIT NINE
 09E6..09EF    ; Beng Cakm Sylo                 # Nd [10] BENGALI DIGIT ZERO..BENGALI DIGIT NINE
 0A66..0A6F    ; Guru Mult                      # Nd [10] GURMUKHI DIGIT ZERO..GURMUKHI DIGIT NINE

--- a/unicodetools/data/ucd/dev/ScriptExtensions.txt
+++ b/unicodetools/data/ucd/dev/ScriptExtensions.txt
@@ -1,5 +1,5 @@
 # ScriptExtensions-16.0.0.txt
-# Date: 2024-02-29, 13:02:14 GMT
+# Date: 2024-02-29, 13:02:29 GMT
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -39,10 +39,10 @@
 0484          ; Cyrl Glag                      # Mn      COMBINING CYRILLIC PALATALIZATION
 0485..0486    ; Cyrl Latn                      # Mn  [2] COMBINING CYRILLIC DASIA PNEUMATA..COMBINING CYRILLIC PSILI PNEUMATA
 0487          ; Cyrl Glag                      # Mn      COMBINING CYRILLIC POKRYTIE
-060C          ; Arab Nkoo Rohg Syrc Thaa Yezi  # Po      ARABIC COMMA
-061B          ; Arab Nkoo Rohg Syrc Thaa Yezi  # Po      ARABIC SEMICOLON
+060C          ; Arab Gara Nkoo Rohg Syrc Thaa Yezi #Po   ARABIC COMMA
+061B          ; Arab Gara Nkoo Rohg Syrc Thaa Yezi #Po   ARABIC SEMICOLON
 061C          ; Arab Syrc Thaa                 # Cf      ARABIC LETTER MARK
-061F          ; Adlm Arab Nkoo Rohg Syrc Thaa Yezi #Po   ARABIC QUESTION MARK
+061F          ; Adlm Arab Gara Nkoo Rohg Syrc Thaa Yezi #Po ARABIC QUESTION MARK
 0640          ; Adlm Arab Mand Mani Ougr Phlp Rohg Sogd Syrc #Lm ARABIC TATWEEL
 064B..0655    ; Arab Syrc                      # Mn [11] ARABIC FATHATAN..ARABIC HAMZA BELOW
 0660..0669    ; Arab Thaa Yezi                 # Nd [10] ARABIC-INDIC DIGIT ZERO..ARABIC-INDIC DIGIT NINE

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -426,14 +426,16 @@ public abstract class UnicodeProperty extends UnicodeLabel {
      * the original contents.
      */
     public final UnicodeSet getSet(String propertyValue, UnicodeSet result) {
-        if (isMultivalued && propertyValue.contains(delimiter)) {
+        if (isMultivalued && propertyValue != null && propertyValue.contains(delimiter)) {
             throw new IllegalArgumentException(
                     "Multivalued property values can't contain the delimiter.");
         } else {
             return getSet(
-                    new SimpleMatcher(
-                            propertyValue,
-                            isType(STRING_OR_MISC_MASK) ? null : PROPERTY_COMPARATOR),
+                    propertyValue == null
+                            ? NULL_MATCHER
+                            : new SimpleMatcher(
+                                    propertyValue,
+                                    isType(STRING_OR_MISC_MASK) ? null : PROPERTY_COMPARATOR),
                     result);
         }
     }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
@@ -1677,7 +1677,7 @@ public class MakeUnicodeFiles {
                 prop.getName(),
                 prop,
                 /*showPropName=*/ false,
-                prop.getFirstValueAlias(ps.skipValue));
+                ps.skipValue == null ? null : prop.getFirstValueAlias(ps.skipValue));
         var source = ToolUnicodePropertySource.make(Default.ucdVersion());
         UnicodeProperty generalCategory = source.getProperty("General_Category");
         UnicodeProperty block = source.getProperty("Block");
@@ -1694,13 +1694,17 @@ public class MakeUnicodeFiles {
                         block, new UnicodeProperty.MapFilter(ignoreBlocksInCJKVPlanes));
         UnicodeSet omitted =
                 generalCategory.getSet("Unassigned").retainAll(prop.getSet(ps.skipValue));
+        if (prop.getName().equals("Script_Extensions")) {
+            bf.setValueWidthOverride(30).setCountWidth(4);
+        } else {
+            bf.setMinSpacesBeforeSemicolon(1)
+                    .setValueWidthOverride(3)
+                    .setMinSpacesBeforeComment(0)
+                    .setCountWidth(7);
+        }
         bf.setValueSource(prop)
                 .setRangeBreakSource(blockOrIdeographicPlane)
-                .setMinSpacesBeforeSemicolon(1)
-                .setValueWidthOverride(3)
-                .setMinSpacesBeforeComment(0)
                 .setRefinedLabelSource(generalCategory)
-                .setCountWidth(7)
                 .setMergeRanges(ps.mergeRanges)
                 .setShowTotal(false)
                 .showSetNames(pw, new UnicodeSet(0, 0x10FFFF).removeAll(omitted));

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/MakeUnicodeFiles.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/MakeUnicodeFiles.txt
@@ -71,10 +71,9 @@ File: ScriptExtensions
 # All code points not explicitly listed for Script_Extensions
 # have as their value the corresponding Script property value
 #
-# @missing: 0000..10FFFF; <script>
 
 Property: Script_Extensions
-Format: valueStyle=short
+Format: kenFile valueStyle=short
 
 File: auxiliary/GraphemeBreakProperty
 Property: Grapheme_Cluster_Break


### PR DESCRIPTION
The diff of ScriptExtensions.txt between main and this new format is obviously useless; however, I have reenacted the history of ScriptExtensions.txt since Unicode 15.0 in the commits of this pull request, so that we can see what diffs would look like in this format.

Compare:
| Old format diff | New format diff |
|---|---|
| 4bfab4a7 | d22e65b4cb836171308387b46bfcc4f0315aeb29 |
| [cab2fa7f](https://github.com/unicode-org/unicodetools/commit/cab2fa7f3329bb79f2ca1e0fee352d8d843cb169#diff-be644dcdee5300b7b7989cb4fdcc3dfe9b2d31451896ea5ca2816b11a5156113) | 4837b38ff730b901ee9fe189fbacd6374fda027d |
| [dac024cc](https://github.com/unicode-org/unicodetools/commit/dac024cc41488b38ff3a59a023bb318a68e2a370#diff-be644dcdee5300b7b7989cb4fdcc3dfe9b2d31451896ea5ca2816b11a5156113) | e4c4db08bc6a8c638bcb090eba004319668b11ba |
| [48ff7889](https://github.com/unicode-org/unicodetools/commit/48ff7889f87c659ada9a259358af5d8c34c1b823#diff-be644dcdee5300b7b7989cb4fdcc3dfe9b2d31451896ea5ca2816b11a5156113) | 7b2c5b4e1a4ee3a785565f5614cbdfb5393d9b3a |
| dc93882a | dba754607779fecd9ba009c960f16921e1378b8e |
| a0f44094 | 6b275eeb69dc97a1849b9c1a04ea1be903c3020e |