### PR TITLE
feat: AacOrder should have a header with version numbers

### DIFF
--- a/unicodetools/src/main/java/org/unicode/tools/AacOrder.java
+++ b/unicodetools/src/main/java/org/unicode/tools/AacOrder.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Set;
 import org.unicode.cldr.draft.FileUtilities;
+import org.unicode.cldr.util.CLDRFile;
 import org.unicode.props.IndexUnicodeProperties;
 import org.unicode.props.PropertyValueSets;
 import org.unicode.props.UcdProperty;
@@ -116,6 +117,12 @@ public class AacOrder {
                             + "\n# Compute the index while reading the file:"
                             + "\n#  For each single codepoint or string, add one; "
                             + "\n#  For each range, add the number of items in the range");
+            outEach.println("# -----");
+            outEach.println("# CLDR GEN_VERSION: " + CLDRFile.GEN_VERSION);
+            outEach.println("# ICU: " + VersionInfo.ICU_VERSION + " getUnicodeVersion(): " + UCharacter.getUnicodeVersion());
+            outEach.println("# UnicodeTools Settings.latestVersion: " + Settings.latestVersion);
+            outEach.println("# AacOrder.VERSION: " + VERSION);
+            outEach.println("# AacOrder.UCD_VERSION: " + UCD_VERSION);
             Range range = new Range(outRanges, true);
             Range rangeNone = new Range(outEach, false);
             for (String s : SORTED_ALL_CHARS_SET) {

--- a/unicodetools/src/main/java/org/unicode/tools/AacOrder.java
+++ b/unicodetools/src/main/java/org/unicode/tools/AacOrder.java
@@ -31,7 +31,7 @@ import org.unicode.tools.emoji.EmojiOrder;
 public class AacOrder {
 
     private static final VersionInfo VERSION = Emoji.VERSION15_1;
-    private static final VersionInfo UCD_VERSION = Emoji.VERSION15;
+    private static final VersionInfo UCD_VERSION = Emoji.VERSION15_1;
 
     private static final CandidateData CANDIDATE_DATA = CandidateData.getInstance();
 
@@ -119,7 +119,11 @@ public class AacOrder {
                             + "\n#  For each range, add the number of items in the range");
             outEach.println("# -----");
             outEach.println("# CLDR GEN_VERSION: " + CLDRFile.GEN_VERSION);
-            outEach.println("# ICU: " + VersionInfo.ICU_VERSION + " getUnicodeVersion(): " + UCharacter.getUnicodeVersion());
+            outEach.println(
+                    "# ICU: "
+                            + VersionInfo.ICU_VERSION
+                            + " getUnicodeVersion(): "
+                            + UCharacter.getUnicodeVersion());
             outEach.println("# UnicodeTools Settings.latestVersion: " + Settings.latestVersion);
             outEach.println("# AacOrder.VERSION: " + VERSION);
             outEach.println("# AacOrder.UCD_VERSION: " + UCD_VERSION);


### PR DESCRIPTION
AacOrder didn't give details about where its data came from.

Example output with this PR:

```
# -----
# CLDR GEN_VERSION: 44.1
# ICU: 72.0.1.0 getUnicodeVersion(): 15.0.0.0
# UnicodeTools Settings.latestVersion: 16.0.0
# AacOrder.VERSION: 15.1.0.0
# AacOrder.UCD_VERSION: 15.1.0.0
```

- Also, update the UCD version number to 15.1