### PR TITLE
Add Knda to scx for U+1CD3

### DIFF
--- a/unicodetools/data/ucd/dev/ScriptExtensions.txt
+++ b/unicodetools/data/ucd/dev/ScriptExtensions.txt
@@ -104,7 +104,7 @@
 1CD0          ; Beng Deva Gran Knda            # Mn      VEDIC TONE KARSHANA
 1CD1          ; Deva                           # Mn      VEDIC TONE SHARA
 1CD2          ; Beng Deva Gran Knda            # Mn      VEDIC TONE PRENKHA
-1CD3          ; Deva Gran                      # Po      VEDIC SIGN NIHSHVASA
+1CD3          ; Deva Gran Knda                 # Po      VEDIC SIGN NIHSHVASA
 1CD4          ; Deva                           # Mn      VEDIC SIGN YAJURVEDIC MIDLINE SVARITA
 1CD5..1CD6    ; Beng Deva                      # Mn  [2] VEDIC TONE YAJURVEDIC AGGRAVATED INDEPENDENT SVARITA..VEDIC TONE YAJURVEDIC INDEPENDENT SVARITA
 1CD7          ; Deva Shrd                      # Mn      VEDIC TONE YAJURVEDIC KATHAKA INDEPENDENT SVARITA

--- a/unicodetools/data/ucd/dev/ScriptExtensions.txt
+++ b/unicodetools/data/ucd/dev/ScriptExtensions.txt
@@ -1,5 +1,5 @@
 # ScriptExtensions-16.0.0.txt
-# Date: 2024-02-29, 13:03:45 GMT
+# Date: 2024-03-13, 01:45:00 GMT
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html


### PR DESCRIPTION
[178-C29] Consensus: Add Kannada to the ScriptExtensions.txt entry for U+1CD3 VEDIC SIGN NIHSHVASA for Unicode Version 16.0 as described in L2/24-024. [Ref. Section 7 of document L2/24-013R]

[178-A80] Action Item for Roozbeh Pournader, PAG: Add the value Knda (Kannada) in ScriptExtensions.txt for U+1CD3 VEDIC SIGN NIHSHVASA for Unicode Version 16.0, based on document L2/24-024. [Ref. Section 7 of L2/24-013R]