### PR TITLE
Are abbreviation marks terminal punctuation? (No.)

### DIFF
--- a/unicodetools/data/ucd/dev/PropList.txt
+++ b/unicodetools/data/ucd/dev/PropList.txt
@@ -133,7 +133,8 @@ FF63          ; Quotation_Mark # Pe       HALFWIDTH RIGHT CORNER BRACKET
 0700..070A    ; Terminal_Punctuation # Po  [11] SYRIAC END OF PARAGRAPH..SYRIAC CONTRACTION
 070C          ; Terminal_Punctuation # Po       SYRIAC HARKLEAN METOBELUS
 07F8..07F9    ; Terminal_Punctuation # Po   [2] NKO COMMA..NKO EXCLAMATION MARK
-0830..083E    ; Terminal_Punctuation # Po  [15] SAMARITAN PUNCTUATION NEQUDAA..SAMARITAN PUNCTUATION ANNAAU
+0830..0835    ; Terminal_Punctuation
+0837..083E    ; Terminal_Punctuation
 085E          ; Terminal_Punctuation # Po       MANDAIC PUNCTUATION
 0964..0965    ; Terminal_Punctuation # Po   [2] DEVANAGARI DANDA..DEVANAGARI DOUBLE DANDA
 0E5A..0E5B    ; Terminal_Punctuation # Po   [2] THAI CHARACTER ANGKHANKHU..THAI CHARACTER KHOMUT

--- a/unicodetools/data/ucd/dev/PropList.txt
+++ b/unicodetools/data/ucd/dev/PropList.txt
@@ -1,5 +1,5 @@
 # PropList-16.0.0.txt
-# Date: 2024-03-12, 13:28:44 GMT
+# Date: 2024-04-30, 19:07:23 GMT
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use, see https://www.unicode.org/terms_of_use.html
@@ -133,8 +133,8 @@ FF63          ; Quotation_Mark # Pe       HALFWIDTH RIGHT CORNER BRACKET
 0700..070A    ; Terminal_Punctuation # Po  [11] SYRIAC END OF PARAGRAPH..SYRIAC CONTRACTION
 070C          ; Terminal_Punctuation # Po       SYRIAC HARKLEAN METOBELUS
 07F8..07F9    ; Terminal_Punctuation # Po   [2] NKO COMMA..NKO EXCLAMATION MARK
-0830..0835    ; Terminal_Punctuation
-0837..083E    ; Terminal_Punctuation
+0830..0835    ; Terminal_Punctuation # Po   [6] SAMARITAN PUNCTUATION NEQUDAA..SAMARITAN PUNCTUATION SHIYYAALAA
+0837..083E    ; Terminal_Punctuation # Po   [8] SAMARITAN PUNCTUATION MELODIC QITSA..SAMARITAN PUNCTUATION ANNAAU
 085E          ; Terminal_Punctuation # Po       MANDAIC PUNCTUATION
 0964..0965    ; Terminal_Punctuation # Po   [2] DEVANAGARI DANDA..DEVANAGARI DOUBLE DANDA
 0E5A..0E5B    ; Terminal_Punctuation # Po   [2] THAI CHARACTER ANGKHANKHU..THAI CHARACTER KHOMUT
@@ -227,7 +227,7 @@ FF64          ; Terminal_Punctuation # Po       HALFWIDTH IDEOGRAPHIC COMMA
 1BC9F         ; Terminal_Punctuation # Po       DUPLOYAN PUNCTUATION CHINOOK FULL STOP
 1DA87..1DA8A  ; Terminal_Punctuation # Po   [4] SIGNWRITING COMMA..SIGNWRITING COLON
 
-# Total code points: 278
+# Total code points: 277
 
 # ================================================
 


### PR DESCRIPTION
[[179-C21](https://www.unicode.org/cgi-bin/GetL2Ref.pl?179-C21)] Consensus: Remove the Terminal_Punctuation property from U+0836 SAMARITAN ABBREVIATION MARK. For Unicode Version 16.0. See document [L2/24-064](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/24-064) item 2.1.

[[179-A89](https://www.unicode.org/cgi-bin/GetL2Ref.pl?179-A89)] Action Item for Robin Leroy, PAG: In PropList.txt, remove the Terminal_Punctuation property from U+0836 SAMARITAN ABBREVIATION MARK. For Unicode Version 16.0. See document [L2/24-064](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/24-064) item 2.1.