### PR TITLE
Kenfiles, frisch vom Faß

### DIFF
--- a/unicodetools/data/ucd/dev/NamesList.txt
+++ b/unicodetools/data/ucd/dev/NamesList.txt
@@ -1,7 +1,7 @@
 ; charset=UTF-8
 @@@	The Unicode Standard 16.0.0
 @@@+	NamesList-16.0.0.txt
-@+	Generation Date: 2024-04-28, 13:44:21 GMT
+@+	Generation Date: 2024-04-30, 11:19:40 GMT
 	Unicode 16.0.0 names list.
 	Repertoire synched with UnicodeData-16.0.0d16.txt.
 	Pre-beta rollup of various fixes.
@@ -14,6 +14,9 @@
 	Added alias and annotation for 12326.
 	Added xrefs between 050F and 1C8A.
 	Added an annotation about Amerindian orthographic use for 00B7.
+	Add notices about use of colon in Egyptian hieroglyph annotations.
+	Add annotation for 0B35; update annotation for 0B55.
+	Add annotation for 1DF8.
 	This file is semi-automatically derived from UnicodeData.txt and
 	a set of manually created annotations using a script to select
 	or suppress information from the data file. The rules used
@@ -5949,6 +5952,7 @@
 0B32	ORIYA LETTER LA
 0B33	ORIYA LETTER LLA
 0B35	ORIYA LETTER VA
+	* Kui uses an alternate glyph with the dot above the small circle
 	x (oriya letter ba - 0B2C)
 0B36	ORIYA LETTER SHA
 0B37	ORIYA LETTER SSA
@@ -5981,7 +5985,7 @@
 0B4D	ORIYA SIGN VIRAMA
 @		Various signs
 0B55	ORIYA SIGN OVERLINE
-	* Kuvi
+	* Kuvi, Kui
 0B56	ORIYA AI LENGTH MARK
 0B57	ORIYA AU LENGTH MARK
 @		Additional consonants
@@ -11936,6 +11940,7 @@
 1DF8	COMBINING DOT ABOVE LEFT
 	* used in Syriac as a disambiguation dot
 	* used in Typicon Cyrillic, where the dot may have a square appearance
+	* used in the Latin-based Americanist phonetic notation of Franz Boas
 	x (combining dot above right - 0358)
 	x (syriac feminine dot - 0740)
 1DF9	COMBINING WIDE INVERTED BRIDGE BELOW
@@ -38054,7 +38059,7 @@ FFFF	<not a character>
 12FF1	CYPRO-MINOAN SIGN CM301
 12FF2	CYPRO-MINOAN SIGN CM302
 @@	13000	Egyptian Hieroglyphs	1342F
-@+		The characters in this block are taken primarily from Alan Gardiner's works on Middle Egyptian.
+@+		The characters in this block are taken primarily from Alan Gardiner's works on Middle Egyptian. Annotations use a colon, preceded and followed by a space, as a delimiter between fields defining functions and phonetic values.
 @		A. Man and his occupations
 13000	EGYPTIAN HIEROGLYPH A001
 	* classifier human being
@@ -40523,6 +40528,7 @@ FFFF	<not a character>
 13455	EGYPTIAN HIEROGLYPH MODIFIER DAMAGED
 @~	!
 @@	13460	Egyptian Hieroglyphs Extended-A	143FF
+@+		Annotations use a colon, preceded and followed by a space, as a delimiter between fields defining functions and phonetic values.
 @		A01. Man seated or kneeling empty handed
 13460	EGYPTIAN HIEROGLYPH-13460
 	* classifier human being


### PR DESCRIPTION
From @Ken-Whistler:
> This took care of 3 more stray action items noted in the minutes, to add
annotations for 0B35, 0B55, and 1DF8 and to explain the use of colon in
the Egyptian function : value annotations.

To wit:

[[179-A87](https://www.unicode.org/cgi-bin/GetL2Ref.pl?179-A87)] Action Item for Ken Whistler, EDC: Fix the punctuation in NamesList.txt to a single space before the colon, and add an explanatory note to NamesList.txt . See ReportID ID20240402044338 in document [L2/24-065](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/24-065) item E2.

[[179-A156](https://www.unicode.org/cgi-bin/GetL2Ref.pl?179-A156)] Action Item for Ken Whistler, EDC: Add annotations to U+0B35 ORIYA LETTER VA, U+0B55 ORIYA SIGN OVERLINE as described in document [L2/24-106](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/24-106). [Ref. Section 8 of document [L2/24-068](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/24-068)]

[[179-A164](https://www.unicode.org/cgi-bin/GetL2Ref.pl?179-A164)] Action Item for Ken Whistler, EDC: Consider adding an annotation for U+1DF8 describing usage in Latin script, as described in document [L2/24-091](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/24-091).