### PR TITLE
short: ID_Status & ID_Type

### DIFF
--- a/unicodetools/data/security/dev/IdentifierStatus.txt
+++ b/unicodetools/data/security/dev/IdentifierStatus.txt
@@ -1,5 +1,5 @@
 # IdentifierStatus.txt
-# Date: 2024-05-03, 03:51:21 GMT
+# Date: 2024-05-04, 21:31:06 GMT
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -16,7 +16,7 @@
 #
 # For the purpose of regular expressions, the property Identifier_Status is defined as
 # an enumerated property of code points.
-# The short name of Identifier_Status is the same as the long name.
+# The short name of Identifier_Status is ID_Status.
 # The possible values are:
 #   Allowed, Restricted
 # The short name of each value is the same as its long name.

--- a/unicodetools/data/security/dev/IdentifierType.txt
+++ b/unicodetools/data/security/dev/IdentifierType.txt
@@ -1,5 +1,5 @@
 # IdentifierType.txt
-# Date: 2024-05-03, 03:51:21 GMT
+# Date: 2024-05-04, 21:31:06 GMT
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -16,7 +16,7 @@
 #
 # For the purpose of regular expressions, the property Identifier_Type is defined as
 # mapping each code point to a set of enumerated values.
-# The short name of Identifier_Type is the same as the long name.
+# The short name of Identifier_Type is ID_Type.
 # The possible values are:
 #   Not_Character, Deprecated, Default_Ignorable, Not_NFKC, Not_XID,
 #   Exclusion, Obsolete, Technical, Uncommon_Use, Limited_Use, Inclusion, Recommended

--- a/unicodetools/data/security/dev/data/confusablesSummaryIdentifier.txt
+++ b/unicodetools/data/security/dev/data/confusablesSummaryIdentifier.txt
@@ -1,5 +1,5 @@
 # confusablesSummaryIdentifier.txt
-# Date: 2024-05-03, 03:26:41 GMT
+# Date: 2024-05-04, 21:31:06 GMT
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -60,7 +60,7 @@
 ←	(‎ Θ ‎)	0398	 GREEK CAPITAL LETTER THETA	# →Ѳ→→О̵→
 ←	(‎ Ө ‎)	04E8	 CYRILLIC CAPITAL LETTER BARRED O	# →Ѳ→→О̵→
 
-#	l	I	1	|	ו	ן	ا	١	۱	Ι	І
+#	l	I	1	|	ו	ן	ا	١	۱	Ι	І	Ӏ
 	(‎ 1 ‎)	0031	 DIGIT ONE
 ←	(‎ l ‎)	006C	 LATIN SMALL LETTER L
 ←	(‎ I ‎)	0049	 LATIN CAPITAL LETTER I
@@ -72,6 +72,7 @@
 ←	(‎ ۱ ‎)	06F1	 EXTENDED ARABIC-INDIC DIGIT ONE
 ←	(‎ Ι ‎)	0399	 GREEK CAPITAL LETTER IOTA	# →I→
 ←	(‎ І ‎)	0406	 CYRILLIC CAPITAL LETTER BYELORUSSIAN-UKRAINIAN I	# →I→
+←	(‎ Ӏ ‎)	04C0	 CYRILLIC LETTER PALOCHKA	# →I→
 
 #	l'	1'	וי	ױ
 	(‎ 1' ‎)	0031 0027	 DIGIT ONE, APOSTROPHE
@@ -1838,5 +1839,5 @@
 	(‎ 鹂 ‎)	9E42	 CJK UNIFIED IDEOGRAPH-9E42
 ←	(‎ 鹃 ‎)	9E43	 CJK UNIFIED IDEOGRAPH-9E43
 
-# total : 634
+# total : 635
 

--- a/unicodetools/data/security/dev/data/draft-restrictions.txt
+++ b/unicodetools/data/security/dev/data/draft-restrictions.txt
@@ -22438,14 +22438,14 @@ ABF9          ;  ; Limited_Use #      (꯹)  MEETEI MAYEK DIGIT NINE
 0DED          ;  ; Obsolete #      (෭)  SINHALA LITH DIGIT SEVEN
 0DEE          ;  ; Obsolete #      (෮)  SINHALA LITH DIGIT EIGHT
 0DEF          ;  ; Obsolete #      (෯)  SINHALA LITH DIGIT NINE
+10A0..10C5    ;  ; Obsolete # [38] (Ⴀ..Ⴥ)  GEORGIAN CAPITAL LETTER AN..GEORGIAN CAPITAL LETTER HOE
 10F1          ;  ; Obsolete #      (ჱ)  GEORGIAN LETTER HE
 10F2          ;  ; Obsolete #      (ჲ)  GEORGIAN LETTER HIE
 10F3          ;  ; Obsolete #      (ჳ)  GEORGIAN LETTER WE
 10F4          ;  ; Obsolete #      (ჴ)  GEORGIAN LETTER HAR
 10F5          ;  ; Obsolete #      (ჵ)  GEORGIAN LETTER HOE
 10F6          ;  ; Obsolete #      (ჶ)  GEORGIAN LETTER FI
-1100..115E    ;  ; Obsolete # [95] (ᄀ..ᅞ)  HANGUL CHOSEONG KIYEOK..HANGUL CHOSEONG TIKEUT-RIEUL
-1161..11FF    ;  ; Obsolete # [159] (ᅡ..ᇿ)  HANGUL JUNGSEONG A..HANGUL JONGSEONG SSANGNIEUN
+1100..11FF    ;  ; Obsolete # [256] (ᄀ..ᇿ)  HANGUL CHOSEONG KIYEOK..HANGUL JONGSEONG SSANGNIEUN
 1369..1371    ;  ; Obsolete #  [9] (፩..፱)  ETHIOPIC DIGIT ONE..ETHIOPIC DIGIT NINE
 1681..169A    ;  ; Obsolete # [26] (ᚁ..ᚚ)  OGHAM LETTER BEITH..OGHAM LETTER PEITH
 16A0..16EA    ;  ; Obsolete # [75] (ᚠ..ᛪ)  RUNIC LETTER FEHU FEOH FE F..RUNIC LETTER X
@@ -22537,10 +22537,12 @@ ABF9          ;  ; Limited_Use #      (꯹)  MEETEI MAYEK DIGIT NINE
 1DE4          ;  ; Obsolete #      (ᷤ)  COMBINING LATIN SMALL LETTER S
 1DE5          ;  ; Obsolete #      (ᷥ)  COMBINING LATIN SMALL LETTER LONG S
 1DE6          ;  ; Obsolete #      (ᷦ)  COMBINING LATIN SMALL LETTER Z
+2132          ;  ; Obsolete #      (Ⅎ)  TURNED CAPITAL F
 214E          ;  ; Obsolete #      (ⅎ)  TURNED SMALL F
 2180          ;  ; Obsolete #      (ↀ)  ROMAN NUMERAL ONE THOUSAND C D
 2181          ;  ; Obsolete #      (ↁ)  ROMAN NUMERAL FIVE THOUSAND
 2182          ;  ; Obsolete #      (ↂ)  ROMAN NUMERAL TEN THOUSAND
+2183          ;  ; Obsolete #      (Ↄ)  ROMAN NUMERAL REVERSED ONE HUNDRED
 2184          ;  ; Obsolete #      (ↄ)  LATIN SMALL LETTER REVERSED C
 2185          ;  ; Obsolete #      (ↅ)  ROMAN NUMERAL SIX LATE FORM
 2186          ;  ; Obsolete #      (ↆ)  ROMAN NUMERAL FIFTY EARLY FORM
@@ -23348,7 +23350,7 @@ D7FB          ;  ; Obsolete #      (ퟻ)  HANGUL JONGSEONG PHIEUPH-THIEUTH
 1D243         ;  ; Obsolete #      (𝉃)  COMBINING GREEK MUSICAL TETRASEME
 1D244         ;  ; Obsolete #      (𝉄)  COMBINING GREEK MUSICAL PENTASEME
 
-# Total code points: 1667
+# Total code points: 1709
 
 0180          ;  ; Technical #      (ƀ)  LATIN SMALL LETTER B WITH STROKE
 01C0          ;  ; Technical #      (ǀ)  LATIN LETTER DENTAL CLICK
@@ -24652,7 +24654,7 @@ AB63          ;  ; Uncommon_Use #      (ꭣ)  LATIN SMALL LETTER UO
 04BD          ; Allowed ; Recommended #      (ҽ)  CYRILLIC SMALL LETTER ABKHASIAN CHE
 04BE          ; Allowed ; Recommended #      (Ҿ)  CYRILLIC CAPITAL LETTER ABKHASIAN CHE WITH DESCENDER
 04BF          ; Allowed ; Recommended #      (ҿ)  CYRILLIC SMALL LETTER ABKHASIAN CHE WITH DESCENDER
-04C1          ; Allowed ; Recommended #      (Ӂ)  CYRILLIC CAPITAL LETTER ZHE WITH BREVE
+04C0..04C1    ; Allowed ; Recommended #  [2] (Ӏ..Ӂ)  CYRILLIC LETTER PALOCHKA..CYRILLIC CAPITAL LETTER ZHE WITH BREVE
 04C2          ; Allowed ; Recommended #      (ӂ)  CYRILLIC SMALL LETTER ZHE WITH BREVE
 04C3          ; Allowed ; Recommended #      (Ӄ)  CYRILLIC CAPITAL LETTER KA WITH HOOK
 04C4          ; Allowed ; Recommended #      (ӄ)  CYRILLIC SMALL LETTER KA WITH HOOK
@@ -26517,6 +26519,7 @@ AB63          ;  ; Uncommon_Use #      (ꭣ)  LATIN SMALL LETTER UO
 17B1          ; Allowed ; Recommended #      (ឱ)  KHMER INDEPENDENT VOWEL QOO TYPE ONE
 17B2          ; Allowed ; Recommended #      (ឲ)  KHMER INDEPENDENT VOWEL QOO TYPE TWO
 17B3          ; Allowed ; Recommended #      (ឳ)  KHMER INDEPENDENT VOWEL QAU
+17B4..17B5    ; Allowed ; Recommended #  [2] (U+17B4..U+17B5)  KHMER VOWEL INHERENT AQ..KHMER VOWEL INHERENT AA
 17B6          ; Allowed ; Recommended #      (ា)  KHMER VOWEL SIGN AA
 17B7          ; Allowed ; Recommended #      (ិ)  KHMER VOWEL SIGN I
 17B8          ; Allowed ; Recommended #      (ី)  KHMER VOWEL SIGN II
@@ -54814,17 +54817,11 @@ FA29          ; Allowed ; Recommended #      (﨩)  CJK COMPATIBILITY IDEOGRAPH-
 323AF         ; Allowed ; Recommended #      (𲎯)  CJK UNIFIED IDEOGRAPH-323AF
 E0100..E01EF  ; Allowed ; Recommended # [240] (U+E0100..U+E01EF)  VARIATION SELECTOR-17..VARIATION SELECTOR-256
 
-# Total code points: 112998
+# Total code points: 113001
 
 005F          ; ~IDNA #      (_)  LOW LINE
-04C0          ; ~IDNA #      (Ӏ)  CYRILLIC LETTER PALOCHKA
-10A0..10C5    ; ~IDNA # [38] (Ⴀ..Ⴥ)  GEORGIAN CAPITAL LETTER AN..GEORGIAN CAPITAL LETTER HOE
-115F..1160    ; ~IDNA #  [2] (U+115F..U+1160)  HANGUL CHOSEONG FILLER..HANGUL JUNGSEONG FILLER
-17B4..17B5    ; ~IDNA #  [2] (U+17B4..U+17B5)  KHMER VOWEL INHERENT AQ..KHMER VOWEL INHERENT AA
-2132          ; ~IDNA #      (Ⅎ)  TURNED CAPITAL F
-2183          ; ~IDNA #      (Ↄ)  ROMAN NUMERAL REVERSED ONE HUNDRED
 
-# Total code points: 46
+# Total code points: 1
 
 0000..002F    ; ~Unicode Identifier # [48] (U+0000../)  <control-0000>..SOLIDUS
 003A..0040    ; ~Unicode Identifier #  [7] (:..@)  COLON..COMMERCIAL AT

--- a/unicodetools/src/main/java/org/unicode/props/UcdProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UcdProperty.java
@@ -234,12 +234,12 @@ public enum UcdProperty {
     Grapheme_Cluster_Break(
             PropertyType.Enumerated, Grapheme_Cluster_Break_Values.class, null, "GCB"),
     Hangul_Syllable_Type(PropertyType.Enumerated, Hangul_Syllable_Type_Values.class, null, "hst"),
-    Identifier_Status(PropertyType.Enumerated, Identifier_Status_Values.class, null, "idstatus"),
+    Identifier_Status(PropertyType.Enumerated, Identifier_Status_Values.class, null, "ID_Status"),
     Identifier_Type(
             PropertyType.Enumerated,
             Identifier_Type_Values.class,
             ValueCardinality.Unordered,
-            "idtype"),
+            "ID_Type"),
     Idn_2008(PropertyType.Enumerated, Idn_2008_Values.class, null, "idn8"),
     Idn_Status(PropertyType.Enumerated, Idn_Status_Values.class, null, "idns"),
     Indic_Conjunct_Break(PropertyType.Enumerated, Indic_Conjunct_Break_Values.class, null, "InCB"),

--- a/unicodetools/src/main/java/org/unicode/text/UCD/IdentifierInfo.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/IdentifierInfo.java
@@ -1082,7 +1082,7 @@ public class IdentifierInfo {
                             + "# mapping each code point to a set of enumerated values.\n"
                             + "# The short name of "
                             + propName
-                            + " is the same as the long name.\n"
+                            + " is ID_Type.\n"
                             + "# The possible values are:\n"
                             + "#   Not_Character, Deprecated, Default_Ignorable, Not_NFKC, Not_XID,\n"
                             + "#   Exclusion, Obsolete, Technical, Uncommon_Use, Limited_Use, Inclusion, Recommended\n"
@@ -1153,7 +1153,7 @@ public class IdentifierInfo {
                             + "# an enumerated property of code points.\n"
                             + "# The short name of "
                             + propName
-                            + " is the same as the long name.\n"
+                            + " is ID_Status.\n"
                             + "# The possible values are:\n"
                             + "#   Allowed, Restricted\n"
                             + "# The short name of each value is the same as its long name.\n\n"

--- a/unicodetools/src/main/resources/org/unicode/props/ExtraPropertyAliases.txt
+++ b/unicodetools/src/main/resources/org/unicode/props/ExtraPropertyAliases.txt
@@ -21,8 +21,8 @@ REZS ; RGI_Emoji_Zwj_Sequence ; Emoji_Zwj_Sequence
 # Enumerated Properties
 # ================================================
 
-idstatus ; Identifier_Status
-idtype ; Identifier_Type
+ID_Status ; Identifier_Status
+ID_Type ; Identifier_Type
 
 idns ; Idn_Status
 idn8 ; Idn_2008

--- a/unicodetools/src/main/resources/org/unicode/props/ExtraPropertyValueAliases.txt
+++ b/unicodetools/src/main/resources/org/unicode/props/ExtraPropertyValueAliases.txt
@@ -126,26 +126,26 @@ idn8 ; na	 ; na
 
 # @missing: 0000..10FFFF; Identifier_Status  	; r
 
-idstatus	; r	 ; Restricted			
-idstatus	; a	 ; Allowed				
+ID_Status	; r	 ; Restricted			
+ID_Status	; a	 ; Allowed				
 
 # @missing: 0000..10FFFF; Identifier_Type    	; nc
 # @missing: 0000..10FFFF; Identifier_Type    	; rec ; v9.0
 
-idtype	; nc	; Not_Character ; not_chars				
-idtype	; d		; Deprecated		
-idtype	; di	; Default_Ignorable		
-idtype	; nn	; Not_NFKC				
-idtype	; nx	; Not_XID		
-idtype	; o		; Obsolete				
-idtype	; ex	; Exclusion		
-idtype	; t		; Technical				
-idtype	; uu	; Uncommon_Use
-# idtype	; h		; Historic		
-idtype	; lu	; Limited_Use			
-idtype	; a		; Aspirational		
-idtype	; inc	; Inclusion				
-idtype	; rec	; Recommended	
+ID_Type	; nc	; Not_Character ; not_chars				
+ID_Type	; d		; Deprecated		
+ID_Type	; di	; Default_Ignorable		
+ID_Type	; nn	; Not_NFKC				
+ID_Type	; nx	; Not_XID		
+ID_Type	; o		; Obsolete				
+ID_Type	; ex	; Exclusion		
+ID_Type	; t		; Technical				
+ID_Type	; uu	; Uncommon_Use
+# ID_Type	; h		; Historic		
+ID_Type	; lu	; Limited_Use			
+ID_Type	; a		; Aspirational		
+ID_Type	; inc	; Inclusion				
+ID_Type	; rec	; Recommended	
 
 # @missing: 0000..10FFFF; Confusable_SL    	; <code point>
 # @missing: 0000..10FFFF; Confusable_SA    	; <code point>


### PR DESCRIPTION
[[179-A127](https://www.unicode.org/cgi-bin/GetL2Ref.pl?179-A127)] Action Item for Markus Scherer, PAG: In UTS #39 and its data files, define & document short property aliases ID_Status for Identifier_Status and ID_Type for Identifier_Type. For Unicode Version 16.0. See document [L2/24-064](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/24-064) item 8.3.

The generated, tool-internal data files also reflect the UTS46/IDNA data changes from the minimized base exclusion set.