### PR TITLE
Remove a redundant rule

### DIFF
--- a/unicodetools/data/ucd/dev/auxiliary/LineBreakTest.html
+++ b/unicodetools/data/ucd/dev/auxiliary/LineBreakTest.html
@@ -7,7 +7,7 @@ td, th { vertical-align: top }
 <body bgcolor='#FFFFFF'>
 <h2>Line_Break Chart</h2>
 <p><b>Unicode Version:</b> 16.0.0</p>
-<p><b>Date:</b> 2024-05-03, 13:11:08 GMT</p>
+<p><b>Date:</b> 2024-05-08, 00:44:06 GMT</p>
 <p>This page illustrates the application of the Line_Break specification. The material here is informative, not normative.</p> <p>The first chart shows where breaks would appear between different sample characters or strings. The sample characters are chosen mechanically to represent the different properties used by the specification.</p><p>Each cell shows the break-status for the position between the character(s) in its row header and the character(s) in its column header. The × symbol indicates no break, while the ÷ symbol indicated a break. The cells with × are also shaded to make it easier to scan the table. For example, in the cell at the intersection of the row headed by “CR” and the column headed by “LF”, there is a × symbol, indicating that there is no break between CR and LF.</p>
 <p>Some column headers may be composed, reflecting “treat as” or “ignore” rules.</p>
 <p>If your browser handles titles (tooltips), then hovering the mouse over the row header will show a sample character of that type. Hovering over a column header will show the sample character, plus its abbreviated general category and script. Hovering over the intersected cells shows the rule number that produces the break-status. For example, hovering over the cell at the intersection of H3 and JT shows ×, with the rule 26.03. Checking below the table, rule 26.03 is “JT | H3 × JT”, which is the one that applies to that case. Note that a rule is invoked only when no lower-numbered rules have applied.</p>
@@ -149,7 +149,6 @@ td, th { vertical-align: top }
 <tr><th style='text-align:right'><a href='#r25.13' name='r25.13'>25.13</a></th><td style='text-align:right'>HY </td><td>×</td><td> NU</td></tr>
 <tr><th style='text-align:right'><a href='#r25.14' name='r25.14'>25.14</a></th><td style='text-align:right'>IS </td><td>×</td><td> NU</td></tr>
 <tr><th style='text-align:right'><a href='#r25.15' name='r25.15'>25.15</a></th><td style='text-align:right'>NU ( SY | IS )* </td><td>×</td><td> NU</td></tr>
-<tr><th style='text-align:right'><a href='#r25.16' name='r25.16'>25.16</a></th><td style='text-align:right'>NU ( SY | IS )* </td><td>×</td><td> SY</td></tr>
 <tr><th style='text-align:right'><a href='#r26.01' name='r26.01'>26.01</a></th><td style='text-align:right'>JL </td><td>×</td><td> JL | JV | H2 | H3</td></tr>
 <tr><th style='text-align:right'><a href='#r26.02' name='r26.02'>26.02</a></th><td style='text-align:right'>JV | H2 </td><td>×</td><td> JV | JT</td></tr>
 <tr><th style='text-align:right'><a href='#r26.03' name='r26.03'>26.03</a></th><td style='text-align:right'>JT | H3 </td><td>×</td><td> JT</td></tr>

--- a/unicodetools/src/main/resources/org/unicode/tools/SegmenterDefault.txt
+++ b/unicodetools/src/main/resources/org/unicode/tools/SegmenterDefault.txt
@@ -288,7 +288,7 @@ $AL=($AL | ^ $CM | (?<=$Spec1_) $CM)
 # LB 20  Break before and after unresolved CB.
 20.01)  ÷ $CB
 20.02) $CB ÷
-# LB20a Do not break after a hyphen that follows break opportunity, a space, or the start of text.
+# LB 20a Do not break after a hyphen that follows break opportunity, a space, or the start of text.
 20.10) ( $sot | $BK | $CR | $LF | $NL | $SP | $ZW | $CB | $GL ) ( $HY | $Hyphen ) × $AL
 # LB 21  Do not break before hyphen-minus, other hyphens, fixed-width spaces, small kana and other non-starters, or after acute accents.
 21.01) × $BA
@@ -328,7 +328,6 @@ $AL=($AL | ^ $CM | (?<=$Spec1_) $CM)
 25.13) $HY × $NU
 25.14) $IS × $NU
 25.15) $NU ( $SY | $IS )* × $NU
-25.16) $NU ( $SY | $IS )* × $SY
 #LB 26 Do not break a Korean syllable.
 26.01) $JL  × $JL | $JV | $H2 | $H3
 26.02) $JV | $H2 × $JV | $JT


### PR DESCRIPTION
This rule, approved by UTC-179-C35, does nothing, because LB13 already did whatever it would do.

I will be putting a review note about that in the proposed update (see https://github.com/unicode-org/unicode-reports/pull/141), this obviously has no effect and will have been called out during review so I do not think it warrants a decision separate from the decision to approve UAX14 for final publication.

Also: add a missing space.