### PR TITLE
UTS46 valid: use IDS not Block=IDC

### DIFF
--- a/unicodetools/src/main/java/org/unicode/idna/GenerateIdna.java
+++ b/unicodetools/src/main/java/org/unicode/idna/GenerateIdna.java
@@ -347,8 +347,9 @@ public class GenerateIdna {
                         .removeAll(properties.getSet("gc=Zl"))
                         .removeAll(properties.getSet("gc=Zp"))
                         .removeAll(properties.getSet("gc=Zs"))
-                        .removeAll(properties.getSet("Block=Ideographic_Description_Characters"))
-                        .remove(0x31EF) // an IDC added in 15.1 outside the full IDC block
+                        .removeAll(properties.getSet("IDS_Unary_Operator=true"))
+                        .removeAll(properties.getSet("IDS_Binary_Operator=true"))
+                        .removeAll(properties.getSet("IDS_Trinary_Operator=true"))
                         .removeAll(new UnicodeSet("[\\u0000-\\u007F]"))
                         // Add lowercase sharp s to the base valid set.
                         // Otherwise the new-in-15.1 baseMapping for capital sharp s


### PR DESCRIPTION
Code version of

[[178-A25](https://www.unicode.org/cgi-bin/GetL2Ref.pl?178-A25)] Action Item for Markus Scherer, Mark Davis, PAG: In UTS#46 section 6 step 2 “Specify the base valid set” replace the removal of \p{Block=Ideographic_Description_Characters} and \u31EF with the removal of [\p{IDS_Unary_Operator}\p{IDS_Binary_Operator}\p{IDS_Trinary_Operator}]. For Unicode Version 16.0. See [L2/24-009](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/24-009) item 7.2.