### PR TITLE
idnatest error if xn-- empty or all-ASCII

### DIFF
--- a/unicodetools/data/idna/dev/IdnaTestV2.txt
+++ b/unicodetools/data/idna/dev/IdnaTestV2.txt
@@ -1,5 +1,5 @@
 # IdnaTestV2.txt
-# Date: 2024-05-21, 22:54:25 GMT
+# Date: 2024-05-22, 02:31:53 GMT
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -548,6 +548,12 @@ $; ; [U1]; ; ; ;  # $
 xn--csh.four; ⑷.four; [U1]; xn--csh.four; ; ;  # ⑷.four
 a\uD900z; ; [V7]; ; [V7, A3]; ;  # az
 A\uD900Z; a\uD900z; [V7]; ; [V7, A3]; ;  # az
+xn--; ""; [P4, X4_2]; ; [P4, A4_1, A4_2]; ;  # 
+xn---; ; [P4]; ; ; ;  # xn---
+xn--ASCII-; ascii; [P4]; ; ; ;  # ascii
+ascii; ; ; ; ; ;  # ascii
+xn--unicode-.org; unicode.org; [P4]; ; ; ;  # unicode.org
+unicode.org; ; ; ; ; ;  # unicode.org
 
 # RANDOMIZED TESTS
 

--- a/unicodetools/src/main/java/org/unicode/idna/GenerateIdnaTest.java
+++ b/unicodetools/src/main/java/org/unicode/idna/GenerateIdnaTest.java
@@ -928,5 +928,11 @@ public class GenerateIdnaTest {
         "(4).four",
         // Ill-formed string with an unpaired surrogate. Punycode.encode() fails, and we report A3.
         "a" + (char) 0xD900 + "z",
+        // Unicode 16 Processing after Punycode decoding: If the label is empty,
+        // or if the label contains only ASCII code points, record that there was an error.
+        "xn--",
+        "xn---",
+        "xn--ASCII-",
+        "xn--unicode-.org",
     };
 }

--- a/unicodetools/src/main/java/org/unicode/idna/Uts46.java
+++ b/unicodetools/src/main/java/org/unicode/idna/Uts46.java
@@ -373,6 +373,11 @@ public class Uts46 extends Idna {
             final StringBuffer temp = new StringBuffer();
             temp.append(label.substring(4));
             final StringBuffer depuny = Punycode.decode(temp, null);
+            // Unicode 16: If the label is empty,
+            // or if the label contains only ASCII code points, record that there was an error.
+            if (depuny.length() == 0 || depuny.chars().allMatch((c) -> c <= 0x7f)) {
+                errors.add(Errors.P4);
+            }
             return depuny.toString();
         } catch (final Exception e) {
             errors.add(Errors.P4);


### PR DESCRIPTION
[[165-A48](https://www.unicode.org/cgi-bin/GetL2Ref.pl?165-A48)] Action Item for Markus Scherer, Editorial Committee: Update UTS#46 to validate ACE label edge cases, see [L2/20-240](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/20-240) item F7. For Unicode 14.

Corresponds to spec change
- https://github.com/unicode-org/unicode-reports/pull/149

## L2/20-240 item F7
The IDNA2008 ToUnicode operation validates ACE labels ("xn--" plus Punycode)
by decoding them, then re-encoding via ToASCII, and verifying that the
round-trip output is the same as the input (case-insensitive).

The UTS#46 ToUnicode operation and its Processing step uses a cheaper
Convert/Validate step which wants to be equivalent.

However, it misses two edge cases which pass Convert/Validate step but which
IDNA2008 catches with its round-trip verification:
1. "xn--" decodes to an empty string
2. "xn--ASCII-" decodes to just "ASCII"

I propose that we modify
https://www.unicode.org/reports/tr46/#ProcessingStepPunycode (section 4
Processing > step 4 "Convert/Validate" > If the label starts with
“xn--”) so that it catches these cases.

...