### PR TITLE
Do not use ICU property values in the JSP TestProperties

### DIFF
--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestProperties.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestProperties.java
@@ -37,6 +37,8 @@ import org.unicode.jsp.UnicodeSetUtilities;
 import org.unicode.jsp.UnicodeUtilities;
 import org.unicode.jsp.XPropertyFactory;
 import org.unicode.props.UnicodeProperty;
+import org.unicode.text.UCD.ToolUnicodePropertySource;
+import org.unicode.text.utility.Settings;
 
 public class TestProperties extends TestFmwk2 {
     static XPropertyFactory factory = XPropertyFactory.make();
@@ -294,7 +296,10 @@ public class TestProperties extends TestFmwk2 {
         for (int i = 0; i < 256; ++i) {
             String s = String.valueOf(i);
             if (s.contains("3")) {
-                expected.addAll(new UnicodeSet("[:ccc=" + s + ":]"));
+                expected.addAll(
+                        ToolUnicodePropertySource.make(Settings.latestVersion)
+                                .getProperty("ccc")
+                                .getSet(s));
             }
         }
         assertEquals(test, expected, actual);


### PR DESCRIPTION
Follow-up on https://github.com/unicode-org/unicodetools/pull/810#issuecomment-2101660806.