### PR TITLE
Fix typo in DoNotEmit.txt comments

### DIFF
--- a/unicodetools/data/ucd/dev/DoNotEmit.txt
+++ b/unicodetools/data/ucd/dev/DoNotEmit.txt
@@ -1,5 +1,5 @@
 # DoNotEmit-16.0.0.txt
-# Date: 2024-03-18, 09:28:00 GMT
+# Date: 2024-05-24, 11:01:00 GMT
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -83,7 +83,7 @@
 # Hamza_Form:
 #    Sequences containing Arabic hamza above, which should be avoided.
 # Precomposed_Hieroglyph:
-#    Precomposed sequences for Egyptial Hieroglyphs which should be avoided.
+#    Precomposed sequences for Egyptian Hieroglyphs which should be avoided.
 # Precomposed_Form:
 #    Sequences for which a precomposed form exists, but without canonical
 #    equivalence.


### PR DESCRIPTION
The file header had a misspelling: Egyptial instead of Egyptian.
https://github.com/unicode-org/properties/issues/295#issuecomment-2130313812