### PR TITLE
Update ArabicShaping for Kashmiri Yeh

### DIFF
--- a/unicodetools/data/ucd/dev/ArabicShaping.txt
+++ b/unicodetools/data/ucd/dev/ArabicShaping.txt
@@ -1,5 +1,5 @@
 # ArabicShaping-16.0.0.txt
-# Date: 2024-02-02
+# Date: 2024-07-30
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -128,7 +128,7 @@
 0605; ARABIC NUMBER MARK ABOVE; U; No_Joining_Group
 0608; ARABIC RAY; U; No_Joining_Group
 060B; AFGHANI SIGN; U; No_Joining_Group
-0620; DOTLESS YEH WITH SEPARATE RING BELOW; D; YEH
+0620; KASHMIRI YEH; D; KASHMIRI YEH
 0621; HAMZA; U; No_Joining_Group
 0622; ALEF WITH MADDA ABOVE; R; ALEF
 0623; ALEF WITH HAMZA ABOVE; R; ALEF

--- a/unicodetools/data/ucd/dev/PropertyValueAliases.txt
+++ b/unicodetools/data/ucd/dev/PropertyValueAliases.txt
@@ -1,5 +1,5 @@
 # PropertyValueAliases-16.0.0.txt
-# Date: 2024-06-06, 22:21:34 GMT
+# Date: 2024-07-30, 19:59:00 GMT
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -1020,6 +1020,7 @@ jg ; Heh_Goal                         ; Heh_Goal
 jg ; Heth                             ; Heth
 jg ; Kaf                              ; Kaf
 jg ; Kaph                             ; Kaph
+jg ; Kashmiri_Yeh                     ; Kashmiri_Yeh
 jg ; Khaph                            ; Khaph
 jg ; Knotted_Heh                      ; Knotted_Heh
 jg ; Lam                              ; Lam

--- a/unicodetools/data/ucd/dev/extracted/DerivedJoiningGroup.txt
+++ b/unicodetools/data/ucd/dev/extracted/DerivedJoiningGroup.txt
@@ -1,5 +1,5 @@
 # DerivedJoiningGroup-16.0.0.txt
-# Date: 2024-04-30, 21:48:17 GMT
+# Date: 2024-07-30, 20:09:00 GMT
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -185,6 +185,12 @@
 # ================================================
 
 071F          ; Kaph # Lo       SYRIAC LETTER KAPH
+
+# Total code points: 1
+
+# ================================================
+
+0620          ; Kashmiri_Yeh # Lo       ARABIC LETTER KASHMIRI YEH
 
 # Total code points: 1
 

--- a/unicodetools/data/ucd/dev/extracted/DerivedJoiningGroup.txt
+++ b/unicodetools/data/ucd/dev/extracted/DerivedJoiningGroup.txt
@@ -190,12 +190,6 @@
 
 # ================================================
 
-0620          ; Kashmiri_Yeh # Lo       ARABIC LETTER KASHMIRI YEH
-
-# Total code points: 1
-
-# ================================================
-
 06BE          ; Knotted_Heh # Lo       ARABIC LETTER HEH DOACHASHMEE
 06FF          ; Knotted_Heh # Lo       ARABIC LETTER HEH WITH INVERTED V
 
@@ -748,6 +742,12 @@
 # ================================================
 
 088E          ; Vertical_Tail # Lo       ARABIC VERTICAL TAIL
+
+# Total code points: 1
+
+# ================================================
+
+0620          ; Kashmiri_Yeh # Lo       ARABIC LETTER KASHMIRI YEH
 
 # Total code points: 1
 

--- a/unicodetools/data/ucd/dev/extracted/DerivedJoiningGroup.txt
+++ b/unicodetools/data/ucd/dev/extracted/DerivedJoiningGroup.txt
@@ -1,5 +1,5 @@
 # DerivedJoiningGroup-16.0.0.txt
-# Date: 2024-07-30, 20:09:00 GMT
+# Date: 2024-07-30, 21:15:55 GMT
 # © 2024 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -377,7 +377,6 @@
 
 # ================================================
 
-0620          ; Yeh # Lo       ARABIC LETTER KASHMIRI YEH
 0626          ; Yeh # Lo       ARABIC LETTER YEH WITH HAMZA ABOVE
 0649..064A    ; Yeh # Lo   [2] ARABIC LETTER ALEF MAKSURA..ARABIC LETTER YEH
 0678          ; Yeh # Lo       ARABIC LETTER HIGH HAMZA YEH
@@ -386,7 +385,7 @@
 08A8..08A9    ; Yeh # Lo   [2] ARABIC LETTER YEH WITH TWO DOTS BELOW AND HAMZA ABOVE..ARABIC LETTER YEH WITH TWO DOTS BELOW AND DOT ABOVE
 08BA          ; Yeh # Lo       ARABIC LETTER YEH WITH TWO DOTS BELOW AND SMALL NOON ABOVE
 
-# Total code points: 11
+# Total code points: 10
 
 # ================================================
 

--- a/unicodetools/src/main/java/org/unicode/props/UcdPropertyValues.java
+++ b/unicodetools/src/main/java/org/unicode/props/UcdPropertyValues.java
@@ -1281,6 +1281,7 @@ public class UcdPropertyValues {
         Heth("Heth"),
         Kaf("Kaf"),
         Kaph("Kaph"),
+        Kashmiri_Yeh("Kashmiri_Yeh"),
         Khaph("Khaph"),
         Knotted_Heh("Knotted_Heh"),
         Lam("Lam"),

--- a/unicodetools/src/main/java/org/unicode/text/UCD/UCD_Names.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/UCD_Names.java
@@ -1222,7 +1222,9 @@ public final class UCD_Names implements UCD_Types {
         "Hanifi_Rohingya_Kinna_Ya",
         // Unicode 14
         "THIN_YEH",
-        "VERTICAL_TAIL"
+        "VERTICAL_TAIL",
+        // Unicode 16
+        "KASHMIRI_YEH"
     };
 
     static {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/UCD_Types.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/UCD_Types.java
@@ -777,8 +777,10 @@ public interface UCD_Types {
             // Unicode 14
             THIN_YEH = 103,
             VERTICAL_TAIL = 104,
+            // Unicode 16
+            KASHMIRI_YEH = 105,
             // limit
-            LIMIT_JOINING_GROUP = VERTICAL_TAIL + 1;
+            LIMIT_JOINING_GROUP = KASHMIRI_YEH + 1;
     static final byte NFD = 0, NFC = 1, NFKD = 2, NFKC = 3;
     public static final int NF_COMPATIBILITY_MASK = 2, NF_COMPOSITION_MASK = 1;
 


### PR DESCRIPTION
[UTC-180-C24] Consensus: In ArabicShaping.txt, change the Joining_Group for U+0620 from YEH to a new joining group KASHMIRI YEH, and change its schematic name from DOTLESS YEH WITH SEPARATE RING BELOW to KASHMIRI YEH for Unicode 16.0. [Ref. Section 3b of L2/24-166]

[UTC-180-A69] Action Item for Roozbeh Pournader, PAG: Update ArabicShaping.txt for U+0620 per L2/24-152 for Unicode 16.0. [Ref. Section 3b of L2/24-166]

[UTC-180-A70] Action Item for Roozbeh Pournader, PAG: Update PropertyValueAliases.txt with the new joining group for Kashmiri Yeh. [Ref. Section 3b of L2/24-166]