### PR TITLE
NamesList-16.0.0d28.txt

### DIFF
--- a/unicodetools/data/ucd/dev/NamesList.txt
+++ b/unicodetools/data/ucd/dev/NamesList.txt
@@ -1,7 +1,7 @@
 ; charset=UTF-8
 @@@	The Unicode Standard 16.0.0
 @@@+	NamesList-16.0.0.txt
-@+	Generation Date: 2024-07-10, 12:25:21 GMT
+@+	Generation Date: 2024-07-31, 08:02:34 GMT
 	Unicode 16.0.0 names list.
 	Repertoire synched with UnicodeData-16.0.0d16.txt.
 	Post-beta rollup of various fixes.
@@ -9,6 +9,8 @@
 	Fixes for subheads G08 - G17, S21, U22 in Egyptian Hieroglyphs Extended-A block.
 	Add xref between 2BFA and 1CC88.
 	Move subhead at 10D6E in Garay block.
+	Add annotation to 2217.
+	Add pointer for UTN #57 for Mongolian block.
 	This file is semi-automatically derived from UnicodeData.txt and
 	a set of manually created annotations using a script to select
 	or suppress information from the data file. The rules used
@@ -9882,6 +9884,7 @@
 @@	1800	Mongolian	18AF
 @@+
 @+		A copy of the Mongolian code chart showing glyphs for all Mongolian positional variants and variation sequences can be found in UTR #54, Unicode Mongolian 12.1 Snapshot.
+@+		For detailed information about implementation of Mongolian shaping, see UTN #57, Encoding and Shaping of the Mongolian Script.
 @		Punctuation
 @+		Additional birgas are encoded in the Mongolian Supplement block at 11660-1167F.
 1800	MONGOLIAN BIRGA
@@ -14329,6 +14332,7 @@
 	x (mathematical falling diagonal - 27CD)
 	x (reverse solidus operator - 29F5)
 2217	ASTERISK OPERATOR
+	* may be used to represent the telephony asterisk seen on keypads
 	x (asterisk - 002A)
 2218	RING OPERATOR
 	= composite function


### PR DESCRIPTION
From @Ken-Whistler:
> I have regenerated NameList.txt with the latest StandardizedVariants.txt
> and Unikemet.txt, and with annotations added for 2217 ([180-A104](https://www.unicode.org/cgi-bin/GetL2Ref.pl?180-A104)) and for
> mentioning UTN #&zwnj;57 in the Mongolian block ([180-A4](https://www.unicode.org/cgi-bin/GetL2Ref.pl?180-A4)).

> The delta should show up as only two point changes and the notes in the
> header section.

And indeed it does.

> I've closed [180-A4](https://www.unicode.org/cgi-bin/GetL2Ref.pl?180-A4) and [180-A104](https://www.unicode.org/cgi-bin/GetL2Ref.pl?180-A104) for this. I'm also closing my action
> [180-A107](https://www.unicode.org/cgi-bin/GetL2Ref.pl?180-A107) to provide an updated NamesList.txt for 16.0, as I have no
> further related actions for 16.0 names list annotations and know of no
> further items that need fixing (e.g. for Egyptian). The names list
> should be ready for 16.0, except for the final BRS step to excise the
> remaining header section notes.

