### PR TITLE
pub beta CollationTest.html: fix placeholders

### DIFF
--- a/pub/copy-beta-to-draft.sh
+++ b/pub/copy-beta-to-draft.sh
@@ -42,7 +42,7 @@ mv $DRAFT/UCD/ucd/zipped-ReadMe.txt $DRAFT/zipped/ReadMe.txt
 
 mkdir -p $DRAFT/UCA
 cp -r $UNITOOLS_DATA/uca/dev/* $DRAFT/UCA
-sed -i -f $DEST/sed-readmes.txt $DRAFT/UCA/CollationTest.html
+sed -i -f $DRAFT/sed-readmes.txt $DRAFT/UCA/CollationTest.html
 
 mkdir -p $DRAFT/emoji
 cp $UNITOOLS_DATA/emoji/dev/* $DRAFT/emoji


### PR DESCRIPTION
The path to the "sed" script was wrong, and I overlooked the error message in the console output, so the placeholders didn't get processed :-(

Not a problem in the final-release publication script. In fact, I had copied the "sed" command from that script to the beta script and failed to adjust for the different path names.