### PR TITLE
Parse IndicMatraCategory.txt

### DIFF
--- a/unicodetools/src/main/resources/org/unicode/props/IndexUnicodeProperties.txt
+++ b/unicodetools/src/main/resources/org/unicode/props/IndexUnicodeProperties.txt
@@ -104,6 +104,7 @@ DerivedAge ; Age
 EastAsianWidth ; East_Asian_Width
 HangulSyllableType ; Hangul_Syllable_Type
 IndicPositionalCategory ; Indic_Positional_Category
+IndicMatraCategory ; Indic_Positional_Category ; v7.0
 IndicSyllabicCategory ; Indic_Syllabic_Category
 Jamo ; Jamo_Short_Name
 LineBreak ; Line_Break


### PR DESCRIPTION
In the unicodetools meeting of 2024-09-03, it came to our attention that Indic_Positional_Category used to be a provisional property called Indic_Matra_Category, renamed in UTC-140-C16 and then made informative in UTC-140-C17, for Unicode Version 8.0.

Just like we parse Indic_Syllabic_Category in versions where it was provisional, and expose it in historical views of property assignments, we should parse the provisional Indic_Matra_Category.

It seems most convenient to treat IndicMatraCategory.txt as defining InPC, since there are often no changes in assignment at the time of the renaming (specifically, `\P{U8.0:Indic_Positional_Category=@U7.0:Indic_Positional_Category@}-\p{U7.0:Indic_Positional_Category=NA}` (the set of characters that changed InPC from non-NA in 8.0) has cardinality 7, whereas `\p{U8.0:Indic_Positional_Category=@U7.0:Indic_Positional_Category@}-\p{U7.0:Indic_Positional_Category=NA}` (the set of non-NA characters that did not change InPC in 8.0) has cardinality 598).

Example: the history of assignments for U+0DDD:

![image](https://github.com/user-attachments/assets/3dad479e-93ad-4884-b6df-a67057aefbb3)

We could add an Extra alias Indic_Matra_Category; I am not doing that for now.

