### PR TITLE
Unbreak the workflows

### DIFF
--- a/.github/workflows/build-jsp.yml
+++ b/.github/workflows/build-jsp.yml
@@ -69,7 +69,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload UnicodeJsps.war
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: UnicodeJsps
         path: UnicodeJsps/target/UnicodeJsps.war

--- a/.github/workflows/push-jsp-on-tag.yml
+++ b/.github/workflows/push-jsp-on-tag.yml
@@ -49,7 +49,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload UnicodeJsps.war
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: UnicodeJsps
         path: UnicodeJsps/target/UnicodeJsps.war


### PR DESCRIPTION
https://github.com/unicode-org/unicodetools/pull/931 failed with
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```
Doing that in a separate PR since it has nothing to do with 17.