### PR TITLE
Stop manually setting versions in AacOrder.java

### DIFF
--- a/docs/emoji/aac.md
+++ b/docs/emoji/aac.md
@@ -5,15 +5,6 @@
 Once the emoji are finalized for new version of TR51, or there is a new version
 of CLDR, run AacOrder.java to generate 3 new files which will be checked in.
 
-Fix the versions at the top of the file, such as:
-```
-private static final VersionInfo VERSION = Emoji.VERSION12;
-
-private static final VersionInfo UCD_VERSION = Emoji.VERSION12;
-```
-
-The emoji version will be ≥ the UCD version.
-
 **Results:**
 
 :construction: **TODO**: Work with Mark on working replacements for "draft" URLs.

--- a/unicodetools/src/main/java/org/unicode/tools/AacOrder.java
+++ b/unicodetools/src/main/java/org/unicode/tools/AacOrder.java
@@ -30,8 +30,8 @@ import org.unicode.tools.emoji.EmojiOrder;
 
 public class AacOrder {
 
-    private static final VersionInfo VERSION = Emoji.VERSION15_1;
-    private static final VersionInfo UCD_VERSION = Emoji.VERSION15_1;
+    private static final VersionInfo VERSION = Emoji.VERSION_TO_GENERATE;
+    private static final VersionInfo UCD_VERSION = Emoji.VERSION_TO_GENERATE_UNICODE;
 
     private static final CandidateData CANDIDATE_DATA = CandidateData.getInstance();
 


### PR DESCRIPTION
Make it easier for anyone to run the tool.