### PR TITLE
Only run Maven cache workflow on the upstream repo

### DIFF
--- a/.github/workflows/cache_retain.yml
+++ b/.github/workflows/cache_retain.yml
@@ -30,6 +30,10 @@ jobs:
   retain-maven-cache:
     name: Run all tests with Maven
     runs-on: ubuntu-latest
+    # Only run this on the upstream repo. Otherwise, running in a person fork will cause
+    # Github to disable the personal fork copy of the workflow
+    # (Github complains about running a scheduled workflow on a repo with > 60 days of inactivity)
+    if: github.ref == 'refs/heads/main' && github.repository == 'unicode-org/unicodetools'
     steps:
       - name: Checkout and setup
         uses: actions/checkout@v2


### PR DESCRIPTION
Mostly a nice-to-have adjustment that prevents the workflow from running in personal forks. When that happens, Github will complain about running a scheduled workflow on a repo with > 60 days of inactivity