### PR TITLE
Allow redundant lines in data files to facilitate merging

### DIFF
--- a/unicodetools/src/main/java/org/unicode/props/PropertyUtilities.java
+++ b/unicodetools/src/main/java/org/unicode/props/PropertyUtilities.java
@@ -31,6 +31,9 @@ public class PropertyUtilities {
     static final <K, V, M extends Map<K, V>> M putNew(M map, K key, V value) {
         final V oldValue = map.get(key);
         if (oldValue != null) {
+            if (oldValue.equals(value)) {
+                return map;
+            }
             throw new UnicodePropertyException(
                     "Key already present in Map: "
                             + key
@@ -48,6 +51,9 @@ public class PropertyUtilities {
         final V oldValue = map.get(key);
         if (oldValue != null && (missingSet == null || !missingSet.contains(key))) {
             if (merger == null) {
+                if (oldValue.equals(value)) {
+                    return map;
+                }
                 throw new UnicodePropertyException(
                         "Key already present in UnicodeMap: "
                                 + Utility.hex(key)


### PR DESCRIPTION
Related to #419; redundant lines in Scripts.txt due to multiple changes affecting the same range caused an error. I think this one uses one of the newer parsers, which would explain why conflicts in the other data files didn’t run into it.

Note that since files get regenerated and we check that they have been regenerated, we shouldn’t actually end up with redundant lines.