### PR TITLE
Greedy context before in LB20a

### DIFF
--- a/unicodetools/src/main/resources/org/unicode/tools/SegmenterDefault.txt
+++ b/unicodetools/src/main/resources/org/unicode/tools/SegmenterDefault.txt
@@ -183,7 +183,7 @@ $NS=[$NSorig $CJ]
 # LB 15a Do not break after an unresolved initial punctuation that lies at the start of the line,
 # after a space, after opening punctuation, or after an unresolved quotation mark, even after
 # spaces.
-15.11) ( $sot | $BK | $CR | $LF | $NL | $OP | $QU | $GL | $SP | $ZW ) $QU_Pi $SP* ×
+15.11) ( $BK | $CR | $LF | $NL | $OP | $QU | $GL | $SP | $ZW | $sot ) $QU_Pi $SP* ×
 # LB 15b Do not break before an unresolved final punctuation that lies at the end of the line, before
 # a space, before a prohibited break, or before an unresolved quotation mark, even before spaces.
 15.21) × $QU_Pf ( $SP | $GL | $WJ | $CL | $QU | $CP | $EX | $IS | $SY | $BK | $CR | $LF | $NL | $ZW | $eot )
@@ -204,12 +204,12 @@ $NS=[$NSorig $CJ]
 19.10) [^$EastAsian] × $QU
 19.11) × $QU ( [^$EastAsian] | $eot )
 19.12) $QU × [^$EastAsian]
-19.13) ( $sot | [^$EastAsian] ) $QU ×
+19.13) ( [^$EastAsian] | $sot ) $QU ×
 # LB 20  Break before and after unresolved CB.
 20.01)  ÷ $CB
 20.02) $CB ÷
 # LB 20a Do not break after a hyphen that follows break opportunity, a space, or the start of text.
-20.10) ( $sot | $BK | $CR | $LF | $NL | $SP | $ZW | $CB | $GL ) ( $HY | $Hyphen ) × $AL
+20.10) ( $BK | $CR | $LF | $NL | $SP | $ZW | $CB | $GL | $sot ) ( $HY | $Hyphen ) × $AL
 # LB 21  Do not break before hyphen-minus, other hyphens, fixed-width spaces, small kana and other non-starters, or after acute accents.
 21.01) × $BA
 21.02) × $HY


### PR DESCRIPTION
Alternatives are left-to-right, not greedy: In the string
\<U+2E09 LEFT TRANSPOSITION BRACKET, U+2E0D RIGHT RAISED OMISSION BRACKET, U+1F3FC EMOJI MODIFIER FITZPATRICK TYPE-3>,
Searching for `( ^ | [^[\p{ea=F}\p{ea=W}\p{ea=H}]] ) \p{Line_Break=Quotation}` will find a match consisting of the first character, whereas searching for `( [^[\p{ea=F}\p{ea=W}\p{ea=H}]] | ^ ) \p{Line_Break=Quotation}` will find a match consisting of the first two characters.

ICU depends on a maximal match in its generated old monkeys: https://github.com/unicode-org/icu/blob/02951053b45f270c04ffeac6e0787dd2313bbd23/icu4c/source/test/intltest/rbbitst.cpp#L1779. This is messy to solve in general, but our alternatives here are simple enough that we can make them greedy by moving sot at the end.
Specifically, this works because except for sot, these alternatives are really unions of character classes. We could prohibit alternatives altogether and use unions of character classes, splitting the sot case into its own sub-rule, but that would be a divergence from the UAX14 formulation, which seems worse.
