### PR TITLE
Bring back the JSPs

### DIFF
--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeJsp.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeJsp.java
@@ -166,6 +166,19 @@ public class UnicodeJsp {
         String a_out;
         a.clear();
         try {
+            if (setA.length() > 4
+                    && setA.startsWith("[:k")
+                    && setA.endsWith(":]")
+                    && setA.contains("=")
+                    && !setA.substring(2, setA.length() - 2).contains(":]")
+                    && XPropertyFactory.make()
+                            .getProperty(setA.substring(2, setA.indexOf("=")))
+                            .isMultivalued()) {
+                throw new Exception(
+                        "POSIX-style queries for multivalued Unihan properties are temporarily disabled.  Try \\p{"
+                                + setA.substring(2, setA.length() - 2)
+                                + "}");
+            }
             // setA = UnicodeSetUtilities.MyNormalize(setA, Normalizer.NFC);
             a.addAll(UnicodeSetUtilities.parseUnicodeSet(setA));
             a_out = UnicodeUtilities.getPrettySet(a, abbreviate, escape);

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
@@ -1648,6 +1648,7 @@ public class UnicodeUtilities {
             VersionInfo last;
             String value;
         }
+        final boolean isMultivalued = getFactory().getProperty(propName).isMultivalued();
         List<PropertyAssignment> history = new ArrayList<>();
         // TODO(eggrobin): TUP normalization chokes on sufficiently old versions, but this is not
         // worth debugging as we want to get rid of it.
@@ -1732,17 +1733,21 @@ public class UnicodeUtilities {
                 out.append(
                         "<td"
                                 + defaultClass
-                                + "><a target='u' "
-                                + (isNew ? "class='changed' " : "")
-                                + "href='list-unicodeset.jsp?a=[:"
-                                + (isCurrent ? "" : "U" + last + ":")
-                                + propName
-                                + "="
-                                + hValue
-                                + ":]'>"
+                                + ">"
+                                + (isMultivalued
+                                        ? ""
+                                        : ("<a target='u' "
+                                                + (isNew ? "class='changed' " : "")
+                                                + "href='list-unicodeset.jsp?a=[:"
+                                                + (isCurrent ? "" : "U" + last + ":")
+                                                + propName
+                                                + "="
+                                                + hValue
+                                                + ":]'>"))
                                 + versionRange
                                 + hValue
-                                + "</a></td>");
+                                + (isMultivalued ? "" : "</a>")
+                                + "</td>");
             }
         }
         out.append("</tr>");

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/XPropertyFactory.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/XPropertyFactory.java
@@ -145,48 +145,6 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
                                 },
                                 false)
                         .setMain("toNFKD", "toNFKD", UnicodeProperty.STRING, "1.1"));
-
-        add(
-                new StringTransformProperty(
-                                new StringTransform() {
-                                    @Override
-                                    public String transform(String source) {
-                                        return UCharacter.foldCase(source, true);
-                                    }
-                                },
-                                false)
-                        .setMain("toCasefold", "toCF", UnicodeProperty.STRING, "1.1"));
-        add(
-                new StringTransformProperty(
-                                new StringTransform() {
-                                    @Override
-                                    public String transform(String source) {
-                                        return UCharacter.toLowerCase(ULocale.ROOT, source);
-                                    }
-                                },
-                                false)
-                        .setMain("toLowercase", "toLC", UnicodeProperty.STRING, "1.1"));
-        add(
-                new StringTransformProperty(
-                                new StringTransform() {
-                                    @Override
-                                    public String transform(String source) {
-                                        return UCharacter.toUpperCase(ULocale.ROOT, source);
-                                    }
-                                },
-                                false)
-                        .setMain("toUppercase", "toUC", UnicodeProperty.STRING, "1.1"));
-        add(
-                new StringTransformProperty(
-                                new StringTransform() {
-                                    @Override
-                                    public String transform(String source) {
-                                        return UCharacter.toTitleCase(ULocale.ROOT, source, null);
-                                    }
-                                },
-                                false)
-                        .setMain("toTitlecase", "toTC", UnicodeProperty.STRING, "1.1"));
-
         add(
                 new StringTransformProperty(
                                 new StringTransform() {

--- a/UnicodeJsps/src/main/webapp/properties.jsp
+++ b/UnicodeJsps/src/main/webapp/properties.jsp
@@ -20,7 +20,8 @@ th           { text-align: left }
         UtfParameters utfParameters = new UtfParameters(queryString);
 
         String propForValues = utfParameters.getParameter("a");
-		UnicodeJsp.showPropsTable(out, propForValues, "properties.jsp");
+        // TODO(egg): Cache this page.
+		//UnicodeJsp.showPropsTable(out, propForValues, "properties.jsp");
 %>
 <h2>Key</h2>
 <p>The Categories are from <a target='_blank' href='http://www.unicode.org/reports/tr44#Property_Index'>UCD

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -164,6 +164,10 @@ public abstract class UnicodeProperty extends UnicodeLabel {
         return this;
     }
 
+    public boolean isMultivalued() {
+        return isMultivalued;
+    }
+
     public UnicodeProperty setDelimiter(String value) {
         delimiter = value;
         delimiterSplitter = Splitter.on(delimiter);


### PR DESCRIPTION
Four commits, deployed in three builds of the JSPs:
1. Drop properties.jsp (we should bring something like it back eventually, but besides its abysmal performance it had not been seriously maintained and was becoming borderline useless);
2. Remove links to UnicodeSet queries for multivalued properties from character.jsp (these queries are very slow as currently implemented—minutes for some of the worst offenders—, and the link was to an invalid query when the character being inspected actually had multiple values anyway);
3.
   * Remove the ICU-based toLowercase etc. pseudoproperties (these are from before the JSPs showed the real Lowercase_Mapping etc. properties, and UnicodeSet queries to compute the preimage of a function are intrinsically very slow);
   * Fail multivalued Unihan property queries if they are in the exact format we used to link to, to deal with residual traffic from links we served before deployment 2., with a suggestion to use a different format in case a hapless human comes across this (this one can hopefully be reverted eventually).

![image](https://github.com/user-attachments/assets/c540b429-6328-4512-a437-59cdeb4c52e1)
![image](https://github.com/user-attachments/assets/933d15d6-c220-408d-b110-93d8d1892ba3)
