### PR TITLE
No ExtPict for old symbols

### DIFF
--- a/unicodetools/data/ucd/dev/emoji/emoji-data.txt
+++ b/unicodetools/data/ucd/dev/emoji/emoji-data.txt
@@ -1,5 +1,5 @@
 # emoji-data.txt
-# Date: 2025-01-08, 04:57:12 GMT
+# Date: 2025-01-29, 17:53:31 GMT
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -843,7 +843,6 @@ E0020..E007F  ; Emoji_Component      # E0.0  [96] (󠀠..󠁿)      tag space..c
 21A9..21AA    ; Extended_Pictographic# E0.6   [2] (↩️..↪️)    right arrow curving left..left arrow curving right
 231A..231B    ; Extended_Pictographic# E0.6   [2] (⌚..⌛)    watch..hourglass done
 2328          ; Extended_Pictographic# E1.0   [1] (⌨️)       keyboard
-2388          ; Extended_Pictographic# E0.0   [1] (⎈)       HELM SYMBOL
 23CF          ; Extended_Pictographic# E1.0   [1] (⏏️)       eject button
 23E9..23EC    ; Extended_Pictographic# E0.6   [4] (⏩..⏬)    fast-forward button..fast down button
 23ED..23EE    ; Extended_Pictographic# E0.7   [2] (⏭️..⏮️)    next track button..last track button
@@ -860,106 +859,63 @@ E0020..E007F  ; Emoji_Component      # E0.0  [96] (󠀠..󠁿)      tag space..c
 2600..2601    ; Extended_Pictographic# E0.6   [2] (☀️..☁️)    sun..cloud
 2602..2603    ; Extended_Pictographic# E0.7   [2] (☂️..☃️)    umbrella..snowman
 2604          ; Extended_Pictographic# E1.0   [1] (☄️)       comet
-2605          ; Extended_Pictographic# E0.0   [1] (★)       BLACK STAR
-2607..260D    ; Extended_Pictographic# E0.0   [7] (☇..☍)    LIGHTNING..OPPOSITION
 260E          ; Extended_Pictographic# E0.6   [1] (☎️)       telephone
-260F..2610    ; Extended_Pictographic# E0.0   [2] (☏..☐)    WHITE TELEPHONE..BALLOT BOX
 2611          ; Extended_Pictographic# E0.6   [1] (☑️)       check box with check
-2612          ; Extended_Pictographic# E0.0   [1] (☒)       BALLOT BOX WITH X
 2614..2615    ; Extended_Pictographic# E0.6   [2] (☔..☕)    umbrella with rain drops..hot beverage
-2616..2617    ; Extended_Pictographic# E0.0   [2] (☖..☗)    WHITE SHOGI PIECE..BLACK SHOGI PIECE
 2618          ; Extended_Pictographic# E1.0   [1] (☘️)       shamrock
-2619..261C    ; Extended_Pictographic# E0.0   [4] (☙..☜)    REVERSED ROTATED FLORAL HEART BULLET..WHITE LEFT POINTING INDEX
 261D          ; Extended_Pictographic# E0.6   [1] (☝️)       index pointing up
-261E..261F    ; Extended_Pictographic# E0.0   [2] (☞..☟)    WHITE RIGHT POINTING INDEX..WHITE DOWN POINTING INDEX
 2620          ; Extended_Pictographic# E1.0   [1] (☠️)       skull and crossbones
-2621          ; Extended_Pictographic# E0.0   [1] (☡)       CAUTION SIGN
 2622..2623    ; Extended_Pictographic# E1.0   [2] (☢️..☣️)    radioactive..biohazard
-2624..2625    ; Extended_Pictographic# E0.0   [2] (☤..☥)    CADUCEUS..ANKH
 2626          ; Extended_Pictographic# E1.0   [1] (☦️)       orthodox cross
-2627..2629    ; Extended_Pictographic# E0.0   [3] (☧..☩)    CHI RHO..CROSS OF JERUSALEM
 262A          ; Extended_Pictographic# E0.7   [1] (☪️)       star and crescent
-262B..262D    ; Extended_Pictographic# E0.0   [3] (☫..☭)    FARSI SYMBOL..HAMMER AND SICKLE
 262E          ; Extended_Pictographic# E1.0   [1] (☮️)       peace symbol
 262F          ; Extended_Pictographic# E0.7   [1] (☯️)       yin yang
-2630..2637    ; Extended_Pictographic# E0.0   [8] (☰..☷)    TRIGRAM FOR HEAVEN..TRIGRAM FOR EARTH
 2638..2639    ; Extended_Pictographic# E0.7   [2] (☸️..☹️)    wheel of dharma..frowning face
 263A          ; Extended_Pictographic# E0.6   [1] (☺️)       smiling face
-263B..263F    ; Extended_Pictographic# E0.0   [5] (☻..☿)    BLACK SMILING FACE..MERCURY
 2640          ; Extended_Pictographic# E4.0   [1] (♀️)       female sign
-2641          ; Extended_Pictographic# E0.0   [1] (♁)       EARTH
 2642          ; Extended_Pictographic# E4.0   [1] (♂️)       male sign
-2643..2647    ; Extended_Pictographic# E0.0   [5] (♃..♇)    JUPITER..PLUTO
 2648..2653    ; Extended_Pictographic# E0.6  [12] (♈..♓)    Aries..Pisces
-2654..265E    ; Extended_Pictographic# E0.0  [11] (♔..♞)    WHITE CHESS KING..BLACK CHESS KNIGHT
 265F          ; Extended_Pictographic# E11.0  [1] (♟️)       chess pawn
 2660          ; Extended_Pictographic# E0.6   [1] (♠️)       spade suit
-2661..2662    ; Extended_Pictographic# E0.0   [2] (♡..♢)    WHITE HEART SUIT..WHITE DIAMOND SUIT
 2663          ; Extended_Pictographic# E0.6   [1] (♣️)       club suit
-2664          ; Extended_Pictographic# E0.0   [1] (♤)       WHITE SPADE SUIT
 2665..2666    ; Extended_Pictographic# E0.6   [2] (♥️..♦️)    heart suit..diamond suit
-2667          ; Extended_Pictographic# E0.0   [1] (♧)       WHITE CLUB SUIT
 2668          ; Extended_Pictographic# E0.6   [1] (♨️)       hot springs
-2669..267A    ; Extended_Pictographic# E0.0  [18] (♩..♺)    QUARTER NOTE..RECYCLING SYMBOL FOR GENERIC MATERIALS
 267B          ; Extended_Pictographic# E0.6   [1] (♻️)       recycling symbol
-267C..267D    ; Extended_Pictographic# E0.0   [2] (♼..♽)    RECYCLED PAPER SYMBOL..PARTIALLY-RECYCLED PAPER SYMBOL
 267E          ; Extended_Pictographic# E11.0  [1] (♾️)       infinity
 267F          ; Extended_Pictographic# E0.6   [1] (♿)       wheelchair symbol
-2680..2685    ; Extended_Pictographic# E0.0   [6] (⚀..⚅)    DIE FACE-1..DIE FACE-6
-2690..2691    ; Extended_Pictographic# E0.0   [2] (⚐..⚑)    WHITE FLAG..BLACK FLAG
 2692          ; Extended_Pictographic# E1.0   [1] (⚒️)       hammer and pick
 2693          ; Extended_Pictographic# E0.6   [1] (⚓)       anchor
 2694          ; Extended_Pictographic# E1.0   [1] (⚔️)       crossed swords
 2695          ; Extended_Pictographic# E4.0   [1] (⚕️)       medical symbol
 2696..2697    ; Extended_Pictographic# E1.0   [2] (⚖️..⚗️)    balance scale..alembic
-2698          ; Extended_Pictographic# E0.0   [1] (⚘)       FLOWER
 2699          ; Extended_Pictographic# E1.0   [1] (⚙️)       gear
-269A          ; Extended_Pictographic# E0.0   [1] (⚚)       STAFF OF HERMES
 269B..269C    ; Extended_Pictographic# E1.0   [2] (⚛️..⚜️)    atom symbol..fleur-de-lis
-269D..269F    ; Extended_Pictographic# E0.0   [3] (⚝..⚟)    OUTLINED WHITE STAR..THREE LINES CONVERGING LEFT
 26A0..26A1    ; Extended_Pictographic# E0.6   [2] (⚠️..⚡)    warning..high voltage
-26A2..26A6    ; Extended_Pictographic# E0.0   [5] (⚢..⚦)    DOUBLED FEMALE SIGN..MALE WITH STROKE SIGN
 26A7          ; Extended_Pictographic# E13.0  [1] (⚧️)       transgender symbol
-26A8..26A9    ; Extended_Pictographic# E0.0   [2] (⚨..⚩)    VERTICAL MALE WITH STROKE SIGN..HORIZONTAL MALE WITH STROKE SIGN
 26AA..26AB    ; Extended_Pictographic# E0.6   [2] (⚪..⚫)    white circle..black circle
-26AC..26AF    ; Extended_Pictographic# E0.0   [4] (⚬..⚯)    MEDIUM SMALL WHITE CIRCLE..UNMARRIED PARTNERSHIP SYMBOL
 26B0..26B1    ; Extended_Pictographic# E1.0   [2] (⚰️..⚱️)    coffin..funeral urn
-26B2..26BC    ; Extended_Pictographic# E0.0  [11] (⚲..⚼)    NEUTER..SESQUIQUADRATE
 26BD..26BE    ; Extended_Pictographic# E0.6   [2] (⚽..⚾)    soccer ball..baseball
-26BF..26C3    ; Extended_Pictographic# E0.0   [5] (⚿..⛃)    SQUARED KEY..BLACK DRAUGHTS KING
 26C4..26C5    ; Extended_Pictographic# E0.6   [2] (⛄..⛅)    snowman without snow..sun behind cloud
-26C6..26C7    ; Extended_Pictographic# E0.0   [2] (⛆..⛇)    RAIN..BLACK SNOWMAN
 26C8          ; Extended_Pictographic# E0.7   [1] (⛈️)       cloud with lightning and rain
-26C9..26CD    ; Extended_Pictographic# E0.0   [5] (⛉..⛍)    TURNED WHITE SHOGI PIECE..DISABLED CAR
 26CE          ; Extended_Pictographic# E0.6   [1] (⛎)       Ophiuchus
 26CF          ; Extended_Pictographic# E0.7   [1] (⛏️)       pick
-26D0          ; Extended_Pictographic# E0.0   [1] (⛐)       CAR SLIDING
 26D1          ; Extended_Pictographic# E0.7   [1] (⛑️)       rescue worker’s helmet
-26D2          ; Extended_Pictographic# E0.0   [1] (⛒)       CIRCLED CROSSING LANES
 26D3          ; Extended_Pictographic# E0.7   [1] (⛓️)       chains
 26D4          ; Extended_Pictographic# E0.6   [1] (⛔)       no entry
-26D5..26E8    ; Extended_Pictographic# E0.0  [20] (⛕..⛨)    ALTERNATE ONE-WAY LEFT WAY TRAFFIC..BLACK CROSS ON SHIELD
 26E9          ; Extended_Pictographic# E0.7   [1] (⛩️)       shinto shrine
 26EA          ; Extended_Pictographic# E0.6   [1] (⛪)       church
-26EB..26EF    ; Extended_Pictographic# E0.0   [5] (⛫..⛯)    CASTLE..MAP SYMBOL FOR LIGHTHOUSE
 26F0..26F1    ; Extended_Pictographic# E0.7   [2] (⛰️..⛱️)    mountain..umbrella on ground
 26F2..26F3    ; Extended_Pictographic# E0.6   [2] (⛲..⛳)    fountain..flag in hole
 26F4          ; Extended_Pictographic# E0.7   [1] (⛴️)       ferry
 26F5          ; Extended_Pictographic# E0.6   [1] (⛵)       sailboat
-26F6          ; Extended_Pictographic# E0.0   [1] (⛶)       SQUARE FOUR CORNERS
 26F7..26F9    ; Extended_Pictographic# E0.7   [3] (⛷️..⛹️)    skier..person bouncing ball
 26FA          ; Extended_Pictographic# E0.6   [1] (⛺)       tent
-26FB..26FC    ; Extended_Pictographic# E0.0   [2] (⛻..⛼)    JAPANESE BANK SYMBOL..HEADSTONE GRAVEYARD SYMBOL
 26FD          ; Extended_Pictographic# E0.6   [1] (⛽)       fuel pump
-26FE..2701    ; Extended_Pictographic# E0.0   [4] (⛾..✁)    CUP ON BLACK SQUARE..UPPER BLADE SCISSORS
 2702          ; Extended_Pictographic# E0.6   [1] (✂️)       scissors
-2703..2704    ; Extended_Pictographic# E0.0   [2] (✃..✄)    LOWER BLADE SCISSORS..WHITE SCISSORS
 2705          ; Extended_Pictographic# E0.6   [1] (✅)       check mark button
 2708..270C    ; Extended_Pictographic# E0.6   [5] (✈️..✌️)    airplane..victory hand
 270D          ; Extended_Pictographic# E0.7   [1] (✍️)       writing hand
-270E          ; Extended_Pictographic# E0.0   [1] (✎)       LOWER RIGHT PENCIL
 270F          ; Extended_Pictographic# E0.6   [1] (✏️)       pencil
-2710..2711    ; Extended_Pictographic# E0.0   [2] (✐..✑)    UPPER RIGHT PENCIL..WHITE NIB
 2712          ; Extended_Pictographic# E0.6   [1] (✒️)       black nib
 2714          ; Extended_Pictographic# E0.6   [1] (✔️)       check mark
 2716          ; Extended_Pictographic# E0.6   [1] (✖️)       multiply
@@ -975,7 +931,6 @@ E0020..E007F  ; Emoji_Component      # E0.0  [96] (󠀠..󠁿)      tag space..c
 2757          ; Extended_Pictographic# E0.6   [1] (❗)       red exclamation mark
 2763          ; Extended_Pictographic# E1.0   [1] (❣️)       heart exclamation
 2764          ; Extended_Pictographic# E0.6   [1] (❤️)       red heart
-2765..2767    ; Extended_Pictographic# E0.0   [3] (❥..❧)    ROTATED HEAVY BLACK HEART BULLET..ROTATED FLORAL HEART BULLET
 2795..2797    ; Extended_Pictographic# E0.6   [3] (➕..➗)    plus..divide
 27A1          ; Extended_Pictographic# E0.6   [1] (➡️)       right arrow
 27B0          ; Extended_Pictographic# E0.6   [1] (➰)       curly loop
@@ -989,19 +944,19 @@ E0020..E007F  ; Emoji_Component      # E0.0  [96] (󠀠..󠁿)      tag space..c
 303D          ; Extended_Pictographic# E0.6   [1] (〽️)       part alternation mark
 3297          ; Extended_Pictographic# E0.6   [1] (㊗️)       Japanese “congratulations” button
 3299          ; Extended_Pictographic# E0.6   [1] (㊙️)       Japanese “secret” button
-1F000..1F003  ; Extended_Pictographic# E0.0   [4] (🀀..🀃)    MAHJONG TILE EAST WIND..MAHJONG TILE NORTH WIND
 1F004         ; Extended_Pictographic# E0.6   [1] (🀄)       mahjong red dragon
-1F005..1F0CE  ; Extended_Pictographic# E0.0 [202] (🀅..🃎)    MAHJONG TILE GREEN DRAGON..PLAYING CARD KING OF DIAMONDS
+1F02C..1F02F  ; Extended_Pictographic# E0.0   [4] (🀬..🀯)    <reserved-1F02C>..<reserved-1F02F>
+1F094..1F09F  ; Extended_Pictographic# E0.0  [12] (🂔..🂟)    <reserved-1F094>..<reserved-1F09F>
+1F0AF..1F0B0  ; Extended_Pictographic# E0.0   [2] (🂯..🂰)    <reserved-1F0AF>..<reserved-1F0B0>
+1F0C0         ; Extended_Pictographic# E0.0   [1] (🃀)       <reserved-1F0C0>
 1F0CF         ; Extended_Pictographic# E0.6   [1] (🃏)       joker
-1F0D0..1F0FF  ; Extended_Pictographic# E0.0  [48] (🃐..🃿)    <reserved-1F0D0>..<reserved-1F0FF>
-1F10D..1F10F  ; Extended_Pictographic# E0.0   [3] (🄍..🄏)    CIRCLED ZERO WITH SLASH..CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH
-1F12F         ; Extended_Pictographic# E0.0   [1] (🄯)       COPYLEFT SYMBOL
-1F16C..1F16F  ; Extended_Pictographic# E0.0   [4] (🅬..🅯)    RAISED MR SIGN..CIRCLED HUMAN FIGURE
+1F0D0         ; Extended_Pictographic# E0.0   [1] (🃐)       <reserved-1F0D0>
+1F0F6..1F0FF  ; Extended_Pictographic# E0.0  [10] (🃶..🃿)    <reserved-1F0F6>..<reserved-1F0FF>
 1F170..1F171  ; Extended_Pictographic# E0.6   [2] (🅰️..🅱️)    A button (blood type)..B button (blood type)
 1F17E..1F17F  ; Extended_Pictographic# E0.6   [2] (🅾️..🅿️)    O button (blood type)..P button
 1F18E         ; Extended_Pictographic# E0.6   [1] (🆎)       AB button (blood type)
 1F191..1F19A  ; Extended_Pictographic# E0.6  [10] (🆑..🆚)    CL button..VS button
-1F1AD..1F1E5  ; Extended_Pictographic# E0.0  [57] (🆭..🇥)    MASK WORK SYMBOL..<reserved-1F1E5>
+1F1AE..1F1E5  ; Extended_Pictographic# E0.0  [56] (🆮..🇥)    <reserved-1F1AE>..<reserved-1F1E5>
 1F201..1F202  ; Extended_Pictographic# E0.6   [2] (🈁..🈂️)    Japanese “here” button..Japanese “service charge” button
 1F203..1F20F  ; Extended_Pictographic# E0.0  [13] (🈃..🈏)    <reserved-1F203>..<reserved-1F20F>
 1F21A         ; Extended_Pictographic# E0.6   [1] (🈚)       Japanese “free of charge” button
@@ -1010,7 +965,8 @@ E0020..E007F  ; Emoji_Component      # E0.0  [96] (󠀠..󠁿)      tag space..c
 1F23C..1F23F  ; Extended_Pictographic# E0.0   [4] (🈼..🈿)    <reserved-1F23C>..<reserved-1F23F>
 1F249..1F24F  ; Extended_Pictographic# E0.0   [7] (🉉..🉏)    <reserved-1F249>..<reserved-1F24F>
 1F250..1F251  ; Extended_Pictographic# E0.6   [2] (🉐..🉑)    Japanese “bargain” button..Japanese “acceptable” button
-1F252..1F2FF  ; Extended_Pictographic# E0.0 [174] (🉒..🋿)    <reserved-1F252>..<reserved-1F2FF>
+1F252..1F25F  ; Extended_Pictographic# E0.0  [14] (🉒..🉟)    <reserved-1F252>..<reserved-1F25F>
+1F266..1F2FF  ; Extended_Pictographic# E0.0 [154] (🉦..🋿)    <reserved-1F266>..<reserved-1F2FF>
 1F300..1F30C  ; Extended_Pictographic# E0.6  [13] (🌀..🌌)    cyclone..milky way
 1F30D..1F30E  ; Extended_Pictographic# E0.7   [2] (🌍..🌎)    globe showing Europe-Africa..globe showing Americas
 1F30F         ; Extended_Pictographic# E0.6   [1] (🌏)       globe showing Asia-Australia
@@ -1026,7 +982,6 @@ E0020..E007F  ; Emoji_Component      # E0.0  [96] (󠀠..󠁿)      tag space..c
 1F31D..1F31E  ; Extended_Pictographic# E1.0   [2] (🌝..🌞)    full moon face..sun with face
 1F31F..1F320  ; Extended_Pictographic# E0.6   [2] (🌟..🌠)    glowing star..shooting star
 1F321         ; Extended_Pictographic# E0.7   [1] (🌡️)       thermometer
-1F322..1F323  ; Extended_Pictographic# E0.0   [2] (🌢..🌣)    BLACK DROPLET..WHITE SUN
 1F324..1F32C  ; Extended_Pictographic# E0.7   [9] (🌤️..🌬️)    sun behind small cloud..wind face
 1F32D..1F32F  ; Extended_Pictographic# E1.0   [3] (🌭..🌯)    hot dog..burrito
 1F330..1F331  ; Extended_Pictographic# E0.6   [2] (🌰..🌱)    chestnut..seedling
@@ -1042,11 +997,8 @@ E0020..E007F  ; Emoji_Component      # E0.0  [96] (󠀠..󠁿)      tag space..c
 1F37D         ; Extended_Pictographic# E0.7   [1] (🍽️)       fork and knife with plate
 1F37E..1F37F  ; Extended_Pictographic# E1.0   [2] (🍾..🍿)    bottle with popping cork..popcorn
 1F380..1F393  ; Extended_Pictographic# E0.6  [20] (🎀..🎓)    ribbon..graduation cap
-1F394..1F395  ; Extended_Pictographic# E0.0   [2] (🎔..🎕)    HEART WITH TIP ON THE LEFT..BOUQUET OF FLOWERS
 1F396..1F397  ; Extended_Pictographic# E0.7   [2] (🎖️..🎗️)    military medal..reminder ribbon
-1F398         ; Extended_Pictographic# E0.0   [1] (🎘)       MUSICAL KEYBOARD WITH JACKS
 1F399..1F39B  ; Extended_Pictographic# E0.7   [3] (🎙️..🎛️)    studio microphone..control knobs
-1F39C..1F39D  ; Extended_Pictographic# E0.0   [2] (🎜..🎝)    BEAMED ASCENDING MUSICAL NOTES..BEAMED DESCENDING MUSICAL NOTES
 1F39E..1F39F  ; Extended_Pictographic# E0.7   [2] (🎞️..🎟️)    film frames..admission tickets
 1F3A0..1F3C4  ; Extended_Pictographic# E0.6  [37] (🎠..🏄)    carousel horse..person surfing
 1F3C5         ; Extended_Pictographic# E1.0   [1] (🏅)       sports medal
@@ -1061,11 +1013,9 @@ E0020..E007F  ; Emoji_Component      # E0.0  [96] (󠀠..󠁿)      tag space..c
 1F3E0..1F3E3  ; Extended_Pictographic# E0.6   [4] (🏠..🏣)    house..Japanese post office
 1F3E4         ; Extended_Pictographic# E1.0   [1] (🏤)       post office
 1F3E5..1F3F0  ; Extended_Pictographic# E0.6  [12] (🏥..🏰)    hospital..castle
-1F3F1..1F3F2  ; Extended_Pictographic# E0.0   [2] (🏱..🏲)    WHITE PENNANT..BLACK PENNANT
 1F3F3         ; Extended_Pictographic# E0.7   [1] (🏳️)       white flag
 1F3F4         ; Extended_Pictographic# E1.0   [1] (🏴)       black flag
 1F3F5         ; Extended_Pictographic# E0.7   [1] (🏵️)       rosette
-1F3F6         ; Extended_Pictographic# E0.0   [1] (🏶)       BLACK ROSETTE
 1F3F7         ; Extended_Pictographic# E0.7   [1] (🏷️)       label
 1F3F8..1F3FA  ; Extended_Pictographic# E1.0   [3] (🏸..🏺)    badminton..amphora
 1F400..1F407  ; Extended_Pictographic# E1.0   [8] (🐀..🐇)    rat..rabbit
@@ -1102,7 +1052,6 @@ E0020..E007F  ; Emoji_Component      # E0.0  [96] (󠀠..󠁿)      tag space..c
 1F4F8         ; Extended_Pictographic# E1.0   [1] (📸)       camera with flash
 1F4F9..1F4FC  ; Extended_Pictographic# E0.6   [4] (📹..📼)    video camera..videocassette
 1F4FD         ; Extended_Pictographic# E0.7   [1] (📽️)       film projector
-1F4FE         ; Extended_Pictographic# E0.0   [1] (📾)       PORTABLE STEREO
 1F4FF..1F502  ; Extended_Pictographic# E1.0   [4] (📿..🔂)    prayer beads..repeat single button
 1F503         ; Extended_Pictographic# E0.6   [1] (🔃)       clockwise vertical arrows
 1F504..1F507  ; Extended_Pictographic# E1.0   [4] (🔄..🔇)    counterclockwise arrows button..muted speaker
@@ -1113,51 +1062,30 @@ E0020..E007F  ; Emoji_Component      # E0.0  [96] (󠀠..󠁿)      tag space..c
 1F516..1F52B  ; Extended_Pictographic# E0.6  [22] (🔖..🔫)    bookmark..water pistol
 1F52C..1F52D  ; Extended_Pictographic# E1.0   [2] (🔬..🔭)    microscope..telescope
 1F52E..1F53D  ; Extended_Pictographic# E0.6  [16] (🔮..🔽)    crystal ball..downwards button
-1F546..1F548  ; Extended_Pictographic# E0.0   [3] (🕆..🕈)    WHITE LATIN CROSS..CELTIC CROSS
 1F549..1F54A  ; Extended_Pictographic# E0.7   [2] (🕉️..🕊️)    om..dove
 1F54B..1F54E  ; Extended_Pictographic# E1.0   [4] (🕋..🕎)    kaaba..menorah
-1F54F         ; Extended_Pictographic# E0.0   [1] (🕏)       BOWL OF HYGIEIA
 1F550..1F55B  ; Extended_Pictographic# E0.6  [12] (🕐..🕛)    one o’clock..twelve o’clock
 1F55C..1F567  ; Extended_Pictographic# E0.7  [12] (🕜..🕧)    one-thirty..twelve-thirty
-1F568..1F56E  ; Extended_Pictographic# E0.0   [7] (🕨..🕮)    RIGHT SPEAKER..BOOK
 1F56F..1F570  ; Extended_Pictographic# E0.7   [2] (🕯️..🕰️)    candle..mantelpiece clock
-1F571..1F572  ; Extended_Pictographic# E0.0   [2] (🕱..🕲)    BLACK SKULL AND CROSSBONES..NO PIRACY
 1F573..1F579  ; Extended_Pictographic# E0.7   [7] (🕳️..🕹️)    hole..joystick
 1F57A         ; Extended_Pictographic# E3.0   [1] (🕺)       man dancing
-1F57B..1F586  ; Extended_Pictographic# E0.0  [12] (🕻..🖆)    LEFT HAND TELEPHONE RECEIVER..PEN OVER STAMPED ENVELOPE
 1F587         ; Extended_Pictographic# E0.7   [1] (🖇️)       linked paperclips
-1F588..1F589  ; Extended_Pictographic# E0.0   [2] (🖈..🖉)    BLACK PUSHPIN..LOWER LEFT PENCIL
 1F58A..1F58D  ; Extended_Pictographic# E0.7   [4] (🖊️..🖍️)    pen..crayon
-1F58E..1F58F  ; Extended_Pictographic# E0.0   [2] (🖎..🖏)    LEFT WRITING HAND..TURNED OK HAND SIGN
 1F590         ; Extended_Pictographic# E0.7   [1] (🖐️)       hand with fingers splayed
-1F591..1F594  ; Extended_Pictographic# E0.0   [4] (🖑..🖔)    REVERSED RAISED HAND WITH FINGERS SPLAYED..REVERSED VICTORY HAND
 1F595..1F596  ; Extended_Pictographic# E1.0   [2] (🖕..🖖)    middle finger..vulcan salute
-1F597..1F5A3  ; Extended_Pictographic# E0.0  [13] (🖗..🖣)    WHITE DOWN POINTING LEFT HAND INDEX..BLACK DOWN POINTING BACKHAND INDEX
 1F5A4         ; Extended_Pictographic# E3.0   [1] (🖤)       black heart
 1F5A5         ; Extended_Pictographic# E0.7   [1] (🖥️)       desktop computer
-1F5A6..1F5A7  ; Extended_Pictographic# E0.0   [2] (🖦..🖧)    KEYBOARD AND MOUSE..THREE NETWORKED COMPUTERS
 1F5A8         ; Extended_Pictographic# E0.7   [1] (🖨️)       printer
-1F5A9..1F5B0  ; Extended_Pictographic# E0.0   [8] (🖩..🖰)    POCKET CALCULATOR..TWO BUTTON MOUSE
 1F5B1..1F5B2  ; Extended_Pictographic# E0.7   [2] (🖱️..🖲️)    computer mouse..trackball
-1F5B3..1F5BB  ; Extended_Pictographic# E0.0   [9] (🖳..🖻)    OLD PERSONAL COMPUTER..DOCUMENT WITH PICTURE
 1F5BC         ; Extended_Pictographic# E0.7   [1] (🖼️)       framed picture
-1F5BD..1F5C1  ; Extended_Pictographic# E0.0   [5] (🖽..🗁)    FRAME WITH TILES..OPEN FOLDER
 1F5C2..1F5C4  ; Extended_Pictographic# E0.7   [3] (🗂️..🗄️)    card index dividers..file cabinet
-1F5C5..1F5D0  ; Extended_Pictographic# E0.0  [12] (🗅..🗐)    EMPTY NOTE..PAGES
 1F5D1..1F5D3  ; Extended_Pictographic# E0.7   [3] (🗑️..🗓️)    wastebasket..spiral calendar
-1F5D4..1F5DB  ; Extended_Pictographic# E0.0   [8] (🗔..🗛)    DESKTOP WINDOW..DECREASE FONT SIZE SYMBOL
 1F5DC..1F5DE  ; Extended_Pictographic# E0.7   [3] (🗜️..🗞️)    clamp..rolled-up newspaper
-1F5DF..1F5E0  ; Extended_Pictographic# E0.0   [2] (🗟..🗠)    PAGE WITH CIRCLED TEXT..STOCK CHART
 1F5E1         ; Extended_Pictographic# E0.7   [1] (🗡️)       dagger
-1F5E2         ; Extended_Pictographic# E0.0   [1] (🗢)       LIPS
 1F5E3         ; Extended_Pictographic# E0.7   [1] (🗣️)       speaking head
-1F5E4..1F5E7  ; Extended_Pictographic# E0.0   [4] (🗤..🗧)    THREE RAYS ABOVE..THREE RAYS RIGHT
 1F5E8         ; Extended_Pictographic# E2.0   [1] (🗨️)       left speech bubble
-1F5E9..1F5EE  ; Extended_Pictographic# E0.0   [6] (🗩..🗮)    RIGHT SPEECH BUBBLE..LEFT ANGER BUBBLE
 1F5EF         ; Extended_Pictographic# E0.7   [1] (🗯️)       right anger bubble
-1F5F0..1F5F2  ; Extended_Pictographic# E0.0   [3] (🗰..🗲)    MOOD BUBBLE..LIGHTNING MOOD
 1F5F3         ; Extended_Pictographic# E0.7   [1] (🗳️)       ballot box with ballot
-1F5F4..1F5F9  ; Extended_Pictographic# E0.0   [6] (🗴..🗹)    BALLOT SCRIPT X..BALLOT BOX WITH BOLD CHECK
 1F5FA         ; Extended_Pictographic# E0.7   [1] (🗺️)       world map
 1F5FB..1F5FF  ; Extended_Pictographic# E0.6   [5] (🗻..🗿)    mount fuji..moai
 1F600         ; Extended_Pictographic# E1.0   [1] (😀)       grinning face
@@ -1226,13 +1154,11 @@ E0020..E007F  ; Emoji_Component      # E0.0  [96] (󠀠..󠁿)      tag space..c
 1F6BF         ; Extended_Pictographic# E1.0   [1] (🚿)       shower
 1F6C0         ; Extended_Pictographic# E0.6   [1] (🛀)       person taking bath
 1F6C1..1F6C5  ; Extended_Pictographic# E1.0   [5] (🛁..🛅)    bathtub..left luggage
-1F6C6..1F6CA  ; Extended_Pictographic# E0.0   [5] (🛆..🛊)    TRIANGLE WITH ROUNDED CORNERS..GIRLS SYMBOL
 1F6CB         ; Extended_Pictographic# E0.7   [1] (🛋️)       couch and lamp
 1F6CC         ; Extended_Pictographic# E1.0   [1] (🛌)       person in bed
 1F6CD..1F6CF  ; Extended_Pictographic# E0.7   [3] (🛍️..🛏️)    shopping bags..bed
 1F6D0         ; Extended_Pictographic# E1.0   [1] (🛐)       place of worship
 1F6D1..1F6D2  ; Extended_Pictographic# E3.0   [2] (🛑..🛒)    stop sign..shopping cart
-1F6D3..1F6D4  ; Extended_Pictographic# E0.0   [2] (🛓..🛔)    STUPA..PAGODA
 1F6D5         ; Extended_Pictographic# E12.0  [1] (🛕)       hindu temple
 1F6D6..1F6D7  ; Extended_Pictographic# E13.0  [2] (🛖..🛗)    hut..elevator
 1F6D8         ; Extended_Pictographic# E17.0  [1] (🛘)       landslide
@@ -1240,13 +1166,10 @@ E0020..E007F  ; Emoji_Component      # E0.0  [96] (󠀠..󠁿)      tag space..c
 1F6DC         ; Extended_Pictographic# E15.0  [1] (🛜)       wireless
 1F6DD..1F6DF  ; Extended_Pictographic# E14.0  [3] (🛝..🛟)    playground slide..ring buoy
 1F6E0..1F6E5  ; Extended_Pictographic# E0.7   [6] (🛠️..🛥️)    hammer and wrench..motor boat
-1F6E6..1F6E8  ; Extended_Pictographic# E0.0   [3] (🛦..🛨)    UP-POINTING MILITARY AIRPLANE..UP-POINTING SMALL AIRPLANE
 1F6E9         ; Extended_Pictographic# E0.7   [1] (🛩️)       small airplane
-1F6EA         ; Extended_Pictographic# E0.0   [1] (🛪)       NORTHEAST-POINTING AIRPLANE
 1F6EB..1F6EC  ; Extended_Pictographic# E1.0   [2] (🛫..🛬)    airplane departure..airplane arrival
 1F6ED..1F6EF  ; Extended_Pictographic# E0.0   [3] (🛭..🛯)    <reserved-1F6ED>..<reserved-1F6EF>
 1F6F0         ; Extended_Pictographic# E0.7   [1] (🛰️)       satellite
-1F6F1..1F6F2  ; Extended_Pictographic# E0.0   [2] (🛱..🛲)    ONCOMING FIRE ENGINE..DIESEL LOCOMOTIVE
 1F6F3         ; Extended_Pictographic# E0.7   [1] (🛳️)       passenger ship
 1F6F4..1F6F6  ; Extended_Pictographic# E3.0   [3] (🛴..🛶)    kick scooter..canoe
 1F6F7..1F6F8  ; Extended_Pictographic# E5.0   [2] (🛷..🛸)    sled..flying saucer
@@ -1254,8 +1177,7 @@ E0020..E007F  ; Emoji_Component      # E0.0  [96] (󠀠..󠁿)      tag space..c
 1F6FA         ; Extended_Pictographic# E12.0  [1] (🛺)       auto rickshaw
 1F6FB..1F6FC  ; Extended_Pictographic# E13.0  [2] (🛻..🛼)    pickup truck..roller skate
 1F6FD..1F6FF  ; Extended_Pictographic# E0.0   [3] (🛽..🛿)    <reserved-1F6FD>..<reserved-1F6FF>
-1F774..1F77F  ; Extended_Pictographic# E0.0  [12] (🝴..🝿)    LOT OF FORTUNE..ORCUS
-1F7D5..1F7DF  ; Extended_Pictographic# E0.0  [11] (🟕..🟟)    CIRCLED TRIANGLE..<reserved-1F7DF>
+1F7DA..1F7DF  ; Extended_Pictographic# E0.0   [6] (🟚..🟟)    <reserved-1F7DA>..<reserved-1F7DF>
 1F7E0..1F7EB  ; Extended_Pictographic# E12.0 [12] (🟠..🟫)    orange circle..brown square
 1F7EC..1F7EF  ; Extended_Pictographic# E0.0   [4] (🟬..🟯)    <reserved-1F7EC>..<reserved-1F7EF>
 1F7F0         ; Extended_Pictographic# E14.0  [1] (🟰)       heavy equals sign
@@ -1264,7 +1186,10 @@ E0020..E007F  ; Emoji_Component      # E0.0  [96] (󠀠..󠁿)      tag space..c
 1F848..1F84F  ; Extended_Pictographic# E0.0   [8] (🡈..🡏)    <reserved-1F848>..<reserved-1F84F>
 1F85A..1F85F  ; Extended_Pictographic# E0.0   [6] (🡚..🡟)    <reserved-1F85A>..<reserved-1F85F>
 1F888..1F88F  ; Extended_Pictographic# E0.0   [8] (🢈..🢏)    <reserved-1F888>..<reserved-1F88F>
-1F8AE..1F8FF  ; Extended_Pictographic# E0.0  [82] (🢮..🣿)    <reserved-1F8AE>..<reserved-1F8FF>
+1F8AE..1F8AF  ; Extended_Pictographic# E0.0   [2] (🢮..🢯)    <reserved-1F8AE>..<reserved-1F8AF>
+1F8BC..1F8BF  ; Extended_Pictographic# E0.0   [4] (🢼..🢿)    <reserved-1F8BC>..<reserved-1F8BF>
+1F8C2..1F8CF  ; Extended_Pictographic# E0.0  [14] (🣂..🣏)    <reserved-1F8C2>..<reserved-1F8CF>
+1F8D9..1F8FF  ; Extended_Pictographic# E0.0  [39] (🣙..🣿)    <reserved-1F8D9>..<reserved-1F8FF>
 1F90C         ; Extended_Pictographic# E13.0  [1] (🤌)       pinched fingers
 1F90D..1F90F  ; Extended_Pictographic# E12.0  [3] (🤍..🤏)    white heart..pinching hand
 1F910..1F918  ; Extended_Pictographic# E1.0   [9] (🤐..🤘)    zipper-mouth face..sign of the horns
@@ -1310,7 +1235,8 @@ E0020..E007F  ; Emoji_Component      # E0.0  [96] (󠀠..󠁿)      tag space..c
 1F9CD..1F9CF  ; Extended_Pictographic# E12.0  [3] (🧍..🧏)    person standing..deaf person
 1F9D0..1F9E6  ; Extended_Pictographic# E5.0  [23] (🧐..🧦)    face with monocle..socks
 1F9E7..1F9FF  ; Extended_Pictographic# E11.0 [25] (🧧..🧿)    red envelope..nazar amulet
-1FA00..1FA6F  ; Extended_Pictographic# E0.0 [112] (🨀..🩯)    NEUTRAL CHESS KING..<reserved-1FA6F>
+1FA58..1FA5F  ; Extended_Pictographic# E0.0   [8] (🩘..🩟)    <reserved-1FA58>..<reserved-1FA5F>
+1FA6E..1FA6F  ; Extended_Pictographic# E0.0   [2] (🩮..🩯)    <reserved-1FA6E>..<reserved-1FA6F>
 1FA70..1FA73  ; Extended_Pictographic# E12.0  [4] (🩰..🩳)    ballet shoes..shorts
 1FA74         ; Extended_Pictographic# E13.0  [1] (🩴)       thong sandal
 1FA75..1FA77  ; Extended_Pictographic# E15.0  [3] (🩵..🩷)    light blue heart..pink heart
@@ -1360,6 +1286,6 @@ E0020..E007F  ; Emoji_Component      # E0.0  [96] (󠀠..󠁿)      tag space..c
 1FAF9..1FAFF  ; Extended_Pictographic# E0.0   [7] (🫹..🫿)    <reserved-1FAF9>..<reserved-1FAFF>
 1FC00..1FFFD  ; Extended_Pictographic# E0.0[1022] (🰀..🿽)    <reserved-1FC00>..<reserved-1FFFD>
 
-# Total elements: 3537
+# Total elements: 2848
 
 #EOF

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/GenerateEmojiData.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/GenerateEmojiData.java
@@ -253,40 +253,6 @@ public class GenerateEmojiData {
                 System.out.println(
                         CandidateData.getInstance().getExtendedPictographic().contains("🦰"));
             UnicodeSet emoji_pict = emojiDataSource.getExtendedPictographic();
-            UnicodeSet emoji_pict_to_remove =
-                    emoji_pict
-                            .cloneAsThawed()
-                            .removeAll(iup.getProperty(UcdProperty.General_Category).getSet("Cn"))
-                            .removeAll(emoji)
-                            .freeze();
-            UnicodeSet emoji_pict_to_remove_16 =
-                    emoji_pict_to_remove
-                            .cloneAsThawed()
-                            .removeAll(
-                                    IndexUnicodeProperties.make(Age_Values.V16_0)
-                                            .getProperty(UcdProperty.General_Category)
-                                            .getSet("Cn"))
-                            .freeze();
-            if (emoji_pict_to_remove_16.size() != 672) {
-                throw new IllegalArgumentException(emoji_pict_to_remove_16.toString());
-            }
-            System.out.println(
-                    "Unassigning Extended_Pictographic from "
-                            + emoji_pict_to_remove.size()
-                            + " characters, including 672 characters present in 16.0, as well as:");
-            emoji_pict = emoji_pict.cloneAsThawed().removeAll(emoji_pict_to_remove).freeze();
-            var out = new PrintWriter(System.out);
-            printer.show(
-                    out,
-                    "",
-                    null,
-                    0,
-                    14,
-                    emoji_pict_to_remove.cloneAsThawed().removeAll(emoji_pict_to_remove_16),
-                    true,
-                    false,
-                    false);
-            out.flush();
             outText2.println(
                     Utility.getBaseDataHeaderWithVersionText(
                             "emoji-data", 51, "Emoji Data", versionTextForUCD));

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/GenerateEmojiData.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/GenerateEmojiData.java
@@ -253,6 +253,40 @@ public class GenerateEmojiData {
                 System.out.println(
                         CandidateData.getInstance().getExtendedPictographic().contains("🦰"));
             UnicodeSet emoji_pict = emojiDataSource.getExtendedPictographic();
+            UnicodeSet emoji_pict_to_remove =
+                    emoji_pict
+                            .cloneAsThawed()
+                            .removeAll(iup.getProperty(UcdProperty.General_Category).getSet("Cn"))
+                            .removeAll(emoji)
+                            .freeze();
+            UnicodeSet emoji_pict_to_remove_16 =
+                    emoji_pict_to_remove
+                            .cloneAsThawed()
+                            .removeAll(
+                                    IndexUnicodeProperties.make(Age_Values.V16_0)
+                                            .getProperty(UcdProperty.General_Category)
+                                            .getSet("Cn"))
+                            .freeze();
+            if (emoji_pict_to_remove_16.size() != 672) {
+                throw new IllegalArgumentException(emoji_pict_to_remove_16.toString());
+            }
+            System.out.println(
+                    "Unassigning Extended_Pictographic from "
+                            + emoji_pict_to_remove.size()
+                            + " characters, including 672 characters present in 16.0, as well as:");
+            emoji_pict = emoji_pict.cloneAsThawed().removeAll(emoji_pict_to_remove).freeze();
+            var out = new PrintWriter(System.out);
+            printer.show(
+                    out,
+                    "",
+                    null,
+                    0,
+                    14,
+                    emoji_pict_to_remove.cloneAsThawed().removeAll(emoji_pict_to_remove_16),
+                    true,
+                    false,
+                    false);
+            out.flush();
             outText2.println(
                     Utility.getBaseDataHeaderWithVersionText(
                             "emoji-data", 51, "Emoji Data", versionTextForUCD));

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
@@ -1090,6 +1090,13 @@ Let $HairComponents := [\U0001F9B0-\U0001F9B3]
 \p{U13.1:RGI_Emoji_Zwj_Sequence} ⊃ \p{U13:RGI_Emoji_Zwj_Sequence}
 [\p{U13.1:RGI_Emoji_Zwj_Sequence} - \p{U13:RGI_Emoji_Zwj_Sequence}] ⊃ [{😵‍💫}]
 
+# [182-C20] Consensus: Unassign the Extended_Pictographic property from the 672 assigned characters
+#           that do not have the Emoji property. For Unicode Version 17.0. See L2/25-006 item 5.1.
+# The only assigned characters that are Extended_Pictographic are Emoji.
+[\p{Extended_Pictographic}-\p{gc=Cn}] ⊆ \p{Emoji}
+# And nearly all emoji are Extended_Pictographic.
+[\p{Extended_Pictographic}-\p{gc=Cn}] = [\p{Emoji}-\p{Regional_Indicator}-\p{Emoji_Modifier}-\p{Block=Basic Latin}]
+
 ##########################
 # POSIX Compatibility Properties (UTS#18)
 # http://www.opengroup.org/onlinepubs/007904975/basedefs/xbd_chap07.html


### PR DESCRIPTION
**[[182-C20](https://www.unicode.org/cgi-bin/GetL2Ref.pl?182-C20)] Consensus:** Unassign the Extended_Pictographic property from the 672 assigned characters that do not have the Emoji property. For Unicode Version 17.0. See [L2/25-006](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/25-006) item 5.1.

**[[182-A57](https://www.unicode.org/cgi-bin/GetL2Ref.pl?182-A57)] Action Item for** Robin Leroy, PAG: In UCD file emoji-data.txt, unassign the Extended_Pictographic property from the 672 assigned characters that do not have the Emoji property. For Unicode Version 17.0. See [L2/25-006](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/25-006) item 5.1.

emoji-data.txt being generated from itself, this was done by regenerating it with the patch in https://github.com/unicode-org/unicodetools/commit/8a59f480e3113b564b3cc134d05904e41c10f94a (reverted afterwards).

The output was:
```
Unassigning Extended_Pictographic from 689 characters, including 672 characters present in 16.0, as well as:

# ================================================

#

1F777..1F77A      # E0.0   [4] (🝷..🝺)    VESTA FORM TWO..PARTHENOPE FORM TWO
1F8D0..1F8D8      # E0.0   [9] (🣐..🣘)    LONG RIGHTWARDS ARROW OVER LONG LEFTWARDS ARROW..LONG LEFT RIGHT ARROW WITH DEPENDENT LOBE
1FA54..1FA57      # E0.0   [4] (🩔..🩗)    WHITE CHESS FERZ..BLACK CHESS ALFIL

# Total elements: 17
Found difference in : C:\Users\robin\Projects\Unicode\unicodetools\unicodetools\data\ucd\dev\emoji\emoji-data.txt, C:\Users\robin\Projects\Unicode\unicodetools\unicodetools\data\ucd\dev\emoji\49238-emoji-data.txt
 File1: '23', '88          ; Extended_Pictographic# E0.0   [1] (⎈)       HELM SYMBOL'
 File2: '23', 'CF          ; Extended_Pictographic# E1.0   [1] (⏏️)       eject button'
```