### PR TITLE
UCD 17 VerticalOrientation.txt jan29

### DIFF
--- a/unicodetools/data/ucd/dev/VerticalOrientation.txt
+++ b/unicodetools/data/ucd/dev/VerticalOrientation.txt
@@ -1,5 +1,5 @@
 # VerticalOrientation-17.0.0.txt
-# Date: 2025-01-29, 10:33:13 GMT [KW]
+# Date: 2025-01-29
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -853,9 +853,9 @@
 200B..200F     ; R  # Cf     [5] ZERO WIDTH SPACE..RIGHT-TO-LEFT MARK
 2010..2015     ; R  # Pd     [6] HYPHEN..HORIZONTAL BAR
 2016           ; U  # Po         DOUBLE VERTICAL LINE
-2017           ; Tr # Po         DOUBLE LOW LINE
+2017           ; R  # Po         DOUBLE LOW LINE
 2018           ; Tr # Pi         LEFT SINGLE QUOTATION MARK
-2019           ; R  # Pf         RIGHT SINGLE QUOTATION MARK
+2019           ; Tr # Pf         RIGHT SINGLE QUOTATION MARK
 201A           ; R  # Ps         SINGLE LOW-9 QUOTATION MARK
 201B           ; R  # Pi         SINGLE HIGH-REVERSED-9 QUOTATION MARK
 201C           ; Tr # Pi         LEFT DOUBLE QUOTATION MARK

--- a/unicodetools/data/ucd/dev/VerticalOrientation.txt
+++ b/unicodetools/data/ucd/dev/VerticalOrientation.txt
@@ -1,5 +1,5 @@
 # VerticalOrientation-17.0.0.txt
-# Date: 2025-01-23, 17:11:05 GMT [KW]
+# Date: 2025-01-29, 10:33:13 GMT [KW]
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -853,12 +853,13 @@
 200B..200F     ; R  # Cf     [5] ZERO WIDTH SPACE..RIGHT-TO-LEFT MARK
 2010..2015     ; R  # Pd     [6] HYPHEN..HORIZONTAL BAR
 2016           ; U  # Po         DOUBLE VERTICAL LINE
-2017           ; R  # Po         DOUBLE LOW LINE
-2018           ; R  # Pi         LEFT SINGLE QUOTATION MARK
+2017           ; Tr # Po         DOUBLE LOW LINE
+2018           ; Tr # Pi         LEFT SINGLE QUOTATION MARK
 2019           ; R  # Pf         RIGHT SINGLE QUOTATION MARK
 201A           ; R  # Ps         SINGLE LOW-9 QUOTATION MARK
-201B..201C     ; R  # Pi     [2] SINGLE HIGH-REVERSED-9 QUOTATION MARK..LEFT DOUBLE QUOTATION MARK
-201D           ; R  # Pf         RIGHT DOUBLE QUOTATION MARK
+201B           ; R  # Pi         SINGLE HIGH-REVERSED-9 QUOTATION MARK
+201C           ; Tr # Pi         LEFT DOUBLE QUOTATION MARK
+201D           ; Tr # Pf         RIGHT DOUBLE QUOTATION MARK
 201E           ; R  # Ps         DOUBLE LOW-9 QUOTATION MARK
 201F           ; R  # Pi         DOUBLE HIGH-REVERSED-9 QUOTATION MARK
 2020..2021     ; U  # Po     [2] DAGGER..DOUBLE DAGGER


### PR DESCRIPTION
[[182-A97](https://www.unicode.org/cgi-bin/GetL2Ref.pl?182-A97)] Action Item for Markus Scherer, PAG: Change the Vertical_Orientation property values of U+2018 LEFT SINGLE QUOTATION MARK, U+2019 RIGHT SINGLE QUOTATION MARK, U+201C LEFT DOUBLE QUOTATION MARK, and U+201D RIGHT DOUBLE QUOTATION MARK from R to Tr, based on document [L2/25-028](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/25-028) and Section 16 of document [L2/25-009](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/25-009), for Unicode Version 17.0.

Starting with @Ken-Whistler 's VerticalOrientation-17.0.0d3.txt but that changed U+2017 DOUBLE LOW LINE instead of U+2019 RIGHT SINGLE QUOTATION MARK, so my second commit fixes these two. I intend to squash-and-merge these changes.