### PR TITLE
It’s α now.

### DIFF
--- a/unicodetools/src/main/java/org/unicode/text/utility/Settings.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/Settings.java
@@ -41,7 +41,7 @@ public class Settings {
         }
     };
 
-    public static final ReleasePhase latestVersionPhase = ReleasePhase.DEV;
+    public static final ReleasePhase latestVersionPhase = ReleasePhase.ALPHA;
 
     public static final String lastVersion = "16.0.0"; // last released version
 


### PR DESCRIPTION
The same procedure as #702.

Unicode 17.0 BRS Α3b.