### PR TITLE
Fix typo in DoNotEmit.txt comments

### DIFF
--- a/unicodetools/data/ucd/dev/DoNotEmit.txt
+++ b/unicodetools/data/ucd/dev/DoNotEmit.txt
@@ -94,7 +94,7 @@
 #    Miscellaneous characters and sequences discouraged in the
 #    Unicode Standard.
 # Preferred_Spelling:
-#    Miscellaneous characters and sequeences for which the Unicode Standard
+#    Miscellaneous characters and sequences for which the Unicode Standard
 #    specifies a preferred spelling.
 
 # ================================================


### PR DESCRIPTION
Fix typo reported by Ole Begemann in public feedback ID20250225044103.

See https://github.com/unicode-org/properties/issues/385