### PR TITLE
Don’t invert twice on comparison queries

### DIFF
--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeSetUtilities.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeSetUtilities.java
@@ -264,6 +264,8 @@ public class UnicodeSetUtilities {
                     otherProperty = factory.getProperty(otherPropName);
                 }
             }
+            // TODO(egg): Name and Name_Alias require special handling (UAX44-LM2), and
+            // treating Name_Alias as aliases for Name.
             boolean isAge = UnicodeProperty.equalNames("age", propertyName);
             if (prop != null) {
                 UnicodeSet set;

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeSetUtilities.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeSetUtilities.java
@@ -250,13 +250,16 @@ public class UnicodeSetUtilities {
             }
             UnicodeProperty otherProperty = null;
             boolean testCp = false;
+            boolean testNone = false;
             if (trimmedPropertyValue.length() > 1
                     && trimmedPropertyValue.startsWith("@")
                     && trimmedPropertyValue.endsWith("@")) {
                 String otherPropName =
                         trimmedPropertyValue.substring(1, trimmedPropertyValue.length() - 1).trim();
-                if ("cp".equalsIgnoreCase(otherPropName)) {
+                if (UnicodeProperty.equalNames("code point", otherPropName)) {
                     testCp = true;
+                } else if (UnicodeProperty.equalNames("none", otherPropName)) {
+                    testNone = true;
                 } else {
                     otherProperty = factory.getProperty(otherPropName);
                 }
@@ -270,8 +273,12 @@ public class UnicodeSetUtilities {
                         if (invert != UnicodeProperty.equals(i, prop.getValue(i))) {
                             set.add(i);
                         }
+                        invert = false;
                     }
+                } else if (testNone) {
+                    set = prop.getSet(UnicodeProperty.NULL_MATCHER);
                 } else if (otherProperty != null) {
+                    System.err.println(otherProperty + ", " + invert);
                     set = new UnicodeSet();
                     for (int i = 0; i <= 0x10FFFF; ++i) {
                         String v1 = prop.getValue(i);
@@ -279,6 +286,7 @@ public class UnicodeSetUtilities {
                         if (invert != UnicodeProperty.equals(v1, v2)) {
                             set.add(i);
                         }
+                        invert = false;
                     }
                 } else if (patternMatcher == null) {
                     if (!isValid(prop, propertyValue)) {

--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestUnicodeSet.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestUnicodeSet.java
@@ -149,7 +149,7 @@ public class TestUnicodeSet extends TestFmwk2 {
                 "\\P{Uppercase=@Changes_When_Lowercased@}");
 
         checkSetsEqual(
-                "\\p{Uppercase≠@Changes_When_Lowercased@}",
+                "\\p{Is_Uppercase≠@Changes_When_Lowercased@}",
                 "[[\\p{Uppercase}\\p{Changes_When_Lowercased}]-[\\p{Uppercase}&\\p{Changes_When_Lowercased}]]");
     }
 
@@ -161,7 +161,7 @@ public class TestUnicodeSet extends TestFmwk2 {
 
     @Test
     public void TestNullQuery() {
-        checkSetsEqual("\\p{Bidi_Paired_Bracket=@none@}", "\\p{Bidi_Paired_Bracket_Type=None}");
+        checkSetsEqual("\\p{Bidi_Paired_Bracket=@none@}", "\\p{Bidi_Paired_Bracket_Type=Is_None}");
         checkSetsEqual("\\p{Bidi_Paired_Bracket≠@None@}", "\\p{Bidi_Paired_Bracket_Type≠None}");
     }
 

--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestUnicodeSet.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestUnicodeSet.java
@@ -141,6 +141,25 @@ public class TestUnicodeSet extends TestFmwk2 {
         logln(derived);
     }
 
+    @Test
+    public void TestInteriorlyNegatedComparison() {
+        checkProperties("\\p{Uppercase≠@Changes_When_Lowercased@}", "[𝕬-𝖅]");
+        checkSetsEqual(
+                "\\p{Uppercase≠@Changes_When_Lowercased@}",
+                "[[\\p{Uppercase}\\p{Changes_When_Lowercased}]-[\\p{Uppercase}&\\p{Changes_When_Lowercased}]]");
+    }
+
+    @Test
+    public void TestIdentityQuery() {
+        checkSetsEqual("\\p{NFKC_Casefold=@codepoint@}", "\\P{Changes_When_NFKC_Casefolded}");
+        checkSetsEqual("\\p{NFKC_Casefold=@Code_Point@}", "\\P{Changes_When_NFKC_Casefolded}");
+    }
+
+    @Test
+    public void TestNullQuery() {
+        checkSetsEqual("\\p{Bidi_Paired_Bracket=@none@}", "\\p{Bidi_Paired_Bracket_Type=None}");
+    }
+
     //    public void TestAExemplars() {
     //        checkProperties("[:exemplars_en:]", "[a]", "[\u0350]");
     //    }
@@ -380,7 +399,7 @@ public class TestUnicodeSet extends TestFmwk2 {
     public void TestNF() {
         for (String nf : new String[] {"d", "c", "kd", "kc"}) {
             checkSetsEqual("[:isnf" + nf + ":]", "[:nf" + nf + "qc!=N:]");
-            checkSetsEqual("[:isnf" + nf + ":]", "[:tonf" + nf + "=@cp@:]");
+            checkSetsEqual("[:isnf" + nf + ":]", "[:tonf" + nf + "=@code point@:]");
         }
     }
 
@@ -479,7 +498,7 @@ public class TestUnicodeSet extends TestFmwk2 {
         checkProperties("\\p{isNFC}", "[:ASCII:]", "[\u212B]");
         checkProperties("[:isNFC=no:]", "[\u212B]", "[:ASCII:]");
         checkProperties("[:dt!=none:]&[:toNFD=/^\\p{ccc:0}/:]", "[\u00A0]", "[\u0340]");
-        checkProperties("[:toLowercase!=@cp@:]", "[A-Z\u00C0]", "[abc]");
+        checkProperties("[:toLowercase!=@code point@:]", "[A-Z\u00C0]", "[abc]");
         checkProperties("[:toNfkc!=@toNfc@:]", "[\\u00A0]", "[abc]");
 
         String trans1 = Common.NFKC_CF.transform("\u2065");

--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestUnicodeSet.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestUnicodeSet.java
@@ -146,18 +146,23 @@ public class TestUnicodeSet extends TestFmwk2 {
         checkProperties("\\p{Uppercase≠@Changes_When_Lowercased@}", "[𝕬-𝖅]");
         checkSetsEqual(
                 "\\p{Uppercase≠@Changes_When_Lowercased@}",
+                "\\P{Uppercase=@Changes_When_Lowercased@}");
+
+        checkSetsEqual(
+                "\\p{Uppercase≠@Changes_When_Lowercased@}",
                 "[[\\p{Uppercase}\\p{Changes_When_Lowercased}]-[\\p{Uppercase}&\\p{Changes_When_Lowercased}]]");
     }
 
     @Test
     public void TestIdentityQuery() {
-        checkSetsEqual("\\p{NFKC_Casefold=@codepoint@}", "\\P{Changes_When_NFKC_Casefolded}");
-        checkSetsEqual("\\p{NFKC_Casefold=@Code_Point@}", "\\P{Changes_When_NFKC_Casefolded}");
+        checkSetsEqual("\\p{NFKC_Casefold=@code point@}", "\\P{Changes_When_NFKC_Casefolded}");
+        checkSetsEqual("\\p{NFKC_Casefold≠@Code_Point@}", "\\p{Changes_When_NFKC_Casefolded}");
     }
 
     @Test
     public void TestNullQuery() {
         checkSetsEqual("\\p{Bidi_Paired_Bracket=@none@}", "\\p{Bidi_Paired_Bracket_Type=None}");
+        checkSetsEqual("\\p{Bidi_Paired_Bracket≠@None@}", "\\p{Bidi_Paired_Bracket_Type≠None}");
     }
 
     //    public void TestAExemplars() {

--- a/docs/help/list-unicodeset.md
+++ b/docs/help/list-unicodeset.md
@@ -113,7 +113,7 @@ There is a special property "cp" that returns the code point itself. For
 example:
 
 *   Find the characters whose lowercase is different:
-    [`\p{toLowercase!=@cp@}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7BtoLowercase!%3D%40cp%40%7D&g=)
+    [`\p{toLowercase!=@code point@}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7BtoLowercase!%3D%40code%20point%40%7D&g=)
 
 ## **Available Properties**
 
@@ -157,7 +157,7 @@ then set the Group By box to the property name.
     1.  uca (the primary UCA weight -- after the CLDR transforms),
     2.  uca2 (the primary and secondary weights)
 
-Normally, \\p{isX} is equivalent to `\p{toX=@cp@}`. There are some exceptions and
+Normally, \\p{isX} is equivalent to `\p{toX=@code point@}`. There are some exceptions and
 missing cases.
 
 Note: The Unassigned, Surrogate, and Private Use code points are skipped in the

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -691,8 +691,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
         return toSkeleton(a).compareTo(toSkeleton(b));
     }
 
-    /** Utility for managing property & non-string value aliases */
-    // TODO account for special names, tibetan, hangul
+    /** Returns a representative of the equivalence class of source under UAX44-LM3. */
     public static String toSkeleton(String source) {
         if (source == null) return null;
         StringBuffer skeletonBuffer = new StringBuffer();
@@ -712,6 +711,10 @@ public abstract class UnicodeProperty extends UnicodeLabel {
                     skeletonBuffer.append(ch);
                 }
             }
+        }
+        while (skeletonBuffer.subSequence(0, 2).equals("is")) {
+            gotOne = true;
+            skeletonBuffer.delete(0, 2);
         }
         if (!gotOne) return source; // avoid string creation
         return skeletonBuffer.toString();

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -720,7 +720,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
         return skeletonBuffer.toString();
     }
 
-    // get the name skeleton
+    /** Returns a representative of the equivalence class of source under UAX44-LM2. */
     public static String toNameSkeleton(String source) {
         if (source == null) return null;
         StringBuffer result = new StringBuffer();


### PR DESCRIPTION
\p{Uppercase≠@Changes_When_Lowercased@} is currently equal to \p{Uppercase=@Changes_When_Lowercased@} rather than  \P{Uppercase=@Changes_When_Lowercased@}, because it is re-inverted before it is returned.

Also added support for null queries and align identity queries with the working draft (`code point` like in `@missing` lines rather than `cp`, and LM3 matching), and brought LM3 matching up to date with Unicode 6.0, stripping leading `is` (see also https://www.unicode.org/reports/tr44/tr44-6.html#UAX44-LM3, the proposed update https://www.unicode.org/reports/tr44/tr44-5.html#UAX44-LM3, UTC-120-A106, and L2/09-248).