### PR TITLE
Fix versioned GC groupings in the JSPs

### DIFF
--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UcdLoader.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UcdLoader.java
@@ -21,7 +21,7 @@ public class UcdLoader implements javax.servlet.Servlet {
         return oldestLoadedUcd;
     }
 
-    private static synchronized void setOldestLoadedUcd(VersionInfo v) {
+    public static synchronized void setOldestLoadedUcd(VersionInfo v) {
         if (v.compareTo(oldestLoadedUcd) < 0) {
             oldestLoadedUcd = v;
         }

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeSetUtilities.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeSetUtilities.java
@@ -9,6 +9,7 @@ import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ULocale;
 import com.ibm.icu.util.VersionInfo;
 import java.text.ParsePosition;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -221,15 +222,15 @@ public class UnicodeSetUtilities {
             return status;
         }
 
-        private static String[][] COARSE_GENERAL_CATEGORIES = {
-            {"Other", "C", "Cc", "Cf", "Cn", "Co", "Cs"},
-            {"Letter", "L", "Ll", "Lm", "Lo", "Lt", "Lu"},
-            {"Cased_Letter", "LC", "Ll", "Lt", "Lu"},
-            {"Mark", "M", "Mc", "Me", "Mn"},
-            {"Number", "N", "Nd", "Nl", "No"},
-            {"Punctuation", "P", "Pc", "Pd", "Pe", "Pf", "Pi", "Po", "Ps"},
-            {"Symbol", "S", "Sc", "Sk", "Sm", "So"},
-            {"Separator", "Z", "Zl", "Zp", "Zs"},
+        private static String[][][] COARSE_GENERAL_CATEGORIES = {
+            {{"Other", "C"}, {"Cc", "Cf", "Cn", "Co", "Cs"}},
+            {{"Letter", "L"}, {"Ll", "Lm", "Lo", "Lt", "Lu"}},
+            {{"Cased_Letter", "LC"}, {"Ll", "Lt", "Lu"}},
+            {{"Mark", "M", "Combining_Mark"}, {"Mc", "Me", "Mn"}},
+            {{"Number", "N"}, {"Nd", "Nl", "No"}},
+            {{"Punctuation", "P"}, {"Pc", "Pd", "Pe", "Pf", "Pi", "Po", "Ps"}},
+            {{"Symbol", "S"}, {"Sc", "Sk", "Sm", "So"}},
+            {{"Separator", "Z"}, {"Zl", "Zp", "Zs"}},
         };
 
         // TODO(eggrobin): I think this function only ever returns true; might as well make it void.
@@ -304,13 +305,15 @@ public class UnicodeSetUtilities {
                                                 UnicodePropertySymbolTable::parseVersionInfoOrMax));
                     } else {
                         if (prop.getName().equals("General_Category")) {
-                            for (String[] coarseValue : COARSE_GENERAL_CATEGORIES) {
-                                final String longName = coarseValue[0];
-                                final String shortName = coarseValue[1];
-                                if (UnicodeProperty.equalNames(propertyValue, longName)
-                                        || UnicodeProperty.equalNames(propertyValue, shortName)) {
-                                    for (int i = 2; i < coarseValue.length; ++i) {
-                                        prop.getSet(coarseValue[i], result);
+                            for (String[][] coarseValue : COARSE_GENERAL_CATEGORIES) {
+                                final String[] aliases = coarseValue[0];
+                                if (Arrays.stream(aliases)
+                                        .anyMatch(
+                                                a ->
+                                                        UnicodeProperty.equalNames(
+                                                                propertyValue, a))) {
+                                    for (var value : coarseValue[1]) {
+                                        prop.getSet(value, result);
                                     }
                                     return true;
                                 }

--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestUnicodeSet.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestUnicodeSet.java
@@ -145,11 +145,17 @@ public class TestUnicodeSet extends TestFmwk2 {
     }
 
     @Test
-    public void TestGeneralCategoryGroupings() {
+    public void TestGeneralCategoryGroupingsWithIncrementalProperties() {
         IndexUnicodeProperties.useIncrementalProperties();
         UcdLoader.setOldestLoadedUcd(VersionInfo.UNICODE_10_0);
         checkSetsEqual("[\\p{U10:Lu}\\p{U10:Ll}\\p{U10:Lm}\\p{U10:Lt}\\p{U10:Lo}]", "\\p{U10:L}");
         UcdLoader.setOldestLoadedUcd(Settings.LAST_VERSION_INFO);
+    }
+
+    @Test
+    public void TestGeneralCategoryGroupings() {
+        checkSetsEqual("[\\p{Lu}\\p{Ll}\\p{Lm}\\p{Lt}\\p{Lo}]", "\\p{L}");
+        checkSetsEqual("[\\p{Mc}\\p{Me}\\p{Mn}]", "\\p{gc=Combining_Mark}");
     }
 
     //    public void TestAExemplars() {

--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestUnicodeSet.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestUnicodeSet.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -145,6 +146,10 @@ public class TestUnicodeSet extends TestFmwk2 {
     }
 
     @Test
+    @EnabledIfSystemProperty(
+            named = "UNICODETOOLS_TEST_WITH_INCREMENTAL_PROPERTIES",
+            matches = ".*",
+            disabledReason = "Tests with incremental properties must be run separately")
     public void TestGeneralCategoryGroupingsWithIncrementalProperties() {
         IndexUnicodeProperties.useIncrementalProperties();
         UcdLoader.setOldestLoadedUcd(VersionInfo.UNICODE_10_0);

--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestUnicodeSet.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestUnicodeSet.java
@@ -33,11 +33,15 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.opentest4j.TestAbortedException;
 import org.unicode.jsp.CharEncoder;
 import org.unicode.jsp.Common;
+import org.unicode.jsp.UcdLoader;
 import org.unicode.jsp.UnicodeJsp;
 import org.unicode.jsp.UnicodeSetUtilities;
 import org.unicode.jsp.UnicodeUtilities;
 import org.unicode.jsp.XPropertyFactory;
+import org.unicode.props.IndexUnicodeProperties;
 import org.unicode.props.UnicodeProperty;
+import org.unicode.props.UcdPropertyValues.Age_Values;
+import org.unicode.text.utility.Settings;
 
 public class TestUnicodeSet extends TestFmwk2 {
 
@@ -139,6 +143,14 @@ public class TestUnicodeSet extends TestFmwk2 {
         String derived = UnicodeUtilities.getPrettySet(source, false, false);
         assertTrue("contains 00A0", derived.contains("00A0"));
         logln(derived);
+    }
+
+    @Test
+    public void TestGeneralCategoryGroupings() {
+        IndexUnicodeProperties.useIncrementalProperties();
+        UcdLoader.setOldestLoadedUcd(VersionInfo.UNICODE_10_0);
+        checkSetsEqual("[\\p{U10:Lu}\\p{U10:Ll}\\p{U10:Lm}\\p{U10:Lt}\\p{U10:Lo}]", "\\p{U10:L}");
+        UcdLoader.setOldestLoadedUcd(Settings.LAST_VERSION_INFO);
     }
 
     //    public void TestAExemplars() {

--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestUnicodeSet.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestUnicodeSet.java
@@ -40,7 +40,6 @@ import org.unicode.jsp.UnicodeUtilities;
 import org.unicode.jsp.XPropertyFactory;
 import org.unicode.props.IndexUnicodeProperties;
 import org.unicode.props.UnicodeProperty;
-import org.unicode.props.UcdPropertyValues.Age_Values;
 import org.unicode.text.utility.Settings;
 
 public class TestUnicodeSet extends TestFmwk2 {

--- a/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
+++ b/unicodetools/src/main/java/org/unicode/props/IndexUnicodeProperties.java
@@ -795,14 +795,16 @@ public class IndexUnicodeProperties extends UnicodeProperty.Factory {
                 return super.getSet(matcher, result);
             }
             final long start = System.currentTimeMillis();
-            final UnicodeSet baseSet =
-                    baseVersionProperties.getProperty(prop).getSet(matcher, result);
+            final UnicodeSet baseSet = baseVersionProperties.getProperty(prop).getSet(matcher);
             final UnicodeSet matchingInThisVersion =
                     super.getSet(matcher, null).retainAll(getDiffSet());
-            result =
-                    baseSet.addAll(matchingInThisVersion)
-                            .removeAll(
-                                    getDiffSet().cloneAsThawed().removeAll(matchingInThisVersion));
+            baseSet.addAll(matchingInThisVersion)
+                    .removeAll(getDiffSet().cloneAsThawed().removeAll(matchingInThisVersion));
+            if (result == null) {
+                result = baseSet;
+            } else {
+                result.addAll(baseSet);
+            }
             final long stop = System.currentTimeMillis();
             final long Δt_in_ms = stop - start;
             if (Δt_in_ms > 100) {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/UCD_Names.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/UCD_Names.java
@@ -747,17 +747,6 @@ public final class UCD_Names implements UCD_Types {
         // usage)
     };
 
-    static final String[][] SUPER_CATEGORIES = {
-        {"L", "Letter", null, "Ll | Lm | Lo | Lt | Lu"},
-        {"M", "Mark", "Combining_Mark", "Mc | Me | Mn"},
-        {"N", "Number", null, "Nd | Nl | No"},
-        {"Z", "Separator", null, "Zl | Zp | Zs"},
-        {"C", "Other", "cntrl", "Cc | Cf | Cn | Co | Cs"},
-        {"S", "Symbol", null, "Sc | Sk | Sm | So"},
-        {"P", "Punctuation", "punct", "Pc | Pd | Pe | Pf | Pi | Po | Ps"},
-        {"LC", "Cased Letter", null, "Ll | Lt | Lu"},
-    };
-
     public static final Relation<String, String> EXTRA_GENERAL_CATEGORY =
             new Relation<String, String>(new TreeMap<String, Set<String>>(), LinkedHashSet.class);
 


### PR DESCRIPTION
The implementation used getSet with a non-null UnicodeSet parameter, which updated the parameter according to the most recent version of the UCD when using incremental properties.

Unfortunately incremental property storage isn’t nicely testable because turning it on messes with static (and even file) caches, and we cannot turn it on by default because of https://github.com/unicode-org/unicodetools/issues/716.

Also handle the alias Combining_Mark for the gc=M grouping. Apparently it was added in 6.1, see UTC-126-C1.
https://github.com/unicode-org/unicodetools/blob/d29babc389773d9a1630ceac82dc7e8c46e42d4b/unicodetools/data/ucd/6.1.0-Update/PropertyValueAliases.txt#L554 https://github.com/unicode-org/unicodetools/blob/d29babc389773d9a1630ceac82dc7e8c46e42d4b/unicodetools/data/ucd/6.0.0-Update/PropertyValueAliases.txt#L508

