### PR TITLE
Miscellaneous character.jsp cleanups

### DIFF
--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
@@ -1743,7 +1743,7 @@ public class UnicodeUtilities {
                                 + defaultClass
                                 + ">"
                                 + (isMultivalued
-                                        ? ""
+                                        ? "<span" + (isNew ? " class='changed'" : "") + ">"
                                         : ("<a target='u' "
                                                 + (isNew ? "class='changed' " : "")
                                                 + "href='list-unicodeset.jsp?a=[:"
@@ -1754,7 +1754,7 @@ public class UnicodeUtilities {
                                                 + ":]'>"))
                                 + versionRange
                                 + hValue
-                                + (isMultivalued ? "" : "</a>")
+                                + (isMultivalued ? "</span>" : "</a>")
                                 + "</td>");
             }
         }

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
@@ -1755,7 +1755,7 @@ public class UnicodeUtilities {
                                             + ":]'>"))
                             + versionRange
                             + htmlValue
-                            + (isMultivalued ? "</span>" : "</a>")
+                            + (isMultivalued || htmlValue.contains("<") ? "</span>" : "</a>")
                             + "</td>");
         }
         out.append("</tr>");

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -265,9 +265,10 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     }
 
     public Iterable<String> getValues(int codepoint) {
-        return isMultivalued
-                ? delimiterSplitter.split(getValue(codepoint))
-                : Collections.singleton(getValue(codepoint));
+        String value = getValue(codepoint);
+        return isMultivalued && value != null
+                ? delimiterSplitter.split(value)
+                : Collections.singleton(value);
     }
 
     public String getValue(int codepoint) {


### PR DESCRIPTION
* Put a `<wbr>` between values of multivalued properties so exemplar doesn’t make https://util.unicode.org/UnicodeJsps/character.jsp?a=a stupidly wide.
* Add back yellowing on multivalued properties (which was accidentally removed by #1018, see, _e.g._,  kPrimaryNumeric in https://util.unicode.org/UnicodeJsps/character.jsp?a=5146&showDevProperties=1)