### PR TITLE
Add spaces for Adlam characters to ArabicShaping.txt

### DIFF
--- a/unicodetools/data/ucd/dev/ArabicShaping.txt
+++ b/unicodetools/data/ucd/dev/ArabicShaping.txt
@@ -1,6 +1,6 @@
 # ArabicShaping-17.0.0.txt
-# Date: 2024-11-14
-# © 2024 Unicode®, Inc.
+# Date: 2025-03-21, 02:39:00 GMT
+# © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
 #
@@ -945,74 +945,74 @@ A873; PHAGS-PA CANDRABINDU; U; No_Joining_Group
 
 # Adlam Characters
 
-1E900;ADLAM CAPITAL ALIF; D; No_Joining_Group
-1E901;ADLAM CAPITAL DAALI; D; No_Joining_Group
-1E902;ADLAM CAPITAL LAAM; D; No_Joining_Group
-1E903;ADLAM CAPITAL MIIM; D; No_Joining_Group
-1E904;ADLAM CAPITAL BA; D; No_Joining_Group
-1E905;ADLAM CAPITAL SINNYIIYHE; D; No_Joining_Group
-1E906;ADLAM CAPITAL PE; D; No_Joining_Group
-1E907;ADLAM CAPITAL BHE; D; No_Joining_Group
-1E908;ADLAM CAPITAL RA; D; No_Joining_Group
-1E909;ADLAM CAPITAL E; D; No_Joining_Group
-1E90A;ADLAM CAPITAL FA; D; No_Joining_Group
-1E90B;ADLAM CAPITAL I; D; No_Joining_Group
-1E90C;ADLAM CAPITAL O; D; No_Joining_Group
-1E90D;ADLAM CAPITAL DHA; D; No_Joining_Group
-1E90E;ADLAM CAPITAL YHE; D; No_Joining_Group
-1E90F;ADLAM CAPITAL WAW; D; No_Joining_Group
-1E910;ADLAM CAPITAL NUN; D; No_Joining_Group
-1E911;ADLAM CAPITAL KAF; D; No_Joining_Group
-1E912;ADLAM CAPITAL YA; D; No_Joining_Group
-1E913;ADLAM CAPITAL U; D; No_Joining_Group
-1E914;ADLAM CAPITAL JIIM; D; No_Joining_Group
-1E915;ADLAM CAPITAL CHI; D; No_Joining_Group
-1E916;ADLAM CAPITAL HA; D; No_Joining_Group
-1E917;ADLAM CAPITAL QAAF; D; No_Joining_Group
-1E918;ADLAM CAPITAL GA; D; No_Joining_Group
-1E919;ADLAM CAPITAL NYA; D; No_Joining_Group
-1E91A;ADLAM CAPITAL TU; D; No_Joining_Group
-1E91B;ADLAM CAPITAL NHA; D; No_Joining_Group
-1E91C;ADLAM CAPITAL VA; D; No_Joining_Group
-1E91D;ADLAM CAPITAL KHA; D; No_Joining_Group
-1E91E;ADLAM CAPITAL GBE; D; No_Joining_Group
-1E91F;ADLAM CAPITAL ZAL; D; No_Joining_Group
-1E920;ADLAM CAPITAL KPO; D; No_Joining_Group
-1E921;ADLAM CAPITAL SHA; D; No_Joining_Group
-1E922;ADLAM SMALL ALIF; D; No_Joining_Group
-1E923;ADLAM SMALL DAALI; D; No_Joining_Group
-1E924;ADLAM SMALL LAAM; D; No_Joining_Group
-1E925;ADLAM SMALL MIIM; D; No_Joining_Group
-1E926;ADLAM SMALL BA; D; No_Joining_Group
-1E927;ADLAM SMALL SINNYIIYHE; D; No_Joining_Group
-1E928;ADLAM SMALL PE; D; No_Joining_Group
-1E929;ADLAM SMALL BHE; D; No_Joining_Group
-1E92A;ADLAM SMALL RA; D; No_Joining_Group
-1E92B;ADLAM SMALL E; D; No_Joining_Group
-1E92C;ADLAM SMALL FA; D; No_Joining_Group
-1E92D;ADLAM SMALL I; D; No_Joining_Group
-1E92E;ADLAM SMALL O; D; No_Joining_Group
-1E92F;ADLAM SMALL DHA; D; No_Joining_Group
-1E930;ADLAM SMALL YHE; D; No_Joining_Group
-1E931;ADLAM SMALL WAW; D; No_Joining_Group
-1E932;ADLAM SMALL NUN; D; No_Joining_Group
-1E933;ADLAM SMALL KAF; D; No_Joining_Group
-1E934;ADLAM SMALL YA; D; No_Joining_Group
-1E935;ADLAM SMALL U; D; No_Joining_Group
-1E936;ADLAM SMALL JIIM; D; No_Joining_Group
-1E937;ADLAM SMALL CHI; D; No_Joining_Group
-1E938;ADLAM SMALL HA; D; No_Joining_Group
-1E939;ADLAM SMALL QAAF; D; No_Joining_Group
-1E93A;ADLAM SMALL GA; D; No_Joining_Group
-1E93B;ADLAM SMALL NYA; D; No_Joining_Group
-1E93C;ADLAM SMALL TU; D; No_Joining_Group
-1E93D;ADLAM SMALL NHA; D; No_Joining_Group
-1E93E;ADLAM SMALL VA; D; No_Joining_Group
-1E93F;ADLAM SMALL KHA; D; No_Joining_Group
-1E940;ADLAM SMALL GBE; D; No_Joining_Group
-1E941;ADLAM SMALL ZAL; D; No_Joining_Group
-1E942;ADLAM SMALL KPO; D; No_Joining_Group
-1E943;ADLAM SMALL SHA; D; No_Joining_Group
-1E94B;ADLAM NASALIZATION MARK; T; No_Joining_Group
+1E900; ADLAM CAPITAL ALIF; D; No_Joining_Group
+1E901; ADLAM CAPITAL DAALI; D; No_Joining_Group
+1E902; ADLAM CAPITAL LAAM; D; No_Joining_Group
+1E903; ADLAM CAPITAL MIIM; D; No_Joining_Group
+1E904; ADLAM CAPITAL BA; D; No_Joining_Group
+1E905; ADLAM CAPITAL SINNYIIYHE; D; No_Joining_Group
+1E906; ADLAM CAPITAL PE; D; No_Joining_Group
+1E907; ADLAM CAPITAL BHE; D; No_Joining_Group
+1E908; ADLAM CAPITAL RA; D; No_Joining_Group
+1E909; ADLAM CAPITAL E; D; No_Joining_Group
+1E90A; ADLAM CAPITAL FA; D; No_Joining_Group
+1E90B; ADLAM CAPITAL I; D; No_Joining_Group
+1E90C; ADLAM CAPITAL O; D; No_Joining_Group
+1E90D; ADLAM CAPITAL DHA; D; No_Joining_Group
+1E90E; ADLAM CAPITAL YHE; D; No_Joining_Group
+1E90F; ADLAM CAPITAL WAW; D; No_Joining_Group
+1E910; ADLAM CAPITAL NUN; D; No_Joining_Group
+1E911; ADLAM CAPITAL KAF; D; No_Joining_Group
+1E912; ADLAM CAPITAL YA; D; No_Joining_Group
+1E913; ADLAM CAPITAL U; D; No_Joining_Group
+1E914; ADLAM CAPITAL JIIM; D; No_Joining_Group
+1E915; ADLAM CAPITAL CHI; D; No_Joining_Group
+1E916; ADLAM CAPITAL HA; D; No_Joining_Group
+1E917; ADLAM CAPITAL QAAF; D; No_Joining_Group
+1E918; ADLAM CAPITAL GA; D; No_Joining_Group
+1E919; ADLAM CAPITAL NYA; D; No_Joining_Group
+1E91A; ADLAM CAPITAL TU; D; No_Joining_Group
+1E91B; ADLAM CAPITAL NHA; D; No_Joining_Group
+1E91C; ADLAM CAPITAL VA; D; No_Joining_Group
+1E91D; ADLAM CAPITAL KHA; D; No_Joining_Group
+1E91E; ADLAM CAPITAL GBE; D; No_Joining_Group
+1E91F; ADLAM CAPITAL ZAL; D; No_Joining_Group
+1E920; ADLAM CAPITAL KPO; D; No_Joining_Group
+1E921; ADLAM CAPITAL SHA; D; No_Joining_Group
+1E922; ADLAM SMALL ALIF; D; No_Joining_Group
+1E923; ADLAM SMALL DAALI; D; No_Joining_Group
+1E924; ADLAM SMALL LAAM; D; No_Joining_Group
+1E925; ADLAM SMALL MIIM; D; No_Joining_Group
+1E926; ADLAM SMALL BA; D; No_Joining_Group
+1E927; ADLAM SMALL SINNYIIYHE; D; No_Joining_Group
+1E928; ADLAM SMALL PE; D; No_Joining_Group
+1E929; ADLAM SMALL BHE; D; No_Joining_Group
+1E92A; ADLAM SMALL RA; D; No_Joining_Group
+1E92B; ADLAM SMALL E; D; No_Joining_Group
+1E92C; ADLAM SMALL FA; D; No_Joining_Group
+1E92D; ADLAM SMALL I; D; No_Joining_Group
+1E92E; ADLAM SMALL O; D; No_Joining_Group
+1E92F; ADLAM SMALL DHA; D; No_Joining_Group
+1E930; ADLAM SMALL YHE; D; No_Joining_Group
+1E931; ADLAM SMALL WAW; D; No_Joining_Group
+1E932; ADLAM SMALL NUN; D; No_Joining_Group
+1E933; ADLAM SMALL KAF; D; No_Joining_Group
+1E934; ADLAM SMALL YA; D; No_Joining_Group
+1E935; ADLAM SMALL U; D; No_Joining_Group
+1E936; ADLAM SMALL JIIM; D; No_Joining_Group
+1E937; ADLAM SMALL CHI; D; No_Joining_Group
+1E938; ADLAM SMALL HA; D; No_Joining_Group
+1E939; ADLAM SMALL QAAF; D; No_Joining_Group
+1E93A; ADLAM SMALL GA; D; No_Joining_Group
+1E93B; ADLAM SMALL NYA; D; No_Joining_Group
+1E93C; ADLAM SMALL TU; D; No_Joining_Group
+1E93D; ADLAM SMALL NHA; D; No_Joining_Group
+1E93E; ADLAM SMALL VA; D; No_Joining_Group
+1E93F; ADLAM SMALL KHA; D; No_Joining_Group
+1E940; ADLAM SMALL GBE; D; No_Joining_Group
+1E941; ADLAM SMALL ZAL; D; No_Joining_Group
+1E942; ADLAM SMALL KPO; D; No_Joining_Group
+1E943; ADLAM SMALL SHA; D; No_Joining_Group
+1E94B; ADLAM NASALIZATION MARK; T; No_Joining_Group
 
 # EOF


### PR DESCRIPTION
For some reason, the Adlam characters were missing spaces before their schematic names. 

Reported by @miloush