### PR TITLE
Fix [:C:] getting interpreted as the entire code space

### DIFF
--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -952,7 +952,8 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             @Override
             public boolean applyPropertyAlias(
                     String propertyName, String propertyValue, UnicodeSet result) {
-                if ((propertyName.equals("C") || propertyName.equals("c")) && propertyValue.isEmpty()) {
+                if ((propertyName.equals("C") || propertyName.equals("c"))
+                        && propertyValue.isEmpty()) {
                     // C matches isc=ISO_Comment, and we are not able to distinguish
                     // \p{C} (=\p{General_Category=Other}) from \p{C=} (=\p{ISO_Comment=}) here.
                     // Fall back to ICU, since this symbol table does not implement GC groupings.

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -952,6 +952,13 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             @Override
             public boolean applyPropertyAlias(
                     String propertyName, String propertyValue, UnicodeSet result) {
+                if (propertyName.equals("C") && propertyValue.isEmpty()) {
+                    // C matches isc=ISO_Comment, and we are not able to distinguish
+                    // \p{C} (=\p{General_Category=Other}) from \p{C=} (=\p{ISO_Comment=}) here.
+                    // Fall back to ICU, since this symbol table does not implement GC groupings.
+                    // TODO(egg): This symbol table needs to go, see #1073, #1074.
+                    return false;
+                }
                 if (false) System.out.println(propertyName + "=" + propertyValue);
                 UnicodeProperty prop = getProperty(propertyName);
                 if (prop == null) return false;

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -952,7 +952,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             @Override
             public boolean applyPropertyAlias(
                     String propertyName, String propertyValue, UnicodeSet result) {
-                if (propertyName.equals("C") && propertyValue.isEmpty()) {
+                if ((propertyName.equals("C") || propertyName.equals("c")) && propertyValue.isEmpty()) {
                     // C matches isc=ISO_Comment, and we are not able to distinguish
                     // \p{C} (=\p{General_Category=Other}) from \p{C=} (=\p{ISO_Comment=}) here.
                     // Fall back to ICU, since this symbol table does not implement GC groupings.


### PR DESCRIPTION
@josh-hadley found that after #1057, everything gets U+-escaped in the comments of https://github.com/unicode-org/unicodetools/blob/main/unicodetools/data/security/dev/data/review.txt.

The rule governing what gets escaped is
https://github.com/unicode-org/unicodetools/blob/83971c46797e9d9cc1cbd5443e1ea10e1eef3e02/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java#L177-L178

and the underlying symbol table is the one from TUP:
https://github.com/unicode-org/unicodetools/blob/83971c46797e9d9cc1cbd5443e1ea10e1eef3e02/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java#L130-L137

ICU UnicodeSet does not give us the possibility of distinguishing \p{X} from \p{X=} in applyPropertyAlias, thus [:C:] is [:C=:].

Recall:
* from UAX44, that ISO_Comment is deprecated and stabilized;
* from https://github.com/unicode-org/unicodetools/pull/640#issuecomment-1880378088, that TUP has the empty string, rather than null, for its ISO_Comment values;
* from PropertyAliases.txt, that ISO_Comment has the alias ISC;
* from PropertyValueAliases.txt, that the General_Category value Other has the alias C.

Thus [:C=:] is the set of code points with the empty string as their ISO_Comment value (the entire code space according to TUP), rather than the set of code points whose General_Category is a value in the Other grouping (which is [:C:]).

This change fixes the immediate issue, but as noted in the comment, the symbol table used here is dangerous (it caused https://github.com/unicode-org/unicodetools/issues/1072), and will need to go away as part of https://github.com/unicode-org/unicodetools/issues/1073 and https://github.com/unicode-org/unicodetools/issues/1074. I also filed ICU-23087 on the ICU side.