### PR TITLE
One symbol table to rule them all

### DIFF
--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -198,6 +198,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             EXTENDED_MASK = 1,
             CORE_MASK = ~EXTENDED_MASK,
             BINARY_MASK = (1 << BINARY) | (1 << EXTENDED_BINARY),
+            NUMERIC_MASK = (1 << NUMERIC) | (1 << EXTENDED_NUMERIC),
             STRING_MASK = (1 << STRING) | (1 << EXTENDED_STRING),
             STRING_OR_MISC_MASK =
                     (1 << STRING) | (1 << EXTENDED_STRING) | (1 << MISC) | (1 << EXTENDED_MISC),

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -445,27 +445,24 @@ public abstract class UnicodeProperty extends UnicodeLabel {
         if (isMultivalued && propertyValue != null && propertyValue.contains(delimiter)) {
             throw new IllegalArgumentException(
                     "Multivalued property values can't contain the delimiter.");
-        } else {
-            Comparator<String> comparator;
-            if (isType(NUMERIC_MASK)) {
-                // UAX44-LM1.
-                comparator = RATIONAL_COMPARATOR;
-            } else if (getName().equals("Name") || getName().equals("Name_Alias")) {
-                // UAX44-LM2.
-                comparator = CHARACTER_NAME_COMPARATOR;
-            } else if (isType(BINARY_OR_ENUMERATED_OR_CATALOG_MASK)) {
-                // UAX44-LM3
-                comparator = PROPERTY_COMPARATOR;
-            } else {
-                // String-valued or Miscellaneous property.
-                comparator = null;
-            }
-            return getSet(
-                    propertyValue == null
-                            ? NULL_MATCHER
-                            : new SimpleMatcher(propertyValue, comparator),
-                    result);
         }
+        Comparator<String> comparator;
+        if (isType(NUMERIC_MASK)) {
+            // UAX44-LM1.
+            comparator = RATIONAL_COMPARATOR;
+        } else if (getName().equals("Name") || getName().equals("Name_Alias")) {
+            // UAX44-LM2.
+            comparator = CHARACTER_NAME_COMPARATOR;
+        } else if (isType(BINARY_OR_ENUMERATED_OR_CATALOG_MASK)) {
+            // UAX44-LM3
+            comparator = PROPERTY_COMPARATOR;
+        } else {
+            // String-valued or Miscellaneous property.
+            comparator = null;
+        }
+        return getSet(
+                propertyValue == null ? NULL_MATCHER : new SimpleMatcher(propertyValue, comparator),
+                result);
     }
 
     private UnicodeMap<String> unicodeMap = null;

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -446,19 +446,24 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             throw new IllegalArgumentException(
                     "Multivalued property values can't contain the delimiter.");
         } else {
+            Comparator<String> comparator;
+            if (isType(NUMERIC_MASK)) {
+                // UAX44-LM1.
+                comparator = RATIONAL_COMPARATOR;
+            } else if (getName().equals("Name") || getName().equals("Name_Alias")) {
+                // UAX44-LM2.
+                comparator = CHARACTER_NAME_COMPARATOR;
+            } else if (isType(BINARY_OR_ENUMERATED_OR_CATALOG_MASK)) {
+                // UAX44-LM3
+                comparator = PROPERTY_COMPARATOR;
+            } else {
+                // String-valued or Miscellaneous property.
+                comparator = null;
+            }
             return getSet(
                     propertyValue == null
                             ? NULL_MATCHER
-                            : new SimpleMatcher(
-                                    propertyValue,
-                                    isType(NUMERIC_MASK)
-                                            ? RATIONAL_COMPARATOR
-                                            : getName().equals("Name")
-                                                            || getName().equals("Name_Alias")
-                                                    ? CHARACTER_NAME_COMPARATOR
-                                                    : isType(STRING_OR_MISC_MASK)
-                                                            ? null
-                                                            : PROPERTY_COMPARATOR),
+                            : new SimpleMatcher(propertyValue, comparator),
                     result);
         }
     }

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -740,8 +740,8 @@ public abstract class UnicodeProperty extends UnicodeLabel {
 
     public static int compareRationals(String a, String b) {
         if (a == b) return 0;
-        if (a == null) return -1;
-        if (b == null) return 1;
+        if (a == null || a.equalsIgnoreCase("NaN")) return -1;
+        if (b == null || b.equalsIgnoreCase("NaN")) return 1;
         return RationalParser.BASIC.parse(a).compareTo(RationalParser.BASIC.parse(b));
     }
 

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -740,8 +740,13 @@ public abstract class UnicodeProperty extends UnicodeLabel {
 
     public static int compareRationals(String a, String b) {
         if (a == b) return 0;
-        if (a == null || a.equalsIgnoreCase("NaN")) return -1;
-        if (b == null || b.equalsIgnoreCase("NaN")) return 1;
+        if (a == null) return -1;
+        if (b == null) return 1;
+        final boolean aIsNaN = equalNames(a, "NaN");
+        final boolean bIsNaN = equalNames(b, "NaN");
+        if (aIsNaN && bIsNaN) return 0;
+        if (aIsNaN) return -1;
+        if (bIsNaN) return 1;
         return RationalParser.BASIC.parse(a).compareTo(RationalParser.BASIC.parse(b));
     }
 

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -446,6 +446,9 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             throw new IllegalArgumentException(
                     "Multivalued property values can't contain the delimiter.");
         }
+        if (propertyValue == null) {
+            return getSet(NULL_MATCHER, result);
+        }
         Comparator<String> comparator;
         if (isType(NUMERIC_MASK)) {
             // UAX44-LM1.
@@ -460,9 +463,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             // String-valued or Miscellaneous property.
             comparator = null;
         }
-        return getSet(
-                propertyValue == null ? NULL_MATCHER : new SimpleMatcher(propertyValue, comparator),
-                result);
+        return getSet(new SimpleMatcher(propertyValue, comparator), result);
     }
 
     private UnicodeMap<String> unicodeMap = null;

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import org.unicode.cldr.util.Rational.RationalParser;
 import org.unicode.cldr.util.props.UnicodeLabel;
 
 public abstract class UnicodeProperty extends UnicodeLabel {
@@ -450,11 +451,14 @@ public abstract class UnicodeProperty extends UnicodeLabel {
                             ? NULL_MATCHER
                             : new SimpleMatcher(
                                     propertyValue,
-                                    getName().equals("Name") || getName().equals("Name_Alias")
-                                            ? CHARACTER_NAME_COMPARATOR
-                                            : isType(STRING_OR_MISC_MASK)
-                                                    ? null
-                                                    : PROPERTY_COMPARATOR),
+                                    isType(NUMERIC_MASK)
+                                            ? RATIONAL_COMPARATOR
+                                            : getName().equals("Name")
+                                                            || getName().equals("Name_Alias")
+                                                    ? CHARACTER_NAME_COMPARATOR
+                                                    : isType(STRING_OR_MISC_MASK)
+                                                            ? null
+                                                            : PROPERTY_COMPARATOR),
                     result);
         }
     }
@@ -724,6 +728,21 @@ public abstract class UnicodeProperty extends UnicodeLabel {
         }
         if (!gotOne) return source; // avoid string creation
         return skeletonBuffer.toString();
+    }
+
+    public static final Comparator<String> RATIONAL_COMPARATOR =
+            new Comparator<String>() {
+                @Override
+                public int compare(String x, String y) {
+                    return compareRationals(x, y);
+                }
+            };
+
+    public static int compareRationals(String a, String b) {
+        if (a == b) return 0;
+        if (a == null) return -1;
+        if (b == null) return 1;
+        return RationalParser.BASIC.parse(a).compareTo(RationalParser.BASIC.parse(b));
     }
 
     public static final Comparator<String> CHARACTER_NAME_COMPARATOR =

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
@@ -59,7 +59,7 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
                         throw new IllegalArgumentException(
                                 "Invalid version-qualifier " + versionQualifier);
                 }
-                String versionNumber = versionQualifier.substring(1, posColon + 1);
+                String versionNumber = versionQualifier.substring(1, posColon);
                 if (versionNumber.endsWith("dev")) {
                     versionNumber = versionNumber.substring(0, versionNumber.length() - 3);
                     if (!versionNumber.isEmpty()

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
@@ -157,6 +157,7 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
 
     @Override
     public boolean applyPropertyAlias(String beforeEquals, String afterEquals, UnicodeSet result) {
+        result.clear();
         String leftHandSide = beforeEquals;
         String propertyPredicate = afterEquals;
         boolean interiorlyNegated = false;

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
@@ -4,6 +4,7 @@ import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.VersionInfo;
 import java.util.Comparator;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import org.unicode.props.IndexUnicodeProperties;
 import org.unicode.props.UcdProperty;
@@ -121,25 +122,25 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
         }
     }
 
-    private static Map<UcdPropertyValues.General_Category_Values, String[]>
+    private static Map<UcdPropertyValues.General_Category_Values, Set<String>>
             COARSE_GENERAL_CATEGORIES =
                     Map.of(
                             UcdPropertyValues.General_Category_Values.Other,
-                            new String[] {"Cc", "Cf", "Cn", "Co", "Cs"},
+                            Set.of("Cc", "Cf", "Cn", "Co", "Cs"),
                             UcdPropertyValues.General_Category_Values.Letter,
-                            new String[] {"Ll", "Lm", "Lo", "Lt", "Lu"},
+                            Set.of("Ll", "Lm", "Lo", "Lt", "Lu"),
                             UcdPropertyValues.General_Category_Values.Cased_Letter,
-                            new String[] {"Ll", "Lt", "Lu"},
+                            Set.of("Ll", "Lt", "Lu"),
                             UcdPropertyValues.General_Category_Values.Mark,
-                            new String[] {"Mc", "Me", "Mn"},
+                            Set.of("Mc", "Me", "Mn"),
                             UcdPropertyValues.General_Category_Values.Number,
-                            new String[] {"Nd", "Nl", "No"},
+                            Set.of("Nd", "Nl", "No"),
                             UcdPropertyValues.General_Category_Values.Punctuation,
-                            new String[] {"Pc", "Pd", "Pe", "Pf", "Pi", "Po", "Ps"},
+                            Set.of("Pc", "Pd", "Pe", "Pf", "Pi", "Po", "Ps"),
                             UcdPropertyValues.General_Category_Values.Symbol,
-                            new String[] {"Sc", "Sk", "Sm", "So"},
+                            Set.of("Sc", "Sk", "Sm", "So"),
                             UcdPropertyValues.General_Category_Values.Separator,
-                            new String[] {"Zl", "Zp", "Zs"});
+                            Set.of("Zl", "Zp", "Zs"));
 
     /**
      * Similar to iup.getProperty(UcdProperty.General_Category).getSet(propertyValue), but takes the

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
@@ -1,155 +1,232 @@
 package org.unicode.text.UCD;
 
+import com.ibm.icu.text.UnicodeSet;
+import com.ibm.icu.util.VersionInfo;
 import java.util.Map;
-import java.util.TreeMap;
-
 import org.unicode.props.IndexUnicodeProperties;
 import org.unicode.props.UcdProperty;
+import org.unicode.props.UcdPropertyValues;
 import org.unicode.props.UnicodeProperty;
 import org.unicode.text.utility.Settings;
 
-import com.ibm.icu.text.UnicodeSet;
-import com.ibm.icu.util.VersionInfo;
-
 /**
- * This class implements the semantics of property-query as defined in the
- * UnicodeSet specification.
+ * This class implements the semantics of property-query as defined in the UnicodeSet specification.
  */
 public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
-  private VersionedSymbolTable() {}
-  public static VersionedSymbolTable forReview() {
-    var result = new VersionedSymbolTable();
-    result.requireSuffixForLatest = true;
-    result.implicitVersion = Settings.LAST_VERSION_INFO;
-    result.previousVersion = Settings.LAST2_VERSION_INFO;
-    return result;
-  }
-  public static VersionedSymbolTable forDevelopment() {
-    var result = new VersionedSymbolTable();
-    result.requireSuffixForLatest = false;
-    result.implicitVersion = Settings.LATEST_VERSION_INFO;
-    result.previousVersion = Settings.LAST_VERSION_INFO;
-    return result;
-  }
+    private VersionedSymbolTable() {}
 
-  /** Parses a string prefixed with an optional-version-qualifier.
-   * If there is a version-qualifier, returns the corresponding VersionInfo and
-   * removes the prefix from the given StringBuilder.
-   */
-  private VersionInfo parseVersionQualifier(StringBuilder qualified) {
-    int posColon = qualified.indexOf(":", 0);
-    if (posColon < 0) {
-      return null;
-    } else {
-      final String versionQualifier = qualified.substring(0, posColon + 1);
-      qualified.delete(0, posColon + 1);
-      if (versionQualifier.equals("U-1")) {
-        return previousVersion;
-      } else {
-        switch (versionQualifier.charAt(0)) {
-          case 'R':
-          // Extension: we allow a version-qualifier starting with R for retroactive properties, that
-          // is, property derivations applied before the property existed.
-          case 'U':
-            break;
-          default:
-            throw new IllegalArgumentException("Invalid version-qualifier " + versionQualifier);
-        }
-        String versionNumber = versionQualifier.substring(1, posColon + 1);
-        if (versionNumber.endsWith("dev")) {
-          versionNumber = versionNumber.substring(0, versionNumber.length() - 3);
-          if (!versionNumber.isEmpty() &&
-              VersionInfo.getInstance(versionNumber) != Settings.LATEST_VERSION_INFO) {
-            throw new IllegalArgumentException("Invalid version-qualifier " + versionQualifier + " with version-suffix dev: the current dev version is " + Settings.latestVersion);
-          }
-          return Settings.LATEST_VERSION_INFO;
-        } else if (versionNumber.endsWith("α") || versionNumber.endsWith("β")) {
-          final String versionSuffix = versionNumber.substring(versionNumber.length() - 1);
-          versionNumber = versionNumber.substring(0, versionNumber.length() - 1);
-          if (versionSuffix != Settings.latestVersionPhase.toString()) {
-            throw new IllegalArgumentException("Invalid version-qualifier " + versionQualifier + " with version-suffix " + versionSuffix + ": the current stage is " + Settings.latestVersionPhase);
-          }
-          if (!versionNumber.isEmpty() &&
-              VersionInfo.getInstance(versionNumber) != Settings.LATEST_VERSION_INFO) {
-            throw new IllegalArgumentException("Invalid version-qualifier " + versionQualifier + " with version-suffix " + versionNumber + ": the current " + versionSuffix + " version is " + Settings.latestVersion);
-          }
-          return Settings.LATEST_VERSION_INFO;
+    public static VersionedSymbolTable forReview() {
+        var result = new VersionedSymbolTable();
+        result.requireSuffixForLatest = true;
+        result.implicitVersion = Settings.LAST_VERSION_INFO;
+        result.previousVersion = Settings.LAST2_VERSION_INFO;
+        return result;
+    }
+
+    public static VersionedSymbolTable forDevelopment() {
+        var result = new VersionedSymbolTable();
+        result.requireSuffixForLatest = false;
+        result.implicitVersion = Settings.LATEST_VERSION_INFO;
+        result.previousVersion = Settings.LAST_VERSION_INFO;
+        return result;
+    }
+
+    /**
+     * Parses a string prefixed with an optional-version-qualifier. If there is a version-qualifier,
+     * returns the corresponding VersionInfo and removes the prefix from the given StringBuilder.
+     */
+    private VersionInfo parseVersionQualifier(StringBuilder qualified) {
+        int posColon = qualified.indexOf(":", 0);
+        if (posColon < 0) {
+            return null;
         } else {
-          var result = VersionInfo.getInstance(versionNumber);
-          if (result == Settings.LATEST_VERSION_INFO && requireSuffixForLatest) {
-            throw new IllegalArgumentException("Invalid version-qualifier " + versionQualifier + " version-suffix " + Settings.latestVersionPhase + " required for unpublished version");
-          }
-          return result;
+            final String versionQualifier = qualified.substring(0, posColon + 1);
+            qualified.delete(0, posColon + 1);
+            if (versionQualifier.equals("U-1")) {
+                return previousVersion;
+            } else {
+                switch (versionQualifier.charAt(0)) {
+                    case 'R':
+                        // Extension: we allow a version-qualifier starting with R for retroactive
+                        // properties, that
+                        // is, property derivations applied before the property existed.
+                    case 'U':
+                        break;
+                    default:
+                        throw new IllegalArgumentException(
+                                "Invalid version-qualifier " + versionQualifier);
+                }
+                String versionNumber = versionQualifier.substring(1, posColon + 1);
+                if (versionNumber.endsWith("dev")) {
+                    versionNumber = versionNumber.substring(0, versionNumber.length() - 3);
+                    if (!versionNumber.isEmpty()
+                            && VersionInfo.getInstance(versionNumber)
+                                    != Settings.LATEST_VERSION_INFO) {
+                        throw new IllegalArgumentException(
+                                "Invalid version-qualifier "
+                                        + versionQualifier
+                                        + " with version-suffix dev: the current dev version is "
+                                        + Settings.latestVersion);
+                    }
+                    return Settings.LATEST_VERSION_INFO;
+                } else if (versionNumber.endsWith("α") || versionNumber.endsWith("β")) {
+                    final String versionSuffix =
+                            versionNumber.substring(versionNumber.length() - 1);
+                    versionNumber = versionNumber.substring(0, versionNumber.length() - 1);
+                    if (versionSuffix != Settings.latestVersionPhase.toString()) {
+                        throw new IllegalArgumentException(
+                                "Invalid version-qualifier "
+                                        + versionQualifier
+                                        + " with version-suffix "
+                                        + versionSuffix
+                                        + ": the current stage is "
+                                        + Settings.latestVersionPhase);
+                    }
+                    if (!versionNumber.isEmpty()
+                            && VersionInfo.getInstance(versionNumber)
+                                    != Settings.LATEST_VERSION_INFO) {
+                        throw new IllegalArgumentException(
+                                "Invalid version-qualifier "
+                                        + versionQualifier
+                                        + " with version-suffix "
+                                        + versionNumber
+                                        + ": the current "
+                                        + versionSuffix
+                                        + " version is "
+                                        + Settings.latestVersion);
+                    }
+                    return Settings.LATEST_VERSION_INFO;
+                } else {
+                    var result = VersionInfo.getInstance(versionNumber);
+                    if (result == Settings.LATEST_VERSION_INFO && requireSuffixForLatest) {
+                        throw new IllegalArgumentException(
+                                "Invalid version-qualifier "
+                                        + versionQualifier
+                                        + " version-suffix "
+                                        + Settings.latestVersionPhase
+                                        + " required for unpublished version");
+                    }
+                    return result;
+                }
+            }
         }
-      }
-    }
-  }
-
-  @Override
-  public boolean applyPropertyAlias(String beforeEquals, String afterEquals, UnicodeSet result) {
-    String leftHandSide = beforeEquals;
-    String propertyPredicate = afterEquals;
-    boolean interiorlyNegated = false;
-    int posNotEqual = beforeEquals.indexOf('≠');
-    // TODO(egg): We cannot distinguish \p{X=} from \p{X} in this API, both give us an empty string
-    // as afterEquals.
-    if (posNotEqual >= 0) {
-      propertyPredicate = afterEquals.length() == 0
-          ? beforeEquals.substring(posNotEqual + 1)
-          : beforeEquals.substring(posNotEqual + 1) + "=" + afterEquals;
-      leftHandSide = beforeEquals.substring(0, posNotEqual);
-      interiorlyNegated = true;
     }
 
-    final var queriedPropertyName = new StringBuilder(leftHandSide);
-    final var queriedVersion = parseVersionQualifier(queriedPropertyName);
-    final var deducedQueriedVersion = queriedVersion == null ? implicitVersion : queriedVersion;
+    private static Map<UcdPropertyValues.General_Category_Values, String[]>
+            COARSE_GENERAL_CATEGORIES =
+                    Map.of(
+                            UcdPropertyValues.General_Category_Values.Other,
+                            new String[] {"Cc", "Cf", "Cn", "Co", "Cs"},
+                            UcdPropertyValues.General_Category_Values.Letter,
+                            new String[] {"Ll", "Lm", "Lo", "Lt", "Lu"},
+                            UcdPropertyValues.General_Category_Values.Cased_Letter,
+                            new String[] {"Ll", "Lt", "Lu"},
+                            UcdPropertyValues.General_Category_Values.Mark,
+                            new String[] {"Mc", "Me", "Mn"},
+                            UcdPropertyValues.General_Category_Values.Number,
+                            new String[] {"Nd", "Nl", "No"},
+                            UcdPropertyValues.General_Category_Values.Punctuation,
+                            new String[] {"Pc", "Pd", "Pe", "Pf", "Pi", "Po", "Ps"},
+                            UcdPropertyValues.General_Category_Values.Symbol,
+                            new String[] {"Sc", "Sk", "Sm", "So"},
+                            UcdPropertyValues.General_Category_Values.Separator,
+                            new String[] {"Zl", "Zp", "Zs"});
 
-    final var queriedUcd = IndexUnicodeProperties.make(deducedQueriedVersion);
-
-    var generalCategory = queriedUcd.getProperty(UcdProperty.General_Category);
-    var script = queriedUcd.getProperty(UcdProperty.Script);
-
-    UnicodeProperty queriedProperty = queriedUcd.getProperty(queriedPropertyName.toString());
-    if (propertyPredicate.length() != 0) {
-      if (queriedProperty == null) {
-        propertyValue = propertyValue.trim();
-      } else if (prop.isTrimmable()) {
-        propertyValue = propertyValue.trim();
-      } else {
-        int debug = 0;
-      }
-      status = applyPropertyAlias0(prop, propertyValue, result, invert);
-    } else {
-      try {
-        status = applyPropertyAlias0(gcProp, versionlessPropertyName, result, invert);
-      } catch (Exception e) {
-      }
-      ;
-      if (!status) {
-        try {
-          status = applyPropertyAlias0(
-              scProp, versionlessPropertyName, result, invert);
-        } catch (Exception e) {
+    /**
+     * Similar to iup.getProperty(UcdProperty.General_Category).getSet(propertyValue), but takes the
+     * groupings into account. Implements both unary-query for a General_Category alias and
+     * binary-query with a property-value where the queried property is General_Category.
+     */
+    private UnicodeSet getGeneralCategorySet(IndexUnicodeProperties iup, String propertyValue) {
+        var gc = iup.getProperty(UcdProperty.General_Category);
+        for (var entry : COARSE_GENERAL_CATEGORIES.entrySet()) {
+            final var aliases = entry.getKey().getNames().getAllNames();
+            if (aliases.stream().anyMatch(a -> UnicodeProperty.equalNames(propertyValue, a))) {
+                UnicodeSet result = new UnicodeSet();
+                for (var value : entry.getValue()) {
+                    gc.getSet(value, result);
+                }
+                return result;
+            }
         }
-        if (!status) {
-          if (prop.isType(UnicodeProperty.BINARY_OR_ENUMERATED_OR_CATALOG_MASK)) {
+        return gc.getSet(propertyValue);
+    }
+
+    @Override
+    public boolean applyPropertyAlias(String beforeEquals, String afterEquals, UnicodeSet result) {
+        String leftHandSide = beforeEquals;
+        String propertyPredicate = afterEquals;
+        boolean interiorlyNegated = false;
+        int posNotEqual = beforeEquals.indexOf('≠');
+        // TODO(egg): We cannot distinguish \p{X=} from \p{X} in this API, both give us an empty
+        // string
+        // as afterEquals.  This is an @internal API, so we could change it to pass null in the
+        // unary
+        // case.
+        if (posNotEqual >= 0) {
+            propertyPredicate =
+                    afterEquals.length() == 0
+                            ? beforeEquals.substring(posNotEqual + 1)
+                            : beforeEquals.substring(posNotEqual + 1) + "=" + afterEquals;
+            leftHandSide = beforeEquals.substring(0, posNotEqual);
+            interiorlyNegated = true;
+        }
+        if (interiorlyNegated) {
+            final var complement = getNonNegatedPropertyQuerySet(leftHandSide, propertyPredicate);
+            result.addAll(complement.complement().removeAllStrings());
+        } else {
+            result.addAll(getNonNegatedPropertyQuerySet(leftHandSide, propertyPredicate));
+        }
+        return true;
+    }
+
+    private UnicodeSet getNonNegatedPropertyQuerySet(
+            String leftHandSide, String propertyPredicate) {
+        final var unqualifiedLeftHandSide = new StringBuilder(leftHandSide);
+        final var queriedVersion = parseVersionQualifier(unqualifiedLeftHandSide);
+        final var deducedQueriedVersion = queriedVersion == null ? implicitVersion : queriedVersion;
+
+        final var queriedProperties = IndexUnicodeProperties.make(deducedQueriedVersion);
+
+        if (propertyPredicate.length() == 0) {
+            // Either unary-property-query, or binary-property-query with an empty property-value.
             try {
-              status = applyPropertyAlias0(prop, "No", result, !invert);
+                return queriedProperties
+                        .getProperty(UcdProperty.Script)
+                        .getSet(unqualifiedLeftHandSide.toString());
             } catch (Exception e) {
             }
-          }
-          if (!status) {
-            status = applyPropertyAlias0(prop, "", result, invert);
-          }
+            try {
+                return getGeneralCategorySet(queriedProperties, unqualifiedLeftHandSide.toString());
+            } catch (Exception e) {
+            }
+            UnicodeProperty queriedProperty =
+                    queriedProperties.getProperty(unqualifiedLeftHandSide.toString());
+            if (queriedProperty != null) {
+                if (!queriedProperty.isType(UnicodeProperty.BINARY)) {
+                    if (queriedProperty.isType(UnicodeProperty.STRING_OR_MISC_MASK)) {
+                        return queriedProperty.getSet("");
+                    }
+                    throw new IllegalArgumentException(
+                            "Invalid unary-query-expression for non-binary property "
+                                    + queriedProperty.getName());
+                }
+                return queriedProperty.getSet(UcdPropertyValues.Binary.Yes);
+            }
+        } else {
+            if (queriedProperty == null) {
+                propertyValue = propertyValue.trim();
+            } else if (prop.isTrimmable()) {
+                propertyValue = propertyValue.trim();
+            } else {
+                int debug = 0;
+            }
+            status = applyPropertyAlias0(prop, propertyValue, result, invert);
         }
-      }
+        // TODO(egg):Something about a factory as a fallback;
     }
-    //TODO(egg):Something about a factory as a fallback;
-    return status;
-  }
 
-  private VersionInfo implicitVersion;
-  private VersionInfo previousVersion;
-  private boolean requireSuffixForLatest;
+    private VersionInfo implicitVersion;
+    private VersionInfo previousVersion;
+    private boolean requireSuffixForLatest;
 }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
@@ -48,8 +48,8 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
                 switch (versionQualifier.charAt(0)) {
                     case 'R':
                         // Extension: we allow a version-qualifier starting with R for retroactive
-                        // properties, that
-                        // is, property derivations applied before the property existed.
+                        // properties, that is, property derivations applied before the property
+                        // existed.
                     case 'U':
                         break;
                     default:
@@ -159,10 +159,8 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
         boolean interiorlyNegated = false;
         int posNotEqual = beforeEquals.indexOf('≠');
         // TODO(egg): We cannot distinguish \p{X=} from \p{X} in this API, both give us an empty
-        // string
-        // as afterEquals.  This is an @internal API, so we could change it to pass null in the
-        // unary
-        // case.
+        // string as afterEquals.  This is an @internal API, so we could change it to pass null in
+        // the unary case.
         if (posNotEqual >= 0) {
             propertyPredicate =
                     afterEquals.length() == 0

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
@@ -200,26 +200,31 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
             }
             UnicodeProperty queriedProperty =
                     queriedProperties.getProperty(unqualifiedLeftHandSide.toString());
-            if (queriedProperty != null) {
-                if (!queriedProperty.isType(UnicodeProperty.BINARY)) {
-                    if (queriedProperty.isType(UnicodeProperty.STRING_OR_MISC_MASK)) {
-                        return queriedProperty.getSet("");
-                    }
-                    throw new IllegalArgumentException(
-                            "Invalid unary-query-expression for non-binary property "
-                                    + queriedProperty.getName());
-                }
-                return queriedProperty.getSet(UcdPropertyValues.Binary.Yes);
+            if (queriedProperty == null && unversionedExtensions != null) {
+              queriedProperty = unversionedExtensions.getProperty(unqualifiedLeftHandSide.toString());
             }
-        } else {
             if (queriedProperty == null) {
-                propertyValue = propertyValue.trim();
-            } else if (prop.isTrimmable()) {
-                propertyValue = propertyValue.trim();
-            } else {
-                int debug = 0;
+              throw new IllegalArgumentException(
+                      "Invalid unary-query-expression; could not find property "
+                              + unqualifiedLeftHandSide);
             }
-            status = applyPropertyAlias0(prop, propertyValue, result, invert);
+            if (!queriedProperty.isType(UnicodeProperty.BINARY_MASK)) {
+                // TODO(egg): Remove when we can tell this is a unary query.
+                if (queriedProperty.isType(UnicodeProperty.STRING_OR_MISC_MASK)) {
+                    return queriedProperty.getSet("");
+                }
+                throw new IllegalArgumentException(
+                        "Invalid unary-query-expression for non-binary property "
+                                + queriedProperty.getName());
+            }
+            return queriedProperty.getSet(UcdPropertyValues.Binary.Yes);
+        } else {
+          // We have a binary-property-query.
+          UnicodeProperty queriedProperty =
+            queriedProperties.getProperty(unqualifiedLeftHandSide.toString());
+          if (queriedProperty == null && unversionedExtensions != null) {
+            queriedProperty = unversionedExtensions.getProperty(unqualifiedLeftHandSide.toString());
+          }
         }
         // TODO(egg):Something about a factory as a fallback;
     }
@@ -227,4 +232,5 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
     private VersionInfo implicitVersion;
     private VersionInfo previousVersion;
     private boolean requireSuffixForLatest;
+    private UnicodeProperty.Factory unversionedExtensions;
 }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
@@ -259,6 +259,7 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
     /**
      * Parses a string prefixed with an optional-version-qualifier. If there is a version-qualifier,
      * returns the corresponding VersionInfo and removes the prefix from the given StringBuilder.
+     * Otherwise returns null.
      */
     private VersionInfo parseVersionQualifier(StringBuilder qualified) {
         int posColon = qualified.indexOf(":", 0);

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
@@ -53,6 +53,7 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
                         // Extension: we allow a version-qualifier starting with R for retroactive
                         // properties, that is, property derivations applied before the property
                         // existed.
+                        // TODO(egg): Actually support that.
                     case 'U':
                         break;
                     default:
@@ -137,8 +138,8 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
 
     /**
      * Similar to iup.getProperty(UcdProperty.General_Category).getSet(propertyValue), but takes the
-     * groupings into account. Implements both unary-query for a General_Category alias and
-     * binary-query with a property-value where the queried property is General_Category.
+     * groupings into account. Implements both unary-query-expression for a General_Category alias and
+     * binary-query-expression with a property-value where the queried property is General_Category.
      */
     private UnicodeSet getGeneralCategorySet(IndexUnicodeProperties iup, String propertyValue) {
         var gc = iup.getProperty(UcdProperty.General_Category);

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
@@ -175,7 +175,7 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
         // the unary case.
         if (posNotEqual >= 0) {
             propertyPredicate =
-                    afterEquals.length() == 0
+                    afterEquals.isEmpty()
                             ? beforeEquals.substring(posNotEqual + 1)
                             : beforeEquals.substring(posNotEqual + 1) + "=" + afterEquals;
             leftHandSide = beforeEquals.substring(0, posNotEqual);
@@ -198,7 +198,7 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
 
         final var queriedProperties = IndexUnicodeProperties.make(deducedQueriedVersion);
 
-        if (propertyPredicate.length() == 0) {
+        if (propertyPredicate.isEmpty()) {
             // Either unary-property-query, or binary-property-query with an empty property-value.
             final var script = queriedProperties.getProperty(UcdProperty.Script);
             final var generalCategory = queriedProperties.getProperty(UcdProperty.General_Category);

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
@@ -333,9 +333,8 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
                     }
                     return result;
                 } else if (queriedProperty.isType(UnicodeProperty.NUMERIC_MASK)) {
-                    if (UnicodeProperty.equalNames(propertyValue, "NaN")) {
-                        propertyValue = "NaN";
-                    } else if (!RATIONAL_PATTERN.matcher(propertyValue).matches()) {
+                    if (UnicodeProperty.equalNames(propertyValue, "NaN") ||
+                        !RATIONAL_PATTERN.matcher(propertyValue).matches()) {
                         throw new IllegalArgumentException(
                                 "Invalid value '"
                                         + propertyValue

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
@@ -34,6 +34,11 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
         return result;
     }
 
+    public VersionedSymbolTable setUnversionedExtensions(UnicodeProperty.Factory factory) {
+        unversionedExtensions = factory;
+        return this;
+    }
+
     /**
      * Parses a string prefixed with an optional-version-qualifier. If there is a version-qualifier,
      * returns the corresponding VersionInfo and removes the prefix from the given StringBuilder.

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
@@ -143,8 +143,9 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
 
     /**
      * Similar to iup.getProperty(UcdProperty.General_Category).getSet(propertyValue), but takes the
-     * groupings into account. Implements both unary-query-expression for a General_Category alias and
-     * binary-query-expression with a property-value where the queried property is General_Category.
+     * groupings into account. Implements both unary-query-expression for a General_Category alias
+     * and binary-query-expression with a property-value where the queried property is
+     * General_Category.
      */
     private UnicodeSet getGeneralCategorySet(IndexUnicodeProperties iup, String propertyValue) {
         var gc = iup.getProperty(UcdProperty.General_Category);
@@ -333,8 +334,8 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
                     }
                     return result;
                 } else if (queriedProperty.isType(UnicodeProperty.NUMERIC_MASK)) {
-                    if (UnicodeProperty.equalNames(propertyValue, "NaN") ||
-                        !RATIONAL_PATTERN.matcher(propertyValue).matches()) {
+                    if (UnicodeProperty.equalNames(propertyValue, "NaN")
+                            || !RATIONAL_PATTERN.matcher(propertyValue).matches()) {
                         throw new IllegalArgumentException(
                                 "Invalid value '"
                                         + propertyValue

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
@@ -318,6 +318,7 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
                         throw new IllegalArgumentException(
                                 "No character name nor name alias matches " + propertyValue);
                     }
+                    return result;
                 } else if (queriedProperty.getName().equals("Name_Alias")) {
                     var result = queriedProperty.getSet(propertyValue);
                     if (result.isEmpty()) {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
@@ -327,7 +327,9 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
                     }
                     return result;
                 } else if (queriedProperty.isType(UnicodeProperty.NUMERIC_MASK)) {
-                    if (!RATIONAL_PATTERN.matcher(propertyValue).matches()) {
+                    if (UnicodeProperty.equalNames(propertyValue, "NaN")) {
+                        propertyValue = "NaN";
+                    } else if (!RATIONAL_PATTERN.matcher(propertyValue).matches()) {
                         throw new IllegalArgumentException(
                                 "Invalid value '"
                                         + propertyValue

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
@@ -376,6 +376,10 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
 
     private static UnicodeSet getIdentitySet(UnicodeProperty queriedProperty) {
         final var result = new UnicodeSet();
+        // Note that while UnicodeProperty, can return strings from getSet, which is an extension of
+        // the UnicodeSet property-query specification, identity queries exclude any strings of
+        // length other than 1, otherwise we would end up with infinite sets, e.g., the set of all
+        // strings that normalize to themselves.
         for (int cp = 0; cp <= 0x10FFFF; ++cp) {
             if (UnicodeProperty.equals(cp, queriedProperty.getValue(cp))) {
                 result.add(cp);
@@ -409,6 +413,10 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
                             + comparisonProperty.getName());
         }
         final var result = new UnicodeSet();
+        // Note that while UnicodeProperty, can return strings from getSet, which is an extension of
+        // the UnicodeSet property-query specification, property comparisons exclude any strings of
+        // length other than 1.  Extending them to include those leads to messy questions of
+        // defining the value of character properties for string (null?) and avoiding infinite sets.
         for (int cp = 0; cp <= 0x10FFFF; ++cp) {
             if (UnicodeProperty.equals(
                     queriedProperty.getValue(cp), comparisonProperty.getValue(cp))) {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
@@ -1,0 +1,155 @@
+package org.unicode.text.UCD;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.unicode.props.IndexUnicodeProperties;
+import org.unicode.props.UcdProperty;
+import org.unicode.props.UnicodeProperty;
+import org.unicode.text.utility.Settings;
+
+import com.ibm.icu.text.UnicodeSet;
+import com.ibm.icu.util.VersionInfo;
+
+/**
+ * This class implements the semantics of property-query as defined in the
+ * UnicodeSet specification.
+ */
+public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
+  private VersionedSymbolTable() {}
+  public static VersionedSymbolTable forReview() {
+    var result = new VersionedSymbolTable();
+    result.requireSuffixForLatest = true;
+    result.implicitVersion = Settings.LAST_VERSION_INFO;
+    result.previousVersion = Settings.LAST2_VERSION_INFO;
+    return result;
+  }
+  public static VersionedSymbolTable forDevelopment() {
+    var result = new VersionedSymbolTable();
+    result.requireSuffixForLatest = false;
+    result.implicitVersion = Settings.LATEST_VERSION_INFO;
+    result.previousVersion = Settings.LAST_VERSION_INFO;
+    return result;
+  }
+
+  /** Parses a string prefixed with an optional-version-qualifier.
+   * If there is a version-qualifier, returns the corresponding VersionInfo and
+   * removes the prefix from the given StringBuilder.
+   */
+  private VersionInfo parseVersionQualifier(StringBuilder qualified) {
+    int posColon = qualified.indexOf(":", 0);
+    if (posColon < 0) {
+      return null;
+    } else {
+      final String versionQualifier = qualified.substring(0, posColon + 1);
+      qualified.delete(0, posColon + 1);
+      if (versionQualifier.equals("U-1")) {
+        return previousVersion;
+      } else {
+        switch (versionQualifier.charAt(0)) {
+          case 'R':
+          // Extension: we allow a version-qualifier starting with R for retroactive properties, that
+          // is, property derivations applied before the property existed.
+          case 'U':
+            break;
+          default:
+            throw new IllegalArgumentException("Invalid version-qualifier " + versionQualifier);
+        }
+        String versionNumber = versionQualifier.substring(1, posColon + 1);
+        if (versionNumber.endsWith("dev")) {
+          versionNumber = versionNumber.substring(0, versionNumber.length() - 3);
+          if (!versionNumber.isEmpty() &&
+              VersionInfo.getInstance(versionNumber) != Settings.LATEST_VERSION_INFO) {
+            throw new IllegalArgumentException("Invalid version-qualifier " + versionQualifier + " with version-suffix dev: the current dev version is " + Settings.latestVersion);
+          }
+          return Settings.LATEST_VERSION_INFO;
+        } else if (versionNumber.endsWith("α") || versionNumber.endsWith("β")) {
+          final String versionSuffix = versionNumber.substring(versionNumber.length() - 1);
+          versionNumber = versionNumber.substring(0, versionNumber.length() - 1);
+          if (versionSuffix != Settings.latestVersionPhase.toString()) {
+            throw new IllegalArgumentException("Invalid version-qualifier " + versionQualifier + " with version-suffix " + versionSuffix + ": the current stage is " + Settings.latestVersionPhase);
+          }
+          if (!versionNumber.isEmpty() &&
+              VersionInfo.getInstance(versionNumber) != Settings.LATEST_VERSION_INFO) {
+            throw new IllegalArgumentException("Invalid version-qualifier " + versionQualifier + " with version-suffix " + versionNumber + ": the current " + versionSuffix + " version is " + Settings.latestVersion);
+          }
+          return Settings.LATEST_VERSION_INFO;
+        } else {
+          var result = VersionInfo.getInstance(versionNumber);
+          if (result == Settings.LATEST_VERSION_INFO && requireSuffixForLatest) {
+            throw new IllegalArgumentException("Invalid version-qualifier " + versionQualifier + " version-suffix " + Settings.latestVersionPhase + " required for unpublished version");
+          }
+          return result;
+        }
+      }
+    }
+  }
+
+  @Override
+  public boolean applyPropertyAlias(String beforeEquals, String afterEquals, UnicodeSet result) {
+    String leftHandSide = beforeEquals;
+    String propertyPredicate = afterEquals;
+    boolean interiorlyNegated = false;
+    int posNotEqual = beforeEquals.indexOf('≠');
+    // TODO(egg): We cannot distinguish \p{X=} from \p{X} in this API, both give us an empty string
+    // as afterEquals.
+    if (posNotEqual >= 0) {
+      propertyPredicate = afterEquals.length() == 0
+          ? beforeEquals.substring(posNotEqual + 1)
+          : beforeEquals.substring(posNotEqual + 1) + "=" + afterEquals;
+      leftHandSide = beforeEquals.substring(0, posNotEqual);
+      interiorlyNegated = true;
+    }
+
+    final var queriedPropertyName = new StringBuilder(leftHandSide);
+    final var queriedVersion = parseVersionQualifier(queriedPropertyName);
+    final var deducedQueriedVersion = queriedVersion == null ? implicitVersion : queriedVersion;
+
+    final var queriedUcd = IndexUnicodeProperties.make(deducedQueriedVersion);
+
+    var generalCategory = queriedUcd.getProperty(UcdProperty.General_Category);
+    var script = queriedUcd.getProperty(UcdProperty.Script);
+
+    UnicodeProperty queriedProperty = queriedUcd.getProperty(queriedPropertyName.toString());
+    if (propertyPredicate.length() != 0) {
+      if (queriedProperty == null) {
+        propertyValue = propertyValue.trim();
+      } else if (prop.isTrimmable()) {
+        propertyValue = propertyValue.trim();
+      } else {
+        int debug = 0;
+      }
+      status = applyPropertyAlias0(prop, propertyValue, result, invert);
+    } else {
+      try {
+        status = applyPropertyAlias0(gcProp, versionlessPropertyName, result, invert);
+      } catch (Exception e) {
+      }
+      ;
+      if (!status) {
+        try {
+          status = applyPropertyAlias0(
+              scProp, versionlessPropertyName, result, invert);
+        } catch (Exception e) {
+        }
+        if (!status) {
+          if (prop.isType(UnicodeProperty.BINARY_OR_ENUMERATED_OR_CATALOG_MASK)) {
+            try {
+              status = applyPropertyAlias0(prop, "No", result, !invert);
+            } catch (Exception e) {
+            }
+          }
+          if (!status) {
+            status = applyPropertyAlias0(prop, "", result, invert);
+          }
+        }
+      }
+    }
+    //TODO(egg):Something about a factory as a fallback;
+    return status;
+  }
+
+  private VersionInfo implicitVersion;
+  private VersionInfo previousVersion;
+  private boolean requireSuffixForLatest;
+}

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
@@ -191,15 +191,13 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
 
         if (propertyPredicate.length() == 0) {
             // Either unary-property-query, or binary-property-query with an empty property-value.
-            try {
-                return queriedProperties
-                        .getProperty(UcdProperty.Script)
-                        .getSet(unqualifiedLeftHandSide.toString());
-            } catch (Exception e) {
+            final var script = queriedProperties.getProperty(UcdProperty.Script);
+            final var generalCategory = queriedProperties.getProperty(UcdProperty.General_Category);
+            if (script.isValidValue(unqualifiedLeftHandSide.toString())) {
+                return script.getSet(unqualifiedLeftHandSide.toString());
             }
-            try {
+            if (generalCategory.isValidValue(unqualifiedLeftHandSide.toString())) {
                 return getGeneralCategorySet(queriedProperties, unqualifiedLeftHandSide.toString());
-            } catch (Exception e) {
             }
             UnicodeProperty queriedProperty =
                     queriedProperties.getProperty(unqualifiedLeftHandSide.toString());

--- a/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
+++ b/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.ibm.icu.text.UnicodeSet;
+import java.text.ParsePosition;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,13 +28,33 @@ public class TestVersionedSymbolTable {
                 .contains("𒀀")
                 .doesNotContain("'")
                 .doesNotContain(",");
+        assertThatUnicodeSet("[\\p{lb=OP}-[\\p{ea=F}\\p{ea=W}\\p{ea=H}]]")
+                .contains("(")
+                .doesNotContain("【");
+        assertThatUnicodeSet(
+                        "[\\p{Other_ID_Start}\\p{Other_ID_Continue}"
+                                + "\\p{L}\\p{Nl}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Pc}"
+                                + "-\\p{Pattern_Syntax}"
+                                + "-\\p{Pattern_White_Space}]")
+                .contains("A")
+                .contains("_")
+                .contains("᧚")
+                .doesNotContain("\u2E2F")
+                .doesNotContain("$");
+        assertThatUnicodeSet("[\\p{L}\\p{Nl}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Pc}-[\\u2E2F]]")
+                .contains("A")
+                .contains("_")
+                .doesNotContain("᧚")
+                .doesNotContain("\u2E2F")
+                .doesNotContain("$");
     }
 
     /** Helper class for testing multiple properties of the same UnicodeSet. */
     private static class UnicodeSetTestFluent {
         UnicodeSetTestFluent(String expression) {
             this.expression = expression;
-            set = new UnicodeSet(expression);
+            ParsePosition parsePosition = new ParsePosition(0);
+            set = new UnicodeSet(expression, parsePosition, VersionedSymbolTable.forDevelopment());
             set.complement().complement();
         }
 

--- a/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
+++ b/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
@@ -157,6 +157,14 @@ public class TestVersionedSymbolTable {
         assertThatUnicodeSet("\\p{Script_Extensions=@Script@}").contains("A").doesNotContain("।");
     }
 
+    @Test
+    void testIdentityAndNullQueries() {
+        assertThatUnicodeSet("\\p{scf=@code point@}").contains("a").doesNotContain("A");
+        assertThatUnicodeSet("[:^kIRG_GSource=@none@:]").contains("喵").doesNotContain("𓃠");
+        assertThatUnicodeSet("\\p{Bidi_Paired_Bracket=@none@}")
+                .isEqualToUnicodeSet("\\p{Bidi_Paired_Bracket_Type=None}");
+    }
+
     /** Helper class for testing multiple properties of the same UnicodeSet. */
     private static class UnicodeSetTestFluent {
         UnicodeSetTestFluent(String expression) {

--- a/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
+++ b/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
@@ -10,6 +10,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Notice to the maintainer: These tests check that the UnicodeSet property queries are correctly
+ * parsed. They are not here to test property assignments. Mostly they check, for every valid
+ * expression, that the set is nonempty, not equal to the entire code space, and that it appears
+ * reasonable. If they are broken by changes to property assignments, feel free to update them.
+ */
 public class TestVersionedSymbolTable {
     @BeforeEach
     void setUp() {

--- a/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
+++ b/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
@@ -1,70 +1,80 @@
 package org.unicode.text.UCD;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Arrays;
-
+import com.ibm.icu.text.UnicodeSet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.unicode.props.IndexUnicodeProperties;
-import org.unicode.props.UcdProperty;
-import org.unicode.props.UcdPropertyValues;
-
-import com.ibm.icu.text.UnicodeSet;
 
 public class TestVersionedSymbolTable {
-  @BeforeEach
-  void setUp() {
-    UnicodeSet.setDefaultXSymbolTable(VersionedSymbolTable.forDevelopment());
-  }
-
-  @AfterEach
-  void tearDown() {
-    UnicodeSet.setDefaultXSymbolTable(NO_PROPS);
-  }
-
-  @Test
-  void testIntroductionExamples() {
-    assertThatUnicodeSet("\\p{XID_Continue}").containsAll("a", "α", "𒀀").containsNone("'", ",");
-  }
-
-  /**
-   * Helper class for testing multiple properties of the same UnicodeSet.
-   */
-  static class UnicodeSetTestFluent {
-    UnicodeSetTestFluent(UnicodeSet set) {}
-    public <T extends CharSequence> UnicodeSetTestFluent isEqualTo(UnicodeSet collection) {
-      assertTrue(set.equals(collection));
-      return this;
+    @BeforeEach
+    void setUp() {
+        UnicodeSet.setDefaultXSymbolTable(VersionedSymbolTable.forDevelopment());
     }
-    public <T extends CharSequence> UnicodeSetTestFluent containsNone(CharSequence... collection) {
-      assertTrue(set.containsNone(Arrays.asList(collection)));
-      return this;
-    }
-    public UnicodeSetTestFluent containsAll(CharSequence... collection) {
-      assertTrue(set.containsAll(Arrays.asList(collection)));
-      return this;
-    }
-    private UnicodeSet set;
-  }
 
-  private UnicodeSetTestFluent assertThatUnicodeSet(String expression) {
-    return new UnicodeSetTestFluent(new UnicodeSet(expression));
-  }
+    @AfterEach
+    void tearDown() {
+        UnicodeSet.setDefaultXSymbolTable(NO_PROPS);
+    }
 
-  static UnicodeSet.XSymbolTable NO_PROPS =
-  new UnicodeSet.XSymbolTable() {
-      @Override
-      public boolean applyPropertyAlias(
-              String propertyName, String propertyValue, UnicodeSet result) {
-          throw new IllegalArgumentException(
-                  "Don't use any ICU Unicode Properties! "
-                          + propertyName
-                          + "="
-                          + propertyValue);
-      }
-      ;
-  };
+    @Test
+    void testIntroductionExamples() {
+        assertThatUnicodeSet("\\p{XID_Continue}")
+                .contains("a")
+                .contains("α")
+                .contains("𒀀")
+                .doesNotContain("'")
+                .doesNotContain(",");
+    }
+
+    /** Helper class for testing multiple properties of the same UnicodeSet. */
+    private static class UnicodeSetTestFluent {
+        UnicodeSetTestFluent(String expression) {
+            this.expression = expression;
+            set = new UnicodeSet(expression);
+            set.complement().complement();
+        }
+
+        public <T extends CharSequence> UnicodeSetTestFluent isEqualTo(UnicodeSet collection) {
+            assertTrue(set.equals(collection));
+            return this;
+        }
+
+        public <T extends CharSequence> UnicodeSetTestFluent doesNotContain(CharSequence element) {
+            assertFalse(
+                    set.contains(element),
+                    element + " ∉ " + expression + " = " + set.toPattern(true));
+            return this;
+        }
+
+        public UnicodeSetTestFluent contains(CharSequence element) {
+            assertTrue(
+                    set.contains(element),
+                    element + " ∈ " + expression + " = " + set.toPattern(true));
+            return this;
+        }
+
+        private UnicodeSet set;
+        private String expression;
+    }
+
+    private UnicodeSetTestFluent assertThatUnicodeSet(String expression) {
+        return new UnicodeSetTestFluent(expression);
+    }
+
+    static UnicodeSet.XSymbolTable NO_PROPS =
+            new UnicodeSet.XSymbolTable() {
+                @Override
+                public boolean applyPropertyAlias(
+                        String propertyName, String propertyValue, UnicodeSet result) {
+                    throw new IllegalArgumentException(
+                            "Don't use any ICU Unicode Properties! "
+                                    + propertyName
+                                    + "="
+                                    + propertyValue);
+                }
+                ;
+            };
 }

--- a/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
+++ b/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
@@ -238,7 +238,7 @@ public class TestVersionedSymbolTable {
         assertThatUnicodeSet("\\p{Script=/ Gondi/}").isEmpty();
         assertThatUnicodeSet("\\p{Script=/_Gondi/}").contains("𑴀").contains("𑵠");
         assertThatUnicodeSet("\\p{gc=/Cased_Letter/}").isEmpty();
-        assertThatUnicodeSet("\\p{gc=/Cased_Letter/}")
+        assertThatUnicodeSet("\\p{gc=Cased_Letter}")
                 .contains("a")
                 .contains("A")
                 .doesNotContain("𒀀");

--- a/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
+++ b/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
@@ -275,10 +275,28 @@ public class TestVersionedSymbolTable {
             final var expected = new UnicodeSet(expectedExpression);
             assertTrue(
                     set.containsAll(expected),
-                    expected + " ⊆ " + expression + " = " + set.toPattern(true));
+                    "Expected "
+                            + expected
+                            + " ⊆ "
+                            + expression
+                            + " = "
+                            + set.toPattern(true)
+                            + " but "
+                            + expression
+                            + " is missing "
+                            + expected.removeAll(set));
             assertTrue(
                     expected.containsAll(set),
-                    expected + " ⊇ " + expression + " = " + set.toPattern(true));
+                    "Expected "
+                            + expected
+                            + " ⊇ "
+                            + expression
+                            + " = "
+                            + set.toPattern(true)
+                            + " but "
+                            + expression
+                            + " contains unexpected "
+                            + set.removeAll(expected));
             return this;
         }
 

--- a/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
+++ b/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
@@ -113,6 +113,7 @@ public class TestVersionedSymbolTable {
 
     @Test
     void testPropertyComparisons() {
+        // From the first set of examples in the section.
         assertThatUnicodeSet("\\p{scf=@lc@}").contains("Σ").contains("σ").doesNotContain("ς");
         assertThatUnicodeSet("\\p{U15.1:scf=@U15.1:lc@}")
                 .contains("Σ")
@@ -132,6 +133,7 @@ public class TestVersionedSymbolTable {
         assertThatUnicodeSet("\\p{case folding=@U16:code point@}")
                 .isIllFormed("comparison version on identity query");
 
+        // From the third set of examples in the section.
         assertThatUnicodeSet("\\p{Decomposition_Mapping=@Ideographic@}")
                 .isIllFormed(
                         "comparison between String property Decomposition_Mapping and"
@@ -142,6 +144,17 @@ public class TestVersionedSymbolTable {
                                 + "-[\\p{Uppercase}&\\p{Changes_When_Lowercased}]]")
                 .contains("𝔄")
                 .doesNotContain("A");
+        assertThatUnicodeSet("\\p{scf≠@cf@}").contains("ß").doesNotContain("ς");
+        assertThatUnicodeSet("\\p{Numeric_Value=@kPrimaryNumeric@}")
+                .contains("A")
+                .contains("喵")
+                .contains("一")
+                .contains("五")
+                .doesNotContain("1")
+                .doesNotContain("伍");
+        // \p{U15.0:Line_Break≠@U15.1:Line_Break@} covered above.
+        assertThatUnicodeSet("\\p{U16.0:kPrimaryNumeric≠@U17.0:kPrimaryNumeric@}").consistsOf("兆");
+        assertThatUnicodeSet("\\p{Script_Extensions=@Script@}").contains("A").doesNotContain("।");
     }
 
     /** Helper class for testing multiple properties of the same UnicodeSet. */

--- a/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
+++ b/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
@@ -111,6 +111,39 @@ public class TestVersionedSymbolTable {
         assertThatUnicodeSet("\\p{Age=/1/}").isIllFormed("regular-expression-match for Age");
     }
 
+    @Test
+    void testPropertyComparisons() {
+        assertThatUnicodeSet("\\p{scf=@lc@}").contains("Σ").contains("σ").doesNotContain("ς");
+        assertThatUnicodeSet("\\p{U15.1:scf=@U15.1:lc@}")
+                .contains("Σ")
+                .contains("σ")
+                .doesNotContain("ς");
+        assertThatUnicodeSet("\\p{U15.0:Line_Break≠@U15.1:Line_Break@}")
+                .contains("ᯤ")
+                .doesNotContain("i");
+        assertThatUnicodeSet("\\p{kIRG_GSource=@none@}").contains("𒇽").doesNotContain("人");
+        assertThatUnicodeSet("\\p{case folding=@code point@}")
+                .contains("s")
+                .doesNotContain("S")
+                .doesNotContain("ſ")
+                .doesNotContain("ß");
+        assertThatUnicodeSet("\\p{kIRG_GSource=@U16:none@}")
+                .isIllFormed("comparison version on null query");
+        assertThatUnicodeSet("\\p{case folding=@U16:code point@}")
+                .isIllFormed("comparison version on identity query");
+
+        assertThatUnicodeSet("\\p{Decomposition_Mapping=@Ideographic@}")
+                .isIllFormed(
+                        "comparison between String property Decomposition_Mapping and"
+                                + " Binary property Ideographic");
+        assertThatUnicodeSet("\\p{Uppercase≠@Changes_When_Lowercased@}")
+                .isEqualToUnicodeSet(
+                        "[[\\p{Uppercase}\\p{Changes_When_Lowercased}]"
+                                + "-[\\p{Uppercase}&\\p{Changes_When_Lowercased}]]")
+                .contains("𝔄")
+                .doesNotContain("A");
+    }
+
     /** Helper class for testing multiple properties of the same UnicodeSet. */
     private static class UnicodeSetTestFluent {
         UnicodeSetTestFluent(String expression) {

--- a/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
+++ b/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.ibm.icu.text.UnicodeSet;
+import com.ibm.icu.text.UnicodeSet.XSymbolTable;
+
 import java.text.ParsePosition;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,14 +19,17 @@ import org.junit.jupiter.api.Test;
  * reasonable. If they are broken by changes to property assignments, feel free to update them.
  */
 public class TestVersionedSymbolTable {
+   XSymbolTable old_default;
+
     @BeforeEach
     void setUp() {
+        old_default = UnicodeSet.getDefaultXSymbolTable();
         UnicodeSet.setDefaultXSymbolTable(VersionedSymbolTable.forDevelopment());
     }
 
     @AfterEach
     void tearDown() {
-        UnicodeSet.setDefaultXSymbolTable(NO_PROPS);
+        UnicodeSet.setDefaultXSymbolTable(old_default);
     }
 
     @Test
@@ -338,18 +343,4 @@ public class TestVersionedSymbolTable {
     private UnicodeSetTestFluent assertThatUnicodeSet(String expression) {
         return new UnicodeSetTestFluent(expression);
     }
-
-    static UnicodeSet.XSymbolTable NO_PROPS =
-            new UnicodeSet.XSymbolTable() {
-                @Override
-                public boolean applyPropertyAlias(
-                        String propertyName, String propertyValue, UnicodeSet result) {
-                    throw new IllegalArgumentException(
-                            "Don't use any ICU Unicode Properties! "
-                                    + propertyName
-                                    + "="
-                                    + propertyValue);
-                }
-                ;
-            };
 }

--- a/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
+++ b/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.ibm.icu.text.UnicodeSet;
-import com.ibm.icu.text.UnicodeSet.XSymbolTable;
 import java.text.ParsePosition;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,17 +17,17 @@ import org.junit.jupiter.api.Test;
  * reasonable. If they are broken by changes to property assignments, feel free to update them.
  */
 public class TestVersionedSymbolTable {
-    XSymbolTable old_default;
+    UnicodeSet.XSymbolTable oldDefault;
 
     @BeforeEach
     void setUp() {
-        old_default = UnicodeSet.getDefaultXSymbolTable();
+        oldDefault = UnicodeSet.getDefaultXSymbolTable();
         UnicodeSet.setDefaultXSymbolTable(VersionedSymbolTable.forDevelopment());
     }
 
     @AfterEach
     void tearDown() {
-        UnicodeSet.setDefaultXSymbolTable(old_default);
+        UnicodeSet.setDefaultXSymbolTable(oldDefault);
     }
 
     @Test

--- a/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
+++ b/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
@@ -284,7 +284,7 @@ public class TestVersionedSymbolTable {
                             + " but "
                             + expression
                             + " is missing "
-                            + expected.removeAll(set));
+                            + expected.cloneAsThawed().removeAll(set));
             assertTrue(
                     expected.containsAll(set),
                     "Expected "
@@ -296,7 +296,7 @@ public class TestVersionedSymbolTable {
                             + " but "
                             + expression
                             + " contains unexpected "
-                            + set.removeAll(expected));
+                            + set.cloneAsThawed().removeAll(expected));
             return this;
         }
 

--- a/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
+++ b/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
@@ -212,6 +212,38 @@ public class TestVersionedSymbolTable {
                 .consistsOf("\n");
     }
 
+    @Test
+    void testRegularExpressionQueries() {
+        assertThatUnicodeSet("\\p{Name=/CAPITAL LETTER/}").contains("A").doesNotContain("a");
+        assertThatUnicodeSet("\\p{Block=/^Cyrillic/}")
+                .contains("и")
+                .contains("\u1C8B")
+                .contains("\u1C8F")
+                .contains("ꙮ")
+                .doesNotContain("k");
+        assertThatUnicodeSet("\\p{scx=/Gondi/}")
+                .isEqualToUnicodeSet("[\\p{scx=Gunjala_Gondi}\\p{scx=Masaram_Gondi}]")
+                .contains("𑴀")
+                .contains("𑵠")
+                .contains("।")
+                .doesNotContain("a");
+        assertThatUnicodeSet("\\p{gc=/^P/}")
+                .isEqualToUnicodeSet("[\\p{Punctuation} \\p{Private Use} \\u2029]");
+
+        assertThatUnicodeSet("\\p{Name=/NO BREAK SPACE/}").isEmpty();
+        assertThatUnicodeSet("\\p{Name=/NO-BREAK SPACE/}")
+                .contains("\u00A0")
+                .contains("\u202F")
+                .contains("\uFEFF");
+        assertThatUnicodeSet("\\p{Script=/ Gondi/}").isEmpty();
+        assertThatUnicodeSet("\\p{Script=/_Gondi/}").contains("𑴀").contains("𑵠");
+        assertThatUnicodeSet("\\p{gc=/Cased_Letter/}").isEmpty();
+        assertThatUnicodeSet("\\p{gc=/Cased_Letter/}")
+                .contains("a")
+                .contains("A")
+                .doesNotContain("𒀀");
+    }
+
     /** Helper class for testing multiple properties of the same UnicodeSet. */
     private static class UnicodeSetTestFluent {
         UnicodeSetTestFluent(String expression) {

--- a/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
+++ b/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
@@ -1,0 +1,70 @@
+package org.unicode.text.UCD;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.unicode.props.IndexUnicodeProperties;
+import org.unicode.props.UcdProperty;
+import org.unicode.props.UcdPropertyValues;
+
+import com.ibm.icu.text.UnicodeSet;
+
+public class TestVersionedSymbolTable {
+  @BeforeEach
+  void setUp() {
+    UnicodeSet.setDefaultXSymbolTable(VersionedSymbolTable.forDevelopment());
+  }
+
+  @AfterEach
+  void tearDown() {
+    UnicodeSet.setDefaultXSymbolTable(NO_PROPS);
+  }
+
+  @Test
+  void testIntroductionExamples() {
+    assertThatUnicodeSet("\\p{XID_Continue}").containsAll("a", "α", "𒀀").containsNone("'", ",");
+  }
+
+  /**
+   * Helper class for testing multiple properties of the same UnicodeSet.
+   */
+  static class UnicodeSetTestFluent {
+    UnicodeSetTestFluent(UnicodeSet set) {}
+    public <T extends CharSequence> UnicodeSetTestFluent isEqualTo(UnicodeSet collection) {
+      assertTrue(set.equals(collection));
+      return this;
+    }
+    public <T extends CharSequence> UnicodeSetTestFluent containsNone(CharSequence... collection) {
+      assertTrue(set.containsNone(Arrays.asList(collection)));
+      return this;
+    }
+    public UnicodeSetTestFluent containsAll(CharSequence... collection) {
+      assertTrue(set.containsAll(Arrays.asList(collection)));
+      return this;
+    }
+    private UnicodeSet set;
+  }
+
+  private UnicodeSetTestFluent assertThatUnicodeSet(String expression) {
+    return new UnicodeSetTestFluent(new UnicodeSet(expression));
+  }
+
+  static UnicodeSet.XSymbolTable NO_PROPS =
+  new UnicodeSet.XSymbolTable() {
+      @Override
+      public boolean applyPropertyAlias(
+              String propertyName, String propertyValue, UnicodeSet result) {
+          throw new IllegalArgumentException(
+                  "Don't use any ICU Unicode Properties! "
+                          + propertyName
+                          + "="
+                          + propertyValue);
+      }
+      ;
+  };
+}

--- a/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
+++ b/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSet.XSymbolTable;
-
 import java.text.ParsePosition;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,7 +18,7 @@ import org.junit.jupiter.api.Test;
  * reasonable. If they are broken by changes to property assignments, feel free to update them.
  */
 public class TestVersionedSymbolTable {
-   XSymbolTable old_default;
+    XSymbolTable old_default;
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
Clearly our problem of proliferation of symbol tables will be solved by adding yet another one; so far not used, and tested against examples from the working draft UnicodeSet spec.

This should be able to replace most of the existing symbol tables as-is. It needs some tweaking before I can use it in the invariant tests, so that it can use the versioned ToolUnicodeProperties[^retire] in some circumstances.

Towards #1073 and #1074.

[^retire]: Yes, those ones: #639. We’re not retiring them just yet…
