### PR TITLE
Python lint

### DIFF
--- a/py/splitunihan.py
+++ b/py/splitunihan.py
@@ -53,7 +53,6 @@ def ParseFile(in_file, root_path):
 
 
 def main():
-  global _prop_data
   root_path = sys.argv[1]
   pattern = os.path.join(root_path, "Unihan*.txt")
   paths = glob.glob(pattern)


### PR DESCRIPTION
It looks like the linter got an update, and it is now annoyed at an unnecessary `global` (`_prop_data` is used but not assigned in `main()`).