### PR TITLE
Improvements to property history

### DIFF
--- a/UnicodeJsps/src/main/webapp/index.css
+++ b/UnicodeJsps/src/main/webapp/index.css
@@ -31,6 +31,7 @@ h3 {background-color: #EEEEEE}
 .L1 {background-color: #CCCCCC}
 .L0 {background-color: #C8C8C8} 
 .default           { background-color: #C8C8C8}
+.nonexistent       { background-color: #FFC8C8}
 .control {
   font-family: 'Last Resort'
 }

--- a/unicodetools/src/main/java/org/unicode/props/PropertyParsingInfo.java
+++ b/unicodetools/src/main/java/org/unicode/props/PropertyParsingInfo.java
@@ -800,6 +800,13 @@ public class PropertyParsingInfo implements Comparable<PropertyParsingInfo> {
                 }
                 continue;
             }
+            if (line.trim().equals("Discrepancy B: UnicodeData but not Unilib")) {
+                // Unicode 2.1.8 includes a diff between Unilib properties used in 2.1.5 and 2.1.9
+                // and something resembling the derivations that would later be used in Unicode 3.1,
+                // but without the Other_* exceptions introduced in Unicode 3.1.
+                // We follow Unilib for continuity.
+                propInfo = null;
+            }
             if (propInfo != null && dataLine.matcher(line).matches()) {
                 var range = new UcdLineParser.IntRange();
                 range.set(line.split(" ", 2)[0]);


### PR DESCRIPTION
## Old dumps.

PropList-2.1.8.txt includes a diff between Unilib properties and what it calls « UnicodeData ». The « UnicodeData » values appear to prefigure the 3.1 derivation for, e.g., Alphabetic, but without the Other_Alphabetic exceptions. Ignoring the Discrepancy heading means we currently take the union of the Unilib and « UnicodeData » sets, which is nonsense. The Unilib set is the more useful one for historical investigation, as it is consistent with the files included in 2.1.5 and 2.1.9 (whereas taking the « UnicodeData » set introduces massive discrepancies that are immediately reverted in 2.1.9).
![image](https://github.com/user-attachments/assets/ebeab7bf-bfab-4900-9a92-f0d6ffe52d69)

Currently, `\P{U2.1.8:Alphabetic=@U2.1.9:Alphabetic@}` has 21226 code points, and `\P{U2.1.8:Alphabetic=@U2.1.5:Alphabetic@}` has 21236 code points, whereas `\P{U2.1.9:Alphabetic=@U2.1.5:Alphabetic@}` has 10 code points. With this change, U2.1.9:Alphabetic and U2.1.8:Alphabetic are identical.

## History tables.

Currently, the Unihan history for U+3400 looks like (A) below.
Because of multiple changes to a few properties, many other properties are squished into a column so narrow that the null does not fit on one line. In addition, there is no relation between the columns: synchronous changes are not aligned, and aligned changes may be decades apart.

With this change, the history of the same properties is displayed as in (B), both more compact and more informative as to the synchronicity of changes and the lifetime of properties.

| (A) | (B) |
|---|---|
| ![image](https://github.com/user-attachments/assets/c5eb1b50-90ad-4d5f-9b07-16ca29b7292c) ![image](https://github.com/user-attachments/assets/467af2ce-8c3b-4e31-ac48-d90eb15d488d) | ![image](https://github.com/user-attachments/assets/15f31486-b1fb-436a-a111-c5f96ef7682b) ![image](https://github.com/user-attachments/assets/43ef5796-b0a9-4f57-86b7-d9705c1b058c) |
