### PR TITLE
kMandarin, kTotalStrokes, and kUnihanCore2020 in PropertyAliases.txt

### DIFF
--- a/unicodetools/data/ucd/dev/PropertyAliases.txt
+++ b/unicodetools/data/ucd/dev/PropertyAliases.txt
@@ -96,7 +96,10 @@ cjkIRG_TSource           ; kIRG_TSource
 cjkIRG_UKSource          ; kIRG_UKSource
 cjkIRG_USource           ; kIRG_USource
 cjkIRG_VSource           ; kIRG_VSource
+cjkMandarin              ; kMandarin
 cjkRSUnicode             ; kRSUnicode                  ; Unicode_Radical_Stroke; URS
+cjkTotalStrokes          ; kTotalStrokes
+cjkUnihanCore2020        ; kUnihanCore2020
 isc                      ; ISO_Comment
 JSN                      ; Jamo_Short_Name
 kEH_Cat                  ; kEH_Cat

--- a/unicodetools/data/ucd/dev/PropertyAliases.txt
+++ b/unicodetools/data/ucd/dev/PropertyAliases.txt
@@ -1,5 +1,5 @@
 # PropertyAliases-17.0.0.txt
-# Date: 2025-04-25, 13:37:02 GMT
+# Date: 2025-04-25, 14:00:52 GMT
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -48,8 +48,11 @@
 #
 # The combination of property value and property name is, however, unique.
 #
-# For more information, see UAX #44, Unicode Character Database, and
-# UTS #18, Unicode Regular Expressions.
+# For more information, see:
+# - UAX #44, Unicode Character Database;
+# - UAX #38, Unicode Han Database (Unihan);
+# - UAX #57, Unicode Egyptian Hieroglyph Database (Unikemet);
+# - UTS #18, Unicode Regular Expressions.
 # ================================================
 
 

--- a/unicodetools/data/ucd/dev/PropertyAliases.txt
+++ b/unicodetools/data/ucd/dev/PropertyAliases.txt
@@ -1,5 +1,5 @@
 # PropertyAliases-17.0.0.txt
-# Date: 2025-01-27, 18:09:29 GMT
+# Date: 2025-04-25, 13:37:02 GMT
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -223,6 +223,6 @@ XO_NFKC                  ; Expands_On_NFKC
 XO_NFKD                  ; Expands_On_NFKD
 
 # ================================================
-# Total:    142
+# Total:    145
 
 # EOF

--- a/unicodetools/data/ucd/dev/PropertyValueAliases.txt
+++ b/unicodetools/data/ucd/dev/PropertyValueAliases.txt
@@ -1,5 +1,5 @@
 # PropertyValueAliases-17.0.0.txt
-# Date: 2025-02-14, 15:50:28 GMT
+# Date: 2025-04-25, 13:37:02 GMT
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -1721,5 +1721,17 @@ kEH_NoMirror; Y                       ; Yes                              ; T    
 
 kEH_NoRotate; N                       ; No                               ; F                                ; False
 kEH_NoRotate; Y                       ; Yes                              ; T                                ; True
+
+# kMandarin (cjkMandarin)
+
+# @missing: 0000..10FFFF; kMandarin; <none>
+
+# kTotalStrokes (cjkTotalStrokes)
+
+# @missing: 0000..10FFFF; kTotalStrokes; <none>
+
+# kUnihanCore2020 (cjkUnihanCore2020)
+
+# @missing: 0000..10FFFF; kUnihanCore2020; <none>
 
 # EOF

--- a/unicodetools/src/main/java/org/unicode/props/UcdProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UcdProperty.java
@@ -348,7 +348,7 @@ public enum UcdProperty {
             PropertyType.Miscellaneous, DerivedPropertyStatus.Provisional, "cjkMainlandTelegraph"),
     kMandarin(
             PropertyType.Miscellaneous,
-            DerivedPropertyStatus.Provisional,
+            DerivedPropertyStatus.Approved,
             null,
             ValueCardinality.Ordered,
             "cjkMandarin"),
@@ -468,12 +468,12 @@ public enum UcdProperty {
             "cjkTang"),
     kTotalStrokes(
             PropertyType.Miscellaneous,
-            DerivedPropertyStatus.Provisional,
+            DerivedPropertyStatus.Approved,
             null,
             ValueCardinality.Ordered,
             "cjkTotalStrokes"),
     kUnihanCore2020(
-            PropertyType.Miscellaneous, DerivedPropertyStatus.Provisional, "cjkUnihanCore2020"),
+            PropertyType.Miscellaneous, DerivedPropertyStatus.Approved, "cjkUnihanCore2020"),
     kVietnamese(
             PropertyType.Miscellaneous,
             DerivedPropertyStatus.Provisional,

--- a/unicodetools/src/main/java/org/unicode/text/UCD/ToolUnicodePropertySource.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/ToolUnicodePropertySource.java
@@ -309,6 +309,9 @@ public class ToolUnicodePropertySource extends UnicodeProperty.Factory {
                 "cjkIRG_VSource",
                 "cjkIRG_VSource",
                 "kIRG_VSource");
+        add(iup.getProperty("kMandarin"));
+        add(iup.getProperty("kTotalStrokes"));
+        add(iup.getProperty("kUnihanCore2020"));
         add(iup.getProperty("kEH_Cat"));
         add(iup.getProperty("kEH_Desc"));
         add(iup.getProperty("kEH_HG"));

--- a/unicodetools/src/main/resources/org/unicode/props/ExtraPropertyAliases.txt
+++ b/unicodetools/src/main/resources/org/unicode/props/ExtraPropertyAliases.txt
@@ -112,7 +112,6 @@ cjkGradeLevel ; kGradeLevel ; Provisional
 cjkHDZRadBreak ; kHDZRadBreak ; Provisional
 cjkHKGlyph ; kHKGlyph ; Provisional
 cjkPhonetic ; kPhonetic ; Provisional
-cjkTotalStrokes ; kTotalStrokes ; Provisional
 cjkBigFive ; kBigFive ; Provisional
 cjkCCCII ; kCCCII ; Provisional
 cjkCNS1986 ; kCNS1986 ; Provisional
@@ -151,7 +150,6 @@ cjkHanyuPinyin ; kHanyuPinyin ; Provisional
 cjkJapaneseKun ; kJapaneseKun ; Provisional
 cjkJapaneseOn ; kJapaneseOn ; Provisional
 cjkKorean ; kKorean ; Provisional
-cjkMandarin ; kMandarin ; Provisional
 cjkTang ; kTang ; Provisional
 cjkVietnamese ; kVietnamese ; Provisional
 cjkXHC1983 ; kXHC1983 ; Provisional
@@ -166,7 +164,6 @@ cjkTGH ; kTGH ; Provisional
 # 13.0
 cjkSpoofingVariant       ; kSpoofingVariant ; Provisional
 cjkTGHZ2013              ; kTGHZ2013 ; Provisional
-cjkUnihanCore2020        ; kUnihanCore2020 ; Provisional
 # 14.0
 cjkStrange               ; kStrange ; Provisional
 # 15.0

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/PropertyAliasesHeader.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/PropertyAliasesHeader.txt
@@ -40,7 +40,10 @@
 #
 # The combination of property value and property name is, however, unique.
 #
-# For more information, see UAX #44, Unicode Character Database, and
-# UTS #18, Unicode Regular Expressions.
+# For more information, see:
+# - UAX #44, Unicode Character Database;
+# - UAX #38, Unicode Han Database (Unihan);
+# - UAX #57, Unicode Egyptian Hieroglyph Database (Unikemet);
+# - UTS #18, Unicode Regular Expressions.
 # ================================================
 


### PR DESCRIPTION
**[[183-C28](https://www.unicode.org/cgi-bin/GetL2Ref.pl?183-C28)] Consensus:** Add the Informative properties kMandarin, kTotalStrokes, and kUnihanCore2020 to PropertyAliases.txt, with respective short aliases cjkMandarin, cjkTotalStrokes, and cjkUnihanCore2020. For Unicode Version 17.0. See [L2/25-087](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/25-087) item 1.5.

**[[183-A57](https://www.unicode.org/cgi-bin/GetL2Ref.pl?183-A57)] Action Item for** Robin Leroy, PAG: In UCD file PropertyAliases.txt, add the Informative properties kMandarin, kTotalStrokes, and kUnihanCore2020, with respective short aliases cjkMandarin, cjkTotalStrokes, and cjkUnihanCore2020. For Unicode Version 17.0. See [L2/25-087](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/25-087) item 1.5.

**[[183-A58](https://www.unicode.org/cgi-bin/GetL2Ref.pl?183-A58)] Action Item for** Robin Leroy, PAG: In UCD file PropertyAliases.txt, add references to UAX #38 and UAX #57.