### PR TITLE
Three Hebrew diacritics

### DIFF
--- a/unicodetools/data/ucd/dev/PropList.txt
+++ b/unicodetools/data/ucd/dev/PropList.txt
@@ -1,9 +1,5 @@
-05A2 ; Diacritic
-05C5 ; Diacritic
-05C7 ; Diacritic
-
 # PropList-17.0.0.txt
-# Date: 2025-04-25, 15:40:08 GMT
+# Date: 2025-04-29, 14:56:00 GMT
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -931,11 +927,11 @@ FA70..FAD9    ; Ideographic # Lo [106] CJK COMPATIBILITY IDEOGRAPH-FA70..CJK COM
 0384..0385    ; Diacritic # Sk   [2] GREEK TONOS..GREEK DIALYTIKA TONOS
 0483..0487    ; Diacritic # Mn   [5] COMBINING CYRILLIC TITLO..COMBINING CYRILLIC POKRYTIE
 0559          ; Diacritic # Lm       ARMENIAN MODIFIER LETTER LEFT HALF RING
-0591..05A1    ; Diacritic # Mn  [17] HEBREW ACCENT ETNAHTA..HEBREW ACCENT PAZER
-05A3..05BD    ; Diacritic # Mn  [27] HEBREW ACCENT MUNAH..HEBREW POINT METEG
+0591..05BD    ; Diacritic # Mn  [45] HEBREW ACCENT ETNAHTA..HEBREW POINT METEG
 05BF          ; Diacritic # Mn       HEBREW POINT RAFE
 05C1..05C2    ; Diacritic # Mn   [2] HEBREW POINT SHIN DOT..HEBREW POINT SIN DOT
-05C4          ; Diacritic # Mn       HEBREW MARK UPPER DOT
+05C4..05C5    ; Diacritic # Mn   [2] HEBREW MARK UPPER DOT..HEBREW MARK LOWER DOT
+05C7          ; Diacritic # Mn       HEBREW POINT QAMATS QATAN
 064B..0652    ; Diacritic # Mn   [8] ARABIC FATHATAN..ARABIC SUKUN
 0657..0658    ; Diacritic # Mn   [2] ARABIC INVERTED DAMMA..ARABIC MARK NOON GHUNNA
 06DF..06E0    ; Diacritic # Mn   [2] ARABIC SMALL HIGH ROUNDED ZERO..ARABIC SMALL HIGH UPRIGHT RECTANGULAR ZERO
@@ -1173,7 +1169,7 @@ FFE3          ; Diacritic # Sk       FULLWIDTH MACRON
 1E944..1E946  ; Diacritic # Mn   [3] ADLAM ALIF LENGTHENER..ADLAM GEMINATION MARK
 1E948..1E94A  ; Diacritic # Mn   [3] ADLAM CONSONANT MODIFIER..ADLAM NUKTA
 
-# Total code points: 1247
+# Total code points: 1250
 
 # ================================================
 

--- a/unicodetools/data/ucd/dev/PropList.txt
+++ b/unicodetools/data/ucd/dev/PropList.txt
@@ -1,3 +1,7 @@
+05A2 ; Diacritic
+05C5 ; Diacritic
+05C7 ; Diacritic
+
 # PropList-17.0.0.txt
 # Date: 2025-04-25, 15:40:08 GMT
 # © 2025 Unicode®, Inc.


### PR DESCRIPTION
[[183-C27](https://www.unicode.org/cgi-bin/GetL2Ref.pl?183-C27)] Consensus: Assign the Diacritic property to U+05A2 HEBREW ACCENT ATNAH HAFUKH, U+05C5 HEBREW MARK LOWER DOT, and U+05C7 HEBREW POINT QAMATS QATAN. For Unicode Version 17.0. See [L2/25-087](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/25-087) item 1.2.

[[183-A56](https://www.unicode.org/cgi-bin/GetL2Ref.pl?183-A56)] Action Item for Robin Leroy, PAG: In UCD file PropList.txt, assign the Diacritic property to U+05A2 HEBREW ACCENT ATNAH HAFUKH, U+05C5 HEBREW MARK LOWER DOT, and U+05C7 HEBREW POINT QAMATS QATAN. For Unicode Version 17.0. See [L2/25-087](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/25-087) item 1.2.

See also unicode-org/properties#381.