### PR TITLE
Various fixes to versioned property utilities

### DIFF
--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeJsp.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeJsp.java
@@ -184,6 +184,9 @@ public class UnicodeJsp {
             a_out = UnicodeUtilities.getPrettySet(a, abbreviate, escape);
         } catch (Exception e) {
             a_out = e.getMessage();
+            for (Throwable cause = e; cause != null; cause = cause.getCause()) {
+                cause.printStackTrace();
+            }
         }
         return a_out;
     }

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
@@ -1703,6 +1703,7 @@ public class UnicodeUtilities {
             // If the property has the value null (<none>), `values` is a one-element list whose
             // sole element is null.
             ArrayList<String> values;
+            boolean isDefault;
             int span;
         }
         final boolean isMultivalued = getFactory().getProperty(propName).isMultivalued();
@@ -1738,6 +1739,7 @@ public class UnicodeUtilities {
                     assignment.first = version;
                     assignment.last = version;
                     assignment.values = values;
+                    assignment.isDefault = property.isDefault(codePoint);
                     assignment.span = 1;
                     history.add(assignment);
                 } else {
@@ -1797,7 +1799,7 @@ public class UnicodeUtilities {
                 String tdClass = "";
                 if (assignment.values == null) {
                     tdClass = "class='nonexistent'";
-                } else if (getFactory().getProperty(propName).isDefault(codePoint)) {
+                } else if (assignment.isDefault) {
                     tdClass = "class='default'";
                 }
                 out.append(

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -14,6 +14,7 @@ import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeMatcher;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
+import com.ibm.icu.util.ICUException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.text.ParsePosition;
@@ -754,7 +755,16 @@ public abstract class UnicodeProperty extends UnicodeLabel {
         if (aIsNaN && bIsNaN) return 0;
         if (aIsNaN) return -1;
         if (bIsNaN) return 1;
-        return RationalParser.BASIC.parse(a).compareTo(RationalParser.BASIC.parse(b));
+        try {
+            return RationalParser.BASIC.parse(a).compareTo(RationalParser.BASIC.parse(b));
+        } catch (ICUException e) {
+            // If either string fails to parse as a rational, compare the strings.
+            // This is nonsense, but we do such comparisons with the UNCHANGED_IN_BASE_VERSION
+            // placeholder string when operating on the chronologically compressed maps (we then
+            // ignore the result by intersecting with the set where the UNCHANGED_IN_BASE_VERSION
+            // placeholder does not appear).
+            return a.compareTo(b);
+        }
     }
 
     public static final Comparator<String> CHARACTER_NAME_COMPARATOR =

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
@@ -315,7 +315,7 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
             } else if (versionNumber.endsWith("α") || versionNumber.endsWith("β")) {
                 final String versionSuffix = versionNumber.substring(versionNumber.length() - 1);
                 versionNumber = versionNumber.substring(0, versionNumber.length() - 1);
-                if (versionSuffix != Settings.latestVersionPhase.toString()) {
+                if (!versionSuffix.equals(Settings.latestVersionPhase.toString())) {
                     throw new IllegalArgumentException(
                             "Invalid version-qualifier "
                                     + versionQualifier


### PR DESCRIPTION
* Allow for gaps in the existence (or at least nontriviality) of a property (or nonproperty). Some of those instances are bugs, see #1118, but some reflect reality, e.g., the vanishing of kSemanticVariant in 2.1.x (shown here for U+3400 in the tools with this change, and in UTN45). 
![image](https://github.com/user-attachments/assets/57e951c2-102b-4a27-911c-d87d448a4346)
![image](https://github.com/user-attachments/assets/2e859e8f-6648-45cf-8baf-0d327ca1208c)
* Fix a bug reported by @macchiati which caused the tools to reject the [version-qualifier](https://www.unicode.org/reports/tr61/#version-qualifier) `U17.0α:`.
* Fix a bug which caused an error in the JSPs on queries on numeric properties for versions other than the current one.