### PR TITLE
change CaseFolding example from MASSE to FUSS

### DIFF
--- a/unicodetools/data/ucd/dev/CaseFolding.txt
+++ b/unicodetools/data/ucd/dev/CaseFolding.txt
@@ -1,5 +1,5 @@
 # CaseFolding-17.0.0.txt
-# Date: 2025-01-27, 18:09:07 GMT
+# Date: 2025-05-02, 21:48:45 GMT
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -18,7 +18,7 @@
 # The data supports both implementations that require simple case foldings
 # (where string lengths don't change), and implementations that allow full case folding
 # (where string lengths may grow). Note that where they can be supported, the
-# full case foldings are superior: for example, they allow "MASSE" and "Maße" to match.
+# full case foldings are superior: for example, they allow "FUSS" and "Fuß" to match.
 #
 # All code points not listed in this file map to themselves.
 #

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/CaseFoldingHeader.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/CaseFoldingHeader.txt
@@ -10,7 +10,7 @@
 # The data supports both implementations that require simple case foldings
 # (where string lengths don't change), and implementations that allow full case folding
 # (where string lengths may grow). Note that where they can be supported, the
-# full case foldings are superior: for example, they allow "MASSE" and "Maße" to match.
+# full case foldings are superior: for example, they allow "FUSS" and "Fuß" to match.
 #
 # All code points not listed in this file map to themselves.
 #


### PR DESCRIPTION
[[183-A59](https://www.unicode.org/cgi-bin/GetL2Ref.pl?183-A59)] Action Item for Markus Scherer, PAG: In CaseFolding.txt, change the full case folding example from "MASSE"/"Maße" to "FUSS"/"Fuß". For Unicode Version 17.0. See [L2/25-087](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/25-087) item 1.6.