### PR TITLE
aux charts (c) 2025 & std ToU

### DIFF
--- a/unicodetools/src/main/java/org/unicode/text/UCA/WriteCharts.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/WriteCharts.java
@@ -1073,10 +1073,11 @@ public class WriteCharts implements UCD_Types {
                         + "\n"
                         + "<hr width=\"50%\">\n"
                         + "\n"
-                        + "<p class=\"copyright\">© 2003–2024 Unicode, Inc.\n"
+                        + "<p class=\"copyright\">© 2003–2025 Unicode, Inc.\n"
                         + "Unicode and the Unicode Logo are registered trademarks of Unicode, Inc.,\n"
                         + "in the U.S. and other countries. "
-                        + "See <a href=\"https://www.unicode.org/copyright.html\">Terms of Use</a>.</p>\n"
+                        + "For terms of use and license, "
+                        + "see <a href=\"https://www.unicode.org/terms_of_use.html\">https://www.unicode.org/terms_of_use.html</a>.</p>\n"
                         + "</body>\n"
                         + "</html>");
         output.close();


### PR DESCRIPTION
For the footer on each contents page of https://www.unicode.org/charts/beta/
- extend the copyright range to 2025
- update to the new standard "For terms of use and license..."