### PR TITLE
pub: UCA -> uca

### DIFF
--- a/pub/copy-beta-to-draft.sh
+++ b/pub/copy-beta-to-draft.sh
@@ -56,8 +56,8 @@ find $DRAFT -name '*ReadMe.txt' | xargs sed -i -f $DRAFT/sed-readmes.txt
 rm $DRAFT/ucd/UCD.zip
 (cd $DRAFT/ucd; zip -r UCD.zip *)
 
-rm $DRAFT/UCA/CollationTest.zip
-(cd $DRAFT/UCA; zip -r CollationTest.zip CollationTest && rm -r CollationTest)
+rm $DRAFT/uca/CollationTest.zip
+(cd $DRAFT/uca; zip -r CollationTest.zip CollationTest && rm -r CollationTest)
 
 rm $DRAFT/security/*.zip
 (cd $DRAFT/security; zip -r uts39-data-$UNI_VER.zip *)

--- a/pub/copy-final.sh
+++ b/pub/copy-final.sh
@@ -64,8 +64,8 @@ find $DEST -name '*ReadMe.txt' | xargs sed -i -f $DEST/sed-readmes.txt
 rm $DEST/$UNI_VER/ucd/UCD.zip
 (cd $DEST/$UNI_VER/ucd; zip -r UCD.zip * && mv UCD.zip $DEST/zipped/$UNI_VER)
 
-rm $DEST/UCA/$UNI_VER/CollationTest.zip
-(cd $DEST/UCA/$UNI_VER; zip -r CollationTest.zip CollationTest && rm -r CollationTest)
+rm $DEST/uca/$UNI_VER/CollationTest.zip
+(cd $DEST/uca/$UNI_VER; zip -r CollationTest.zip CollationTest && rm -r CollationTest)
 
 rm $DEST/security/$UNI_VER/*.zip
 (cd $DEST/security/$UNI_VER; zip -r uts39-data-$UNI_VER.zip *)

--- a/unicodetools/data/uca/dev/ReadMe.txt
+++ b/unicodetools/data/uca/dev/ReadMe.txt
@@ -20,7 +20,7 @@ files for the Unicode Collation Algorithm.
 
 If you accessed this file via
 
-https://www.unicode.org/Public/draft/UCA/ReadMe.txt
+https://www.unicode.org/Public/draft/uca/ReadMe.txt
 
 then you are looking at a draft for the next version of the UCA.
 


### PR DESCRIPTION
Draft & final folders have lowercase "uca" since 17 for consistency.
17 beta is the first time we publish UCA files, so I hadn't noticed until now that the zipping step was broken.