### PR TITLE
Unikemet grouped property attributes and newlines in TR38/57

### DIFF
--- a/unicodetools/src/main/java/org/unicode/xml/AttributeResolver.java
+++ b/unicodetools/src/main/java/org/unicode/xml/AttributeResolver.java
@@ -355,6 +355,6 @@ public class AttributeResolver {
     }
 
     public boolean isUnikemetAttributeRange(int codepoint) {
-        return !getAttributeValue(UcdProperty.kEH_Cat, codepoint).isEmpty();
+        return getAttributeValue(UcdProperty.Block, codepoint).startsWith("Egyptian_Hieroglyph");
     }
 }

--- a/unicodetools/src/main/java/org/unicode/xml/GeneratePropertyValues.java
+++ b/unicodetools/src/main/java/org/unicode/xml/GeneratePropertyValues.java
@@ -1830,7 +1830,9 @@ public class GeneratePropertyValues {
                             isList,
                             matcher.group(3)
                                     .trim()
-                                    .replaceAll("<br>", "")
+                                    .replaceAll("\r", "")
+                                    .replaceAll("<br>", "\n")
+                                    .replaceAll("\n\n", "\n")
                                     .replaceAll("<span class=\"removed\">.*?</span>", "")
                                     .replaceAll("<span class=\"changed\">", "")
                                     .replaceAll("</span>", ""));

--- a/unicodetools/src/main/java/org/unicode/xml/UCDXML.java
+++ b/unicodetools/src/main/java/org/unicode/xml/UCDXML.java
@@ -21,7 +21,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.xml.transform.TransformerConfigurationException;
 import org.unicode.props.IndexUnicodeProperties;
-import org.unicode.props.PropertyType;
 import org.unicode.props.UcdProperty;
 import org.unicode.props.UcdPropertyValues;
 import org.unicode.text.utility.Settings;
@@ -408,7 +407,12 @@ public class UCDXML {
                                         outputRange);
                             } else {
                                 buildUngroupedRange(
-                                        writer, attributeResolver, ucdVersion, range, rangeType, outputRange);
+                                        writer,
+                                        attributeResolver,
+                                        ucdVersion,
+                                        range,
+                                        rangeType,
+                                        outputRange);
                             }
                         }
                         range.clear();
@@ -430,7 +434,12 @@ public class UCDXML {
                                     outputRange);
                         } else {
                             buildUngroupedRange(
-                                    writer, attributeResolver, ucdVersion, range, rangeType, outputRange);
+                                    writer,
+                                    attributeResolver,
+                                    ucdVersion,
+                                    range,
+                                    rangeType,
+                                    outputRange);
                         }
                     }
                     range.clear();
@@ -457,9 +466,16 @@ public class UCDXML {
             if (outputRange != UCDXMLOUTPUTRANGE.UNIHAN) {
                 if (outputType == UCDXMLOUTPUTTYPE.GROUPED) {
                     buildGroupedRange(
-                            writer, attributeResolver, ucdVersion, range, rangeType, groupAttrs, outputRange);
+                            writer,
+                            attributeResolver,
+                            ucdVersion,
+                            range,
+                            rangeType,
+                            groupAttrs,
+                            outputRange);
                 } else {
-                    buildUngroupedRange(writer, attributeResolver, ucdVersion, range, rangeType, outputRange);
+                    buildUngroupedRange(
+                            writer, attributeResolver, ucdVersion, range, rangeType, outputRange);
                 }
             }
         }
@@ -802,7 +818,9 @@ public class UCDXML {
     }
 
     private static AttributesImpl getReservedAttributes(
-            VersionInfo version, AttributeResolver attributeResolver, ArrayList<Integer> range,
+            VersionInfo version,
+            AttributeResolver attributeResolver,
+            ArrayList<Integer> range,
             UCDXMLOUTPUTRANGE outputRange) {
         AttributesImpl attributes = new AttributesImpl();
 
@@ -841,7 +859,11 @@ public class UCDXML {
                                 outputRange);
                 if (isAttributeIncluded) {
                     attributes.addAttribute(
-                            NAMESPACE, prop.getShortName(), prop.getShortName(), "CDATA", attrValue);
+                            NAMESPACE,
+                            prop.getShortName(),
+                            prop.getShortName(),
+                            "CDATA",
+                            attrValue);
                 }
             }
         }

--- a/unicodetools/src/main/java/org/unicode/xml/UCDXML.java
+++ b/unicodetools/src/main/java/org/unicode/xml/UCDXML.java
@@ -21,6 +21,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.xml.transform.TransformerConfigurationException;
 import org.unicode.props.IndexUnicodeProperties;
+import org.unicode.props.PropertyType;
 import org.unicode.props.UcdProperty;
 import org.unicode.props.UcdPropertyValues;
 import org.unicode.text.utility.Settings;
@@ -403,10 +404,11 @@ public class UCDXML {
                                         ucdVersion,
                                         range,
                                         rangeType,
-                                        groupAttrs);
+                                        groupAttrs,
+                                        outputRange);
                             } else {
                                 buildUngroupedRange(
-                                        writer, attributeResolver, ucdVersion, range, rangeType);
+                                        writer, attributeResolver, ucdVersion, range, rangeType, outputRange);
                             }
                         }
                         range.clear();
@@ -424,10 +426,11 @@ public class UCDXML {
                                     ucdVersion,
                                     range,
                                     rangeType,
-                                    groupAttrs);
+                                    groupAttrs,
+                                    outputRange);
                         } else {
                             buildUngroupedRange(
-                                    writer, attributeResolver, ucdVersion, range, rangeType);
+                                    writer, attributeResolver, ucdVersion, range, rangeType, outputRange);
                         }
                     }
                     range.clear();
@@ -454,9 +457,9 @@ public class UCDXML {
             if (outputRange != UCDXMLOUTPUTRANGE.UNIHAN) {
                 if (outputType == UCDXMLOUTPUTTYPE.GROUPED) {
                     buildGroupedRange(
-                            writer, attributeResolver, ucdVersion, range, rangeType, groupAttrs);
+                            writer, attributeResolver, ucdVersion, range, rangeType, groupAttrs, outputRange);
                 } else {
-                    buildUngroupedRange(writer, attributeResolver, ucdVersion, range, rangeType);
+                    buildUngroupedRange(writer, attributeResolver, ucdVersion, range, rangeType, outputRange);
                 }
             }
         }
@@ -544,10 +547,11 @@ public class UCDXML {
             VersionInfo ucdVersion,
             ArrayList<Integer> range,
             Range rangeType,
-            AttributesImpl groupAttrs)
+            AttributesImpl groupAttrs,
+            UCDXMLOUTPUTRANGE outputRange)
             throws SAXException {
         AttributesImpl orgRangeAttributes =
-                getReservedAttributes(ucdVersion, attributeResolver, range);
+                getReservedAttributes(ucdVersion, attributeResolver, range, outputRange);
         AttributesImpl rangeAttributes = new AttributesImpl();
         if (range.size() == 1) {
             rangeAttributes.addAttribute(
@@ -594,10 +598,11 @@ public class UCDXML {
             AttributeResolver attributeResolver,
             VersionInfo ucdVersion,
             ArrayList<Integer> range,
-            Range rangeType)
+            Range rangeType,
+            UCDXMLOUTPUTRANGE outputRange)
             throws SAXException {
         AttributesImpl rangeAttributes =
-                getReservedAttributes(ucdVersion, attributeResolver, range);
+                getReservedAttributes(ucdVersion, attributeResolver, range, outputRange);
         writer.startElement(rangeType.tag, rangeAttributes);
         {
             writer.endElement(rangeType.tag);
@@ -700,6 +705,7 @@ public class UCDXML {
                     && (propDetail.getMaxVersion() == null
                             || version.compareTo(propDetail.getMaxVersion()) < 0)) {
                 int totalCount = 0;
+                int unassignedCount = 0;
                 Map<String, Integer> counters = new LinkedHashMap<>();
 
                 for (int CodePoint = lowCodePoint; CodePoint <= highCodePoint; CodePoint++) {
@@ -796,7 +802,8 @@ public class UCDXML {
     }
 
     private static AttributesImpl getReservedAttributes(
-            VersionInfo version, AttributeResolver attributeResolver, ArrayList<Integer> range) {
+            VersionInfo version, AttributeResolver attributeResolver, ArrayList<Integer> range,
+            UCDXMLOUTPUTRANGE outputRange) {
         AttributesImpl attributes = new AttributesImpl();
 
         if (range.size() == 1) {
@@ -816,7 +823,7 @@ public class UCDXML {
                     "CDATA",
                     attributeResolver.getHexString(range.get(range.size() - 1)));
         }
-        for (UCDPropertyDetail propDetail : UCDPropertyDetail.baseValues()) {
+        for (UCDPropertyDetail propDetail : UCDPropertyDetail.ucdxmlValues()) {
             UcdProperty prop = propDetail.getUcdProperty();
             if (version.compareTo(propDetail.getMinVersion()) >= 0
                     && (propDetail.getMaxVersion() == null
@@ -824,9 +831,18 @@ public class UCDXML {
                 String attrValue =
                         attributeResolver.getAttributeValue(
                                 propDetail.getUcdProperty(), range.get(0));
-
-                attributes.addAttribute(
-                        NAMESPACE, prop.getShortName(), prop.getShortName(), "CDATA", attrValue);
+                boolean isAttributeIncluded =
+                        getIsAttributeIncluded(
+                                attrValue,
+                                attributeResolver.isUnihanAttributeRange(range.get(0)),
+                                attributeResolver.isUnikemetAttributeRange(range.get(0)),
+                                propDetail,
+                                prop,
+                                outputRange);
+                if (isAttributeIncluded) {
+                    attributes.addAttribute(
+                            NAMESPACE, prop.getShortName(), prop.getShortName(), "CDATA", attrValue);
+                }
             }
         }
         return attributes;

--- a/unicodetools/src/main/resources/org/unicode/uax42/fragments/Unikemet.xml
+++ b/unicodetools/src/main/resources/org/unicode/uax42/fragments/Unikemet.xml
@@ -16,7 +16,9 @@
     attribute kEH_FVal { text }?
 
   code-point-attributes &amp;= attribute kEH_UniK
-    { xsd:string { pattern="([A-IK-Z]|AA|NL|NU)\d{3}[A-Z]{0,2}|HJ ([A-IK-Z]|AA)\d{3}[A-Z]{0,2}" } }?
+    { xsd:string { pattern="([A-IK-Z]|AA|NL|NU)\d{3}[A-Z]{0,2}" }
+     | xsd:string { pattern="HJ ([A-IK-Z]|AA)\d{3}[A-Z]{0,2}" }
+    }?
 
   code-point-attributes &amp;= attribute kEH_JSesh
     { list { ( xsd:string { pattern="([A-IK-Z]|Aa|NL|NU|Ff)\d{1,3}[A-Za-z]{0,5}" }

--- a/unicodetools/src/main/resources/org/unicode/uax42/output/tr42.html
+++ b/unicodetools/src/main/resources/org/unicode/uax42/output/tr42.html
@@ -2625,7 +2625,9 @@
     attribute kEH_FVal { text }?
 
   code-point-attributes &amp;= attribute kEH_UniK
-    { xsd:string { pattern="([A-IK-Z]|AA|NL|NU)\d{3}[A-Z]{0,2}|HJ ([A-IK-Z]|AA)\d{3}[A-Z]{0,2}" } }?
+    { xsd:string { pattern="([A-IK-Z]|AA|NL|NU)\d{3}[A-Z]{0,2}" }
+     | xsd:string { pattern="HJ ([A-IK-Z]|AA)\d{3}[A-Z]{0,2}" }
+    }?
 
   code-point-attributes &amp;= attribute kEH_JSesh
     { list { ( xsd:string { pattern="([A-IK-Z]|Aa|NL|NU|Ff)\d{1,3}[A-Za-z]{0,5}" }

--- a/unicodetools/src/main/resources/org/unicode/uax42/output/tr42.rnc
+++ b/unicodetools/src/main/resources/org/unicode/uax42/output/tr42.rnc
@@ -1379,7 +1379,9 @@
     attribute kEH_FVal { text }?
 
   code-point-attributes &= attribute kEH_UniK
-    { xsd:string { pattern="([A-IK-Z]|AA|NL|NU)\d{3}[A-Z]{0,2}|HJ ([A-IK-Z]|AA)\d{3}[A-Z]{0,2}" } }?
+    { xsd:string { pattern="([A-IK-Z]|AA|NL|NU)\d{3}[A-Z]{0,2}" }
+     | xsd:string { pattern="HJ ([A-IK-Z]|AA)\d{3}[A-Z]{0,2}" }
+    }?
 
   code-point-attributes &= attribute kEH_JSesh
     { list { ( xsd:string { pattern="([A-IK-Z]|Aa|NL|NU|Ff)\d{1,3}[A-Za-z]{0,5}" }


### PR DESCRIPTION
Fixed an issue where Unikemet properties weren't being applied correctly to ranges of characters. Improved handling of newlines and breaks in TR38/TR57.