### PR TITLE
Address feedback on character.jsp from the public mailing list

### DIFF
--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeJsp.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeJsp.java
@@ -13,6 +13,7 @@ import com.ibm.icu.util.VersionInfo;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -131,8 +132,15 @@ public class UnicodeJsp {
 
     public static void showProperties(
             int cp, String history, boolean showDevProperties, Appendable out) throws IOException {
+        List<String> originalParameters = new ArrayList<>();
+        if (!history.isEmpty()) {
+            originalParameters.add("history=" + history);
+        }
+        if (showDevProperties) {
+            originalParameters.add("showDevProperties=1");
+        }
         showDevProperties = Settings.latestVersionPhase == ReleasePhase.BETA || showDevProperties;
-        UnicodeUtilities.showProperties(cp, history, showDevProperties, out);
+        UnicodeUtilities.showProperties(cp, history, showDevProperties, originalParameters, out);
     }
 
     static String defaultIdnaInput =
@@ -201,10 +209,18 @@ public class UnicodeJsp {
             boolean collate,
             Appendable out)
             throws IOException {
+        List<String> originalParameters =
+                showDevProperties ? List.of("showDevProperties=1") : List.of();
         showDevProperties = Settings.latestVersionPhase == ReleasePhase.BETA || showDevProperties;
         CodePointShower codePointShower =
                 new CodePointShower(
-                        grouping, info, showDevProperties, abbreviate, ucdFormat, collate);
+                        grouping,
+                        info,
+                        showDevProperties,
+                        abbreviate,
+                        ucdFormat,
+                        collate,
+                        originalParameters);
         UnicodeUtilities.showSetMain(a, showDevProperties, codePointShower, out);
     }
 
@@ -416,8 +432,10 @@ public class UnicodeJsp {
     }
 
     public static String getIdentifier(String script, boolean showDevProperties) {
+        List<String> originalParameters =
+                showDevProperties ? List.of("showDevProperties=1") : List.of();
         showDevProperties = Settings.latestVersionPhase == ReleasePhase.BETA || showDevProperties;
-        return UnicodeUtilities.getIdentifier(script, showDevProperties);
+        return UnicodeUtilities.getIdentifier(script, showDevProperties, originalParameters);
     }
 
     static final String VERSIONS =


### PR DESCRIPTION
See https://corp.unicode.org/pipermail/unicode/2025-May/011446.html from @neatnit and my reply https://corp.unicode.org/pipermail/unicode/2025-May/011447.html.

* Drop the links to the blank properties.jsp (blanked in #1018).
* Show links to the individual character property pages for string-valued properties, e.g., for U+FDFA,  ![image](https://github.com/user-attachments/assets/f9514c47-b71a-4877-ad11-1a3b7f654d56) or for U+00DF, ![image](https://github.com/user-attachments/assets/66260028-bfad-4dc2-bd10-4c588e64e932)
* Link to the null query from _null_ values.