### PR TITLE
CheckXmlProperties and Grouped NoUnihan fix.

### DIFF
--- a/unicodetools/src/main/java/org/unicode/xml/UCDXML.java
+++ b/unicodetools/src/main/java/org/unicode/xml/UCDXML.java
@@ -627,7 +627,8 @@ public class UCDXML {
 
     private static boolean isWritableCodePoint(
             int CodePoint, UCDXMLOUTPUTRANGE outputRange, AttributeResolver attributeResolver) {
-        return outputRange == UCDXMLOUTPUTRANGE.ALL || outputRange == UCDXMLOUTPUTRANGE.NOUNIHAN
+        return outputRange == UCDXMLOUTPUTRANGE.ALL
+                || outputRange == UCDXMLOUTPUTRANGE.NOUNIHAN
                 || (outputRange == UCDXMLOUTPUTRANGE.UNIHAN
                         && attributeResolver.isUnihanAttributeRange(CodePoint));
     }

--- a/unicodetools/src/main/java/org/unicode/xml/UCDXML.java
+++ b/unicodetools/src/main/java/org/unicode/xml/UCDXML.java
@@ -627,11 +627,9 @@ public class UCDXML {
 
     private static boolean isWritableCodePoint(
             int CodePoint, UCDXMLOUTPUTRANGE outputRange, AttributeResolver attributeResolver) {
-        return outputRange == UCDXMLOUTPUTRANGE.ALL
+        return outputRange == UCDXMLOUTPUTRANGE.ALL || outputRange == UCDXMLOUTPUTRANGE.NOUNIHAN
                 || (outputRange == UCDXMLOUTPUTRANGE.UNIHAN
-                        && attributeResolver.isUnihanAttributeRange(CodePoint))
-                || (outputRange == UCDXMLOUTPUTRANGE.NOUNIHAN
-                        && !attributeResolver.isUnifiedIdeograph(CodePoint));
+                        && attributeResolver.isUnihanAttributeRange(CodePoint));
     }
 
     private static Range getRangeType(AttributeResolver attributeResolver, int CodePoint) {

--- a/unicodetools/src/test/java/org/unicode/propstest/CheckXmlProperties.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/CheckXmlProperties.java
@@ -2,6 +2,9 @@ package org.unicode.propstest;
 
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.text.UnicodeSet;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.unicode.cldr.util.Timer;
 import org.unicode.props.IndexUnicodeProperties;
 import org.unicode.props.UcdProperty;
@@ -9,10 +12,6 @@ import org.unicode.props.UnicodeProperty;
 import org.unicode.props.ValueCardinality;
 import org.unicode.text.utility.Settings;
 import org.unicode.text.utility.Utility;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 public class CheckXmlProperties {
     /**
@@ -112,15 +111,14 @@ public class CheckXmlProperties {
                     // just for debugging
                     final String xx = XMLProperties.getXmlResolved(prop, i, xmap.get(i));
                     final String ii = iup.getResolvedValue(prop, i);
-                    //UCDXML only contains cjkNumeric values when they are not null/NaN.
+                    // UCDXML only contains cjkNumeric values when they are not null/NaN.
                     switch (prop) {
                         case kAccountingNumeric:
                         case kOtherNumeric:
                         case kPrimaryNumeric:
                             if (upval != null && upval.equals("NaN") && xval == null) {
                                 empty.add(i);
-                            }
-                            else {
+                            } else {
                                 errorMap.put(
                                         i,
                                         " codepoints where up=\t"
@@ -130,10 +128,11 @@ public class CheckXmlProperties {
                             }
                             break;
                         case Name_Alias:
-                            //Name_Alias is sorted for display in UCDXML.
+                            // Name_Alias is sorted for display in UCDXML.
                             List<String> xList = Arrays.asList(xval.split("; "));
-                            List<String> upList = (ii != null ? Arrays.asList(ii.split("\\|")): null);
-                            //Collections.sort(xList);
+                            List<String> upList =
+                                    (ii != null ? Arrays.asList(ii.split("\\|")) : null);
+                            // Collections.sort(xList);
                             Collections.sort(upList);
                             if (!xList.equals(upList)) {
                                 errorMap.put(
@@ -147,8 +146,7 @@ public class CheckXmlProperties {
                         case kEH_Core:
                             if (upval != null && upval.equals("None") && xval == null) {
                                 empty.add(i);
-                            }
-                            else {
+                            } else {
                                 errorMap.put(
                                         i,
                                         " codepoints where up=\t"
@@ -161,8 +159,7 @@ public class CheckXmlProperties {
                         case kEH_NoRotate:
                             if (upval != null && upval.equals("No") && xval == null) {
                                 empty.add(i);
-                            }
-                            else {
+                            } else {
                                 errorMap.put(
                                         i,
                                         " codepoints where up=\t"
@@ -172,8 +169,12 @@ public class CheckXmlProperties {
                             }
                             break;
                         default:
-                            if ((xval == null || xval.isEmpty() || xval.equals(Character.toString(i)))
-                                    && (upval == null || upval.isEmpty() || upval.equals(Character.toString(i)))) {
+                            if ((xval == null
+                                            || xval.isEmpty()
+                                            || xval.equals(Character.toString(i)))
+                                    && (upval == null
+                                            || upval.isEmpty()
+                                            || upval.equals(Character.toString(i)))) {
                                 empty.add(i);
                             } else {
                                 errorMap.put(

--- a/unicodetools/src/test/java/org/unicode/propstest/CheckXmlProperties.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/CheckXmlProperties.java
@@ -10,6 +10,10 @@ import org.unicode.props.ValueCardinality;
 import org.unicode.text.utility.Settings;
 import org.unicode.text.utility.Utility;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 public class CheckXmlProperties {
     /**
      * TODO Known problems
@@ -108,16 +112,77 @@ public class CheckXmlProperties {
                     // just for debugging
                     final String xx = XMLProperties.getXmlResolved(prop, i, xmap.get(i));
                     final String ii = iup.getResolvedValue(prop, i);
-
-                    if ((xval == null || xval.isEmpty()) && (upval == null || upval.isEmpty())) {
-                        empty.add(i);
-                    } else {
-                        errorMap.put(
-                                i,
-                                " codepoints where up=\t"
-                                        + XMLProperties.show(upval)
-                                        + "\t& xml=\t"
-                                        + XMLProperties.show(xval));
+                    //UCDXML only contains cjkNumeric values when they are not null/NaN.
+                    switch (prop) {
+                        case kAccountingNumeric:
+                        case kOtherNumeric:
+                        case kPrimaryNumeric:
+                            if (upval != null && upval.equals("NaN") && xval == null) {
+                                empty.add(i);
+                            }
+                            else {
+                                errorMap.put(
+                                        i,
+                                        " codepoints where up=\t"
+                                                + XMLProperties.show(upval)
+                                                + "\t& xml=\t"
+                                                + XMLProperties.show(xval));
+                            }
+                            break;
+                        case Name_Alias:
+                            //Name_Alias is sorted for display in UCDXML.
+                            List<String> xList = Arrays.asList(xval.split("; "));
+                            List<String> upList = (ii != null ? Arrays.asList(ii.split("\\|")): null);
+                            //Collections.sort(xList);
+                            Collections.sort(upList);
+                            if (!xList.equals(upList)) {
+                                errorMap.put(
+                                        i,
+                                        " codepoints where up=\t"
+                                                + XMLProperties.show(upval)
+                                                + "\t& xml=\t"
+                                                + XMLProperties.show(xval));
+                            }
+                            break;
+                        case kEH_Core:
+                            if (upval != null && upval.equals("None") && xval == null) {
+                                empty.add(i);
+                            }
+                            else {
+                                errorMap.put(
+                                        i,
+                                        " codepoints where up=\t"
+                                                + XMLProperties.show(upval)
+                                                + "\t& xml=\t"
+                                                + XMLProperties.show(xval));
+                            }
+                            break;
+                        case kEH_NoMirror:
+                        case kEH_NoRotate:
+                            if (upval != null && upval.equals("No") && xval == null) {
+                                empty.add(i);
+                            }
+                            else {
+                                errorMap.put(
+                                        i,
+                                        " codepoints where up=\t"
+                                                + XMLProperties.show(upval)
+                                                + "\t& xml=\t"
+                                                + XMLProperties.show(xval));
+                            }
+                            break;
+                        default:
+                            if ((xval == null || xval.isEmpty() || xval.equals(Character.toString(i)))
+                                    && (upval == null || upval.isEmpty() || upval.equals(Character.toString(i)))) {
+                                empty.add(i);
+                            } else {
+                                errorMap.put(
+                                        i,
+                                        " codepoints where up=\t"
+                                                + XMLProperties.show(upval)
+                                                + "\t& xml=\t"
+                                                + XMLProperties.show(xval));
+                            }
                     }
                 }
             }
@@ -138,7 +203,7 @@ public class CheckXmlProperties {
                     int showCount = 0;
                     for (String value : errorMap.values()) {
                         System.out.println(
-                                "\t" + value + "\t: " + errorMap.getSet(value).toPattern(false));
+                                "\t" + value + "\t: " + errorMap.getSet(value).toString());
                         if (++showCount > MAX_SHOW) {
                             System.out.println("… " + (errorMap.size() - MAX_SHOW) + " more");
                             break;

--- a/unicodetools/src/test/java/org/unicode/propstest/XMLProperties.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/XMLProperties.java
@@ -51,7 +51,9 @@ public class XMLProperties {
         NORMALIZATION_CORRECTIONS,
         STANDARDIZED_VARIANTS,
         CJK_RADICALS,
-        EMOJI_SOURCES;
+        EMOJI_SOURCES,
+        DO_NOT_EMIT,
+        INSTEAD;
         static final XmlLeaf GREATEST_LEAF = NAME_ALIAS;
         static final XmlLeaf GREATEST_BOTH = CHAR;
 
@@ -310,10 +312,19 @@ public class XMLProperties {
                         setProp(cps, UcdProperty.Emoji_KDDI, attributes.get("kddi"));
                         setProp(cps, UcdProperty.Emoji_SB, attributes.get("softbank"));
                         break;
+                    case INSTEAD:
+                        // ucd/do-not-emit/instead[@of="0905 0946"]
+                        // [@use="0904"][@because="Indic_Vowel_Letter"]
+                        cps = Utility.fromHex(attributes.get("of"));
+                        setProp(cps, UcdProperty.Do_Not_Emit_Preferred, attributes.get("use"));
+                        leavesNotHandled.add("do-not-emit type=");
+                        //setProp(cps, UcdProperty.Do_Not_Emit_Type, attributes.get("because"));
+                        break;
                     case REPERTOIRE:
                     case BLOCKS:
                     case CJK_RADICALS:
                     case EMOJI_SOURCES:
+                    case DO_NOT_EMIT:
                     case NAMED_SEQUENCES:
                     case NORMALIZATION_CORRECTIONS:
                     case STANDARDIZED_VARIANTS:

--- a/unicodetools/src/test/java/org/unicode/propstest/XMLProperties.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/XMLProperties.java
@@ -318,7 +318,7 @@ public class XMLProperties {
                         cps = Utility.fromHex(attributes.get("of"));
                         setProp(cps, UcdProperty.Do_Not_Emit_Preferred, attributes.get("use"));
                         leavesNotHandled.add("do-not-emit type=");
-                        //setProp(cps, UcdProperty.Do_Not_Emit_Type, attributes.get("because"));
+                        // setProp(cps, UcdProperty.Do_Not_Emit_Type, attributes.get("because"));
                         break;
                     case REPERTOIRE:
                     case BLOCKS:


### PR DESCRIPTION
Fixed an issue with grouped noUnihan not showing nonCJK properties for Unihan range.
Updated CheckXmlProperties to work with UCDXML for 17.0