### PR TITLE
Updated Unikemet regular expressions and regenerated UCDXML

### DIFF
--- a/unicodetools/src/main/java/org/unicode/props/UcdProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UcdProperty.java
@@ -217,12 +217,7 @@ public enum UcdProperty {
     kEACC(PropertyType.Miscellaneous, DerivedPropertyStatus.Provisional, "cjkEACC"),
     kEH_Cat(PropertyType.Miscellaneous, DerivedPropertyStatus.Approved, "kEH_Cat"),
     kEH_Desc(PropertyType.Miscellaneous, DerivedPropertyStatus.Approved, "kEH_Desc"),
-    kEH_FVal(
-            PropertyType.Miscellaneous,
-            DerivedPropertyStatus.Provisional,
-            null,
-            ValueCardinality.Unordered,
-            "kEH_FVal"),
+    kEH_FVal(PropertyType.Miscellaneous, DerivedPropertyStatus.Provisional, "kEH_FVal"),
     kEH_Func(
             PropertyType.Miscellaneous,
             DerivedPropertyStatus.Provisional,

--- a/unicodetools/src/main/java/org/unicode/xml/AttributeResolver.java
+++ b/unicodetools/src/main/java/org/unicode/xml/AttributeResolver.java
@@ -212,6 +212,7 @@ public class AttributeResolver {
                         }
                         return Optional.ofNullable(resolvedValue).orElse("");
                     case kDefinition:
+                    case kEH_FVal:
                         return resolvedValue;
                     default:
                         if (resolvedValue != null) {

--- a/unicodetools/src/main/resources/org/unicode/props/IndexPropertyRegex.txt
+++ b/unicodetools/src/main/resources/org/unicode/props/IndexPropertyRegex.txt
@@ -216,14 +216,15 @@ Names_List_Cross_Ref ; MULTI_VALUED ; .*
 
 # Regex patterns from UAX #57
 
-kEH_Cat ;                     SINGLE_VALUED ;                ([A-IK-Z]|AA)-[0-9]{2}-[0-9]{3}
+kEH_Cat ;                     SINGLE_VALUED ;                ([A-IK-Z]|AA)-\d{2}-\d{3}
 kEH_Desc ;                    SINGLE_VALUED ;                [^\t"]+
 kEH_Func ;                    MULTI_VALUED ;                 [^\t"]+
-kEH_FVal ;                    MULTI_VALUED ;                 [\x{A723}\x{A7BD}y\x{A725}wbpfmnrh\x{1E25}\x{1E2B}\x{1E96}s\x{0161}\x{1E33}kgt\x{1E6F}d\x{1E0F}./|\-;=\(\)\s]+
-kEH_HG ;                      MULTI_VALUED ;                 ([A-IK-Z]|AA)[0-9]{1,3}[A-Za-z]{0,2}
-kEH_IFAO ;                    MULTI_VALUED ;                 [0-9]{1,3},[0-9]{1,2}
-kEH_JSesh ;                   MULTI_VALUED ;                 ([A-IK-Z]|Aa|NL|NU|Ff)[0-9]{1,3}[A-Za-z]{0,5}|(US1|US22|US248|US685)([A-IK-Z]|Aa|NL|NU)[0-9]{1,3}[A-Za-z]{0,5}
-kEH_UniK ;                    SINGLE_VALUED ;                ([A-IK-Z]|AA|NL|NU)[0-9]{3}[A-Z]{0,2}|HJ ([A-IK-Z]|AA)[0-9]{3}[A-Z]{0,2}
+# Revisit once the spec settles down.
+kEH_FVal ;                    SINGLE_VALUED ;                [^\t"]+
+kEH_HG ;                      MULTI_VALUED ;                 ([A-IK-Z]|AA)\d{1,3}[A-Za-z]{0,2}
+kEH_IFAO ;                    MULTI_VALUED ;                 \d{1,3},\d{1,2}[ab]?
+kEH_JSesh ;                   MULTI_VALUED ;                 ([A-IK-Z]|Aa|NL|NU|Ff)\d{1,3}[A-Za-z]{0,5}|(US1|US22|US248|US685)([A-IK-Z]|Aa|NL|NU)\d{1,3}[A-Za-z]{0,5}
+kEH_UniK ;                    SINGLE_VALUED ;                ([A-IK-Z]|AA|NL|NU)\d{3}[A-Z]{0,2}|HJ ([A-IK-Z]|AA)\d{3}[A-Z]{0,2}
 
 # =============================
 # Catalog/Enum/Binary Properties


### PR DESCRIPTION
Fix for https://github.com/unicode-org/properties/issues/435

Updated Unikemet regular expressions; however, RegEx for kEH_FVal doesn't validate against current data.

There are two issues:

1. The separator is ambiguous: "The delimiters '/' or '|' are used to separate alternative values..."
2. The syntax specifies letters and combining characters (e.g., h + COMBINING DOT BELOW [U+0323], rather than ḥ [U+1E25]). But Unikemet.txt in UCD uses the composed forms.

To avoid this for now, we'll treat kEH_FVal as SINGLE_VALUED.

I updated the rest of the Unikemet regular expressions from the latest version of UAX 57.