### PR TITLE
Unikemet-17.0.0d3

### DIFF
--- a/unicodetools/data/ucd/dev/Unikemet.txt
+++ b/unicodetools/data/ucd/dev/Unikemet.txt
@@ -1,6 +1,6 @@
-# Unikemet-16.0.0.txt
-# Date: 2025-04-18
-# © 2024 Unicode®, Inc.
+# Unikemet-17.0.0.txt
+# Date: 2025-07-21
+# © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
 #
@@ -179,7 +179,7 @@ U+13012	kEH_HG	A15
 U+13012	kEH_IFAO	7,11
 U+13013	kEH_Cat	A-04-005
 U+13013	kEH_Core	C
-U+13013	kEH_Desc	Man, standing, bend forwards, arms hanging downwards, extended towards the front.
+U+13013	kEH_Desc	Man, standing, bent forwards, arms hanging downwards, extended towards the front.
 U+13013	kEH_Func	Classifier bowing
 U+13013	kEH_UniK	A016
 U+13013	kEH_JSesh	A16
@@ -209,7 +209,7 @@ U+13016	kEH_HG	A18
 U+13016	kEH_IFAO	35,7
 U+13017	kEH_Cat	A-06-017
 U+13017	kEH_Core	C
-U+13017	kEH_Desc	Old man, standing, with a bend back, right arm forwards, holding a staff/stick near the top, with the staff at a slight backward angle, left arm hanging beside the body.
+U+13017	kEH_Desc	Old man, standing, with a bent back, right arm forwards, holding a staff/stick near the top, with the staff at a slight backward angle, left arm hanging beside the body.
 U+13017	kEH_Func	Logogram (old, old age)
 U+13017	kEH_FVal	ꞽꜣw
 U+13017	kEH_UniK	A019
@@ -329,7 +329,7 @@ U+13025	kEH_UniK	A032A
 U+13025	kEH_IFAO	29,12
 U+13026	kEH_Cat	A-14-011
 U+13026	kEH_Core	C
-U+13026	kEH_Desc	Man, standing, bend forwards, both arms forward, holding a stick with a bundle or a mat over his shoulders, bundle behind the back.
+U+13026	kEH_Desc	Man, standing, bent forwards, both arms forward, holding a stick with a bundle or a mat over his shoulders, bundle behind the back.
 U+13026	kEH_Func	Classifier wandering/displaced
 U+13026	kEH_FVal	rw
 U+13026	kEH_UniK	A033
@@ -337,7 +337,7 @@ U+13026	kEH_JSesh	A33
 U+13026	kEH_HG	A33
 U+13027	kEH_Cat	A-12-019
 U+13027	kEH_Core	C
-U+13027	kEH_Desc	Man, standing, back slightly bend forwards, both arms forward, holding a long stick (rammer), which ends at the bottom in a mortar.
+U+13027	kEH_Desc	Man, standing, back slightly bent forwards, both arms forward, holding a long stick (rammer), which ends at the bottom in a mortar.
 U+13027	kEH_Func	Logogram (to pound, to build)
 U+13027	kEH_FVal	ḫwsꞽ
 U+13027	kEH_UniK	A034
@@ -439,7 +439,7 @@ U+13032	kEH_JSesh	A43
 U+13033	kEH_Cat	A-28-017
 U+13033	kEH_Core	C
 U+13033	kEH_Desc	King, seated, both knees up, with covered legs and arms, with a long straight beard, wearing the white crown (S1), holding a sceptre with a straight shaft, topped with the head of the Seth animal vertically.
-U+13033	kEH_Func	Logogram (king of UE)
+U+13033	kEH_Func	Logogram (king of Upper Egypt)
 U+13033	kEH_FVal	n.y-sw.t
 U+13033	kEH_UniK	A043A
 U+13033	kEH_JSesh	A43M
@@ -493,7 +493,7 @@ U+13038	kEH_IFAO	17,8
 U+13039	kEH_Cat	A-13-030
 U+13039	kEH_Core	C
 U+13039	kEH_Desc	Man, seated, both knees up, with covered legs and arms, with short hair/wig, holding an unknown object (mace/knife/stick?)
-U+13039	kEH_Func	Logogram (relating to; belonging to)
+U+13039	kEH_Func	Logogram (relating to, belonging to)
 U+13039	kEH_FVal	ꞽr.y
 U+13039	kEH_UniK	A048
 U+13039	kEH_JSesh	A48
@@ -763,7 +763,7 @@ U+13059	kEH_HG	B47
 U+13059	kEH_IFAO	53,10
 U+1305A	kEH_Cat	C-24-002
 U+1305A	kEH_Core	C
-U+1305A	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long-curved beard and long wig/hair, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on its head.
+U+1305A	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long-curved beard and long wig/hair, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on its head.
 U+1305A	kEH_Func	Logogram (Re)
 U+1305A	kEH_FVal	rꜥ
 U+1305A	kEH_UniK	C001
@@ -772,7 +772,7 @@ U+1305A	kEH_HG	C1
 U+1305A	kEH_IFAO	76,5
 U+1305B	kEH_Cat	C-09-029
 U+1305B	kEH_Core	C
-U+1305B	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with a sun disk (N5) on its head, holding a tie or strap, used with sandals (ankh-sign, S34), angling forward. 
+U+1305B	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with a sun disk (N5) on its head, holding a tie or strap, used with sandals (ankh sign, S34), angling forward. 
 U+1305B	kEH_Func	Logogram (Re)
 U+1305B	kEH_FVal	rꜥ
 U+1305B	kEH_UniK	C002
@@ -818,7 +818,7 @@ U+13060	kEH_HG	C4
 U+13060	kEH_IFAO	71,3
 U+13061	kEH_Cat	C-15-007
 U+13061	kEH_Core	C
-U+13061	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a ram with horizontal twisted horns, holding a tie or strap, used with sandals (ankh-sign, S34), angling forward. 
+U+13061	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a ram with horizontal twisted horns, holding a tie or strap, used with sandals (ankh sign, S34), angling forward. 
 U+13061	kEH_Func	Logogram/phonemogram (who joins with life)
 U+13061	kEH_FVal	ẖnm.t-ꜥnḫ
 U+13061	kEH_UniK	C005
@@ -870,7 +870,7 @@ U+13066	kEH_HG	C10
 U+13066	kEH_IFAO	85,7
 U+13067	kEH_Cat	C-37-005
 U+13067	kEH_Core	C
-U+13067	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, with a cloth band around her head, with a feather (H6) on her head, holding a tie or strap, used with sandals (ankh-sign, S34), angling forward. 
+U+13067	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, with a cloth band around her head, with a feather (H6) on her head, holding a tie or strap, used with sandals (ankh sign, S34), angling forward. 
 U+13067	kEH_Func	Logogram (Maat)
 U+13067	kEH_FVal	mꜣꜥ.t
 U+13067	kEH_UniK	C010A
@@ -913,13 +913,13 @@ U+1306C	kEH_UniK	C015
 U+1306C	kEH_AltSeq	1306B 13440
 U+1306D	kEH_Cat	A-30-004
 U+1306D	kEH_Core	C
-U+1306D	kEH_Desc	God, seated, both knees up, with covered legs and arms, with a long, curved beard, wearing the double crown (S5), holding a tie or strap, used with sandals (ankh-sign, S34), angling forward. 
+U+1306D	kEH_Desc	God, seated, both knees up, with covered legs and arms, with a long, curved beard, wearing the double crown (S5), holding a tie or strap, used with sandals (ankh sign, S34), angling forward. 
 U+1306D	kEH_Func	Logogram (Atum)
 U+1306D	kEH_FVal	ꞽtmw
 U+1306D	kEH_UniK	C016
 U+1306E	kEH_Cat	C-09-078
 U+1306E	kEH_Core	C
-U+1306E	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, wearing a headdress consisting of two plumes with a sun disk (S63A/S70), holding a tie or strap, used with sandals (ankh-sign, S34), angling forward. 
+U+1306E	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, wearing a headdress consisting of two plumes with a sun disk (S63A/S70), holding a tie or strap, used with sandals (ankh sign, S34), angling forward. 
 U+1306E	kEH_Func	Classifier Montu (divinity)
 U+1306E	kEH_UniK	C017
 U+1306E	kEH_JSesh	C17
@@ -942,7 +942,7 @@ U+13070	kEH_HG	C19
 U+13070	kEH_IFAO	75,11
 U+13071	kEH_Cat	C-23-023
 U+13071	kEH_Core	C
-U+13071	kEH_Desc	God, in mummy form, standing upright on a platform, with a long straight beard, wearing a cap, both arms forward, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the god, vertically, adorned with an ankh-sign (S34) and a djed-pillar (R11); inside a shrine supported by pillars resembling a stem of papyrus with a bud (M13).
+U+13071	kEH_Desc	God, in mummy form, standing upright on a platform, with a long straight beard, wearing a cap, both arms forward, holding a sceptre with a straight shaft, forked bottom, and the vertically oriented head of the Seth animal (S040), of the same size as the god, adorned with an ankh sign (S034) and a djed pillar (R011); enclosed within a shrine supported by columns resembling papyrus stems with buds (M013).
 U+13071	kEH_Func	Logogram (Ptah)
 U+13071	kEH_FVal	ptḥ
 U+13071	kEH_UniK	C020
@@ -968,7 +968,7 @@ U+13073	kEH_JSesh	C49B
 U+13073	kEH_HG	C49B
 U+13074	kEH_Cat	C-36-015
 U+13074	kEH_Core	C
-U+13074	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, with the head of a lion/lioness, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on her head.
+U+13074	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, with the head of a lion/lioness, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on her head.
 U+13074	kEH_Func	Logogram (Sekhmet)
 U+13074	kEH_FVal	sḫm.t
 U+13074	kEH_UniK	C023
@@ -1073,7 +1073,7 @@ U+1307F	kEH_HG	D9
 U+13080	kEH_Cat	D-08-002
 U+13080	kEH_Core	C
 U+13080	kEH_Desc	An eye, with the markings of the head of a falcon.
-U+13080	kEH_Func	Logogram (Udjat eye)
+U+13080	kEH_Func	Logogram (udjat eye)
 U+13080	kEH_FVal	wḏꜣ.t
 U+13080	kEH_UniK	D010
 U+13080	kEH_JSesh	D10
@@ -1117,21 +1117,21 @@ U+13084	kEH_IFAO	99,13
 U+13084	kEH_NoMirror	Y
 U+13085	kEH_Cat	D-09-010
 U+13085	kEH_Core	C
-U+13085	kEH_Desc	The right lower marking of an Udjat eye.
+U+13085	kEH_Desc	The right lower marking of an udjat eye.
 U+13085	kEH_Func	Logogram 1/32
 U+13085	kEH_UniK	D015
 U+13085	kEH_JSesh	D15
 U+13085	kEH_HG	D15
 U+13086	kEH_Cat	D-09-011
 U+13086	kEH_Core	C
-U+13086	kEH_Desc	The left lower marking of an Udjat eye.
+U+13086	kEH_Desc	The left lower marking of an udjat eye.
 U+13086	kEH_Func	Logogram 1/64
 U+13086	kEH_UniK	D016
 U+13086	kEH_JSesh	D16
 U+13086	kEH_HG	D16
 U+13087	kEH_Cat	D-09-012
 U+13087	kEH_Core	C
-U+13087	kEH_Desc	The left and right lower marking of an Udjat eye.
+U+13087	kEH_Desc	The left and right lower marking of an udjat eye.
 U+13087	kEH_Func	Logogram (figure, image)
 U+13087	kEH_FVal	tꞽ.t
 U+13087	kEH_UniK	D017
@@ -1366,7 +1366,7 @@ U+130A1	kEH_HG	D40
 U+130A1	kEH_IFAO	110,13
 U+130A2	kEH_Cat	D-25-014
 U+130A2	kEH_Core	C
-U+130A2	kEH_Desc	A forearm, with the palm of the hand downwards, with the upper arm bend forwards.
+U+130A2	kEH_Desc	A forearm, with the palm of the hand downwards, with the upper arm bent forwards.
 U+130A2	kEH_Func	Classifier arm related movements or actions
 U+130A2	kEH_UniK	D041
 U+130A2	kEH_JSesh	D41
@@ -1401,7 +1401,7 @@ U+130A5	kEH_HG	D44
 U+130A5	kEH_IFAO	111,3
 U+130A6	kEH_Cat	D-26-011
 U+130A6	kEH_Core	C
-U+130A6	kEH_Desc	An arm, bend at the elbow, forearm nearly horizontal, holding a wand or brush.
+U+130A6	kEH_Desc	An arm, bent at the elbow, forearm nearly horizontal, holding a wand or brush.
 U+130A6	kEH_Func	Logogram (to make holy)
 U+130A6	kEH_FVal	ḏsr
 U+130A6	kEH_UniK	D045
@@ -1656,7 +1656,7 @@ U+130C7	kEH_HG	D132
 U+130C7	kEH_IFAO	96,12
 U+130C8	kEH_Cat	D-26-022
 U+130C8	kEH_Core	C
-U+130C8	kEH_Desc	An arm, bend at the elbow, forearm nearly horizontal, hand held like a fist, with a stylus angled over the tip of the fist.
+U+130C8	kEH_Desc	An arm, bent at the elbow, forearm nearly horizontal, hand held like a fist, with a stylus angled over the tip of the fist.
 U+130C8	kEH_Func	Classifier to engrave
 U+130C8	kEH_FVal	wdꞽ
 U+130C8	kEH_UniK	D066
@@ -1717,7 +1717,7 @@ U+130D4	kEH_HG	E3
 U+130D4	kEH_IFAO	145,4
 U+130D5	kEH_Cat	E-23-091
 U+130D5	kEH_Core	C
-U+130D5	kEH_Desc	A cult image of a bovid (cow), lying down, with a sun-disk (N5) with two feathers between the horns, with a flagellum (S45) on its back, and a necklace around the neck.
+U+130D5	kEH_Desc	A cult image of a bovid (cow), lying down, with a sun disk (N5) with two feathers between the horns, with a flagellum (S45) on its back, and a necklace around the neck.
 U+130D5	kEH_Func	Classifier cow divinity
 U+130D5	kEH_FVal	mḥ.yt
 U+130D5	kEH_UniK	E004
@@ -2187,7 +2187,7 @@ U+1310C	kEH_AltSeq	1310B
 U+1310D	kEH_Cat	F-11-006
 U+1310D	kEH_Core	C
 U+1310D	kEH_Desc	A palm branch, stripped of leaves and notched with a round notch (M4), written within the horns of a bovid (F13).
-U+1310D	kEH_Func	Logogram (new years day)
+U+1310D	kEH_Func	Logogram (New Year's Day)
 U+1310D	kEH_FVal	wp-rnp.t
 U+1310D	kEH_UniK	F014
 U+1310D	kEH_JSesh	F14
@@ -2195,8 +2195,8 @@ U+1310D	kEH_HG	F14
 U+1310D	kEH_IFAO	154,14
 U+1310E	kEH_Cat	F-11-010
 U+1310E	kEH_Core	C
-U+1310E	kEH_Desc	A palm branch, stripped of leaves and notched with a round notch (M4), on top of a sun-disk (N5), written within the horns of a bovid (F13). 
-U+1310E	kEH_Func	Logogram (new years day)
+U+1310E	kEH_Desc	A palm branch, stripped of leaves and notched with a round notch (M4), on top of a sun disk (N5), written within the horns of a bovid (F13). 
+U+1310E	kEH_Func	Logogram (New Year's Day)
 U+1310E	kEH_FVal	wp-rnp.t
 U+1310E	kEH_UniK	F015
 U+1310E	kEH_JSesh	F15
@@ -2708,7 +2708,7 @@ U+13149	kEH_JSesh	G8
 U+13149	kEH_HG	G8
 U+1314A	kEH_Cat	G-12-015
 U+1314A	kEH_Core	C
-U+1314A	kEH_Desc	A falcon (G5) with a sun-disk (N5) on its head.
+U+1314A	kEH_Desc	A falcon (G5) with a sun disk (N5) on its head.
 U+1314A	kEH_Func	Logogram (Re-Hor (usually in rꜥ-ḥr-ꜣḫ.ty)
 U+1314A	kEH_FVal	rꜥ-ḥr
 U+1314A	kEH_UniK	G009
@@ -2774,7 +2774,7 @@ U+13151	kEH_HG	G15
 U+13151	kEH_IFAO	202,14
 U+13152	kEH_Cat	G-24-029
 U+13152	kEH_Core	L
-U+13152	kEH_Desc	A griffon vulture (Gyps fulvus), on top of a wickerwork basket (V30), in front of a cobra (Naja haje), standing up, with expanded hood (Uraeus), with a coiled tail (I12), upon a wickerwork basket (V30).
+U+13152	kEH_Desc	A griffon vulture (Gyps fulvus), on top of a wickerwork basket (V30), in front of a cobra (Naja haje), standing up, with expanded hood (uraeus), with a coiled tail (I12), upon a wickerwork basket (V30).
 U+13152	kEH_Func	Logogram (the two ladies (i.e. Nekhbet and Wadjet)
 U+13152	kEH_FVal	nb.ty
 U+13152	kEH_UniK	G016
@@ -3367,7 +3367,7 @@ U+13196	kEH_IFAO	216,7
 U+13196	kEH_AltSeq	13193 13433 13437 133CF 13430 131FF 13438
 U+13197	kEH_Cat	I-11-049
 U+13197	kEH_Core	C
-U+13197	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus), with a coiled tail.
+U+13197	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus), with a coiled tail.
 U+13197	kEH_Func	Classifier female divinity
 U+13197	kEH_FVal	nbw.t
 U+13197	kEH_UniK	I012
@@ -3376,7 +3376,7 @@ U+13197	kEH_HG	I12
 U+13197	kEH_IFAO	220,4
 U+13198	kEH_Cat	I-11-053
 U+13198	kEH_Core	C
-U+13198	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus), with a coiled tail (I12), upon a wickerwork basket (V30).
+U+13198	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus), with a coiled tail (I12), upon a wickerwork basket (V30).
 U+13198	kEH_Func	Classifier female divinity (Wadjet)
 U+13198	kEH_FVal	wꜣḏ.t
 U+13198	kEH_UniK	I013
@@ -3393,7 +3393,7 @@ U+13199	kEH_HG	I14
 U+13199	kEH_IFAO	223,8
 U+1319A	kEH_Cat	I-13-003
 U+1319A	kEH_Core	C
-U+1319A	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus), with a coiled tail, consisting of two coils.
+U+1319A	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus), with a coiled tail, consisting of two coils.
 U+1319A	kEH_Func	Classifier snake/uraeus
 U+1319A	kEH_FVal	ꞽꜥr.t
 U+1319A	kEH_UniK	I015
@@ -3484,7 +3484,7 @@ U+131A3	kEH_IFAO	229,1
 U+131A4	kEH_Cat	L-02-002
 U+131A4	kEH_Core	C
 U+131A4	kEH_Desc	A bee.
-U+131A4	kEH_Func	Logogram (king of LE)
+U+131A4	kEH_Func	Logogram (king of Lower Egypt)
 U+131A4	kEH_FVal	bꞽ.ty
 U+131A4	kEH_UniK	L002
 U+131A4	kEH_JSesh	L2
@@ -3493,7 +3493,7 @@ U+131A4	kEH_IFAO	230,4
 U+131A5	kEH_Cat	L-02-005
 U+131A5	kEH_Core	L
 U+131A5	kEH_Desc	A sedge (M23) written above a half round loaf of bread (X1), in front of a bee (L2) written above a half round loaf of bread (X1).
-U+131A5	kEH_Func	Logogram (King of UE and LE)
+U+131A5	kEH_Func	Logogram (king of Upper Egypt and Lower Egypt)
 U+131A5	kEH_FVal	n(.y)-sw.t-bꞽ.ty
 U+131A5	kEH_UniK	L002A
 U+131A5	kEH_AltSeq	131D3 13431 131A4 13430 133CF 13431 133CF
@@ -3753,7 +3753,7 @@ U+131C7	kEH_HG	M15
 U+131C7	kEH_IFAO	247,14
 U+131C8	kEH_Cat	M-13-021
 U+131C8	kEH_Core	C
-U+131C8	kEH_Desc	Three thin stems of papyrus with a bud, with two buds bend down; on top of a plan of a crossroads in a village (O49).
+U+131C8	kEH_Desc	Three thin stems of papyrus with a bud, with two buds bent down; on top of a plan of a crossroads in a village (O49).
 U+131C8	kEH_Func	Logogram (Lower Egypt)
 U+131C8	kEH_FVal	mḥ.w
 U+131C8	kEH_UniK	M015A
@@ -3847,7 +3847,7 @@ U+131D2	kEH_UniK	M022A
 U+131D3	kEH_Cat	M-16-016
 U+131D3	kEH_Core	C
 U+131D3	kEH_Desc	A sedge.
-U+131D3	kEH_Func	Logogram (King of UE)
+U+131D3	kEH_Func	Logogram (king of Upper Egypt)
 U+131D3	kEH_FVal	n(.y)-sw.t
 U+131D3	kEH_UniK	M023
 U+131D3	kEH_JSesh	M23
@@ -3901,7 +3901,7 @@ U+131D8	kEH_AltSeq	1309D 13436 131D7
 U+131D9	kEH_Cat	M-16-056
 U+131D9	kEH_Core	C
 U+131D9	kEH_Desc	A desert plant, with four branches, with flowers on every branch (M26A), written on top of a hobble for cattle without a crossbar (V20).
-U+131D9	kEH_Func	Logogram (the 10 of UE)
+U+131D9	kEH_Func	Logogram (the 10 of Upper Egypt)
 U+131D9	kEH_FVal	mḏ-šmꜥ.w
 U+131D9	kEH_UniK	M028
 U+131D9	kEH_HG	M28
@@ -4130,7 +4130,7 @@ U+131F3	kEH_HG	N5
 U+131F3	kEH_IFAO	262,6
 U+131F4	kEH_Cat	N-03-003
 U+131F4	kEH_Core	C
-U+131F4	kEH_Desc	The sun within a halo, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus).
+U+131F4	kEH_Desc	The sun within a halo, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus).
 U+131F4	kEH_Func	Logogram (the sun, Re)
 U+131F4	kEH_FVal	rꜥ
 U+131F4	kEH_UniK	N006
@@ -4139,7 +4139,7 @@ U+131F4	kEH_HG	N6
 U+131F4	kEH_IFAO	263,2
 U+131F5	kEH_Cat	N-04-015
 U+131F5	kEH_Core	C
-U+131F5	kEH_Desc	The sun-disk upon a butcher's block.
+U+131F5	kEH_Desc	The sun disk upon a butcher's block.
 U+131F5	kEH_Func	Logogram (course (of the day), daily requirements)
 U+131F5	kEH_FVal	ẖr.t-hrw
 U+131F5	kEH_UniK	N007
@@ -4515,35 +4515,35 @@ U+13221	kEH_JSesh	NL2
 U+13222	kEH_Cat	G-12-156
 U+13222	kEH_Core	C
 U+13222	kEH_Desc	A feather (H6), in front of a falcon (G5), on top of a standard used for carrying religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
-U+13222	kEH_Func	Logogram (West, 3rd nome of LE)
+U+13222	kEH_Func	Logogram (West, 3rd nome of Lower Egypt)
 U+13222	kEH_FVal	ꞽmn.tt
 U+13222	kEH_UniK	NL003
 U+13222	kEH_JSesh	NL3
 U+13223	kEH_Cat	T-07-037
 U+13223	kEH_Core	C
 U+13223	kEH_Desc	A shield with a rounded top, with two arrows crossed over it, fletching upwards (T62) in front of a sedge written on top of a mouth (M24); on top of a standard used for carrying religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
-U+13223	kEH_Func	Logogram (Neith-south, 4th nome LE)
+U+13223	kEH_Func	Logogram (Neith-South, 4th nome of Lower Egypt)
 U+13223	kEH_FVal	n.t-rs.yt
 U+13223	kEH_UniK	NL004
 U+13223	kEH_JSesh	NL4
 U+13224	kEH_Cat	T-07-035
 U+13224	kEH_Core	C
 U+13224	kEH_Desc	A shield with a rounded top, with two arrows crossed over it, fletching upwards (T62), in front of a clump of three papyrus flowers, with two buds bent down (M15); on top of a standard used for carrying religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
-U+13224	kEH_Func	Logogram (Neith-north, 5th nome of LE)
+U+13224	kEH_Func	Logogram (Neith-North, 5th nome of Lower Egypt)
 U+13224	kEH_FVal	n.t-mḥ.yt
 U+13224	kEH_UniK	NL005
 U+13224	kEH_JSesh	NL5
 U+13225	kEH_Cat	T-07-036
 U+13225	kEH_Core	C
 U+13225	kEH_Desc	A shield with a rounded top, with two arrows crossed over it, fletching upwards (T62) in front of a whip with a loop at the front (V23A) on top of a half round loaf of bread (X1); on top of a standard used for carrying religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
-U+13225	kEH_Func	Logogram (Neith-north, 5th nome of LE)
+U+13225	kEH_Func	Logogram (Neith-North, 5th nome of Lower Egypt)
 U+13225	kEH_FVal	n.t-mḥ.yt
 U+13225	kEH_UniK	NL005A
 U+13225	kEH_JSesh	NL5A
 U+13226	kEH_Cat	E-23-048
 U+13226	kEH_Core	C
 U+13226	kEH_Desc	A sand covered mountain over the edge of the cultivated areas (N26), in front of a bovid (bull), standing (E1), on top of a standard used for the carrying of religious symbols (R12) on top of a parcel of land with irrigation ditches (N24).
-U+13226	kEH_Func	Logogram (6th nome of LE)
+U+13226	kEH_Func	Logogram (6th nome of Lower Egypt)
 U+13226	kEH_FVal	ḫꜣsw.w
 U+13226	kEH_UniK	NL006
 U+13226	kEH_JSesh	NL6
@@ -4564,70 +4564,70 @@ U+13228	kEH_JSesh	NL8
 U+13229	kEH_Cat	C-32-014
 U+13229	kEH_Core	C
 U+13229	kEH_Desc	Man/god, standing, with a double plume/feather headdress, right arm forward, hand at the height of the shoulder, holding a crook (S38) of the size of the man, left arm hanging beside the body, holding a flagellum (S45) horizontally; on top of a standard used for the carrying of religious symbols (R12) on top of a parcel of land with irrigation ditches (N24).
-U+13229	kEH_Func	Logogram (9th nome of UE)
+U+13229	kEH_Func	Logogram (9th nome of Lower Egypt)
 U+13229	kEH_FVal	ꜥnḏ.ty 
 U+13229	kEH_UniK	NL009
 U+13229	kEH_JSesh	NL9
 U+1322A	kEH_Cat	E-23-049
 U+1322A	kEH_Core	C
 U+1322A	kEH_Desc	A piece of crocodile skin with horizontal spines, or tail of a crocodile (I6), in front of a bovid (bull), standing; on top of a standard used for the carrying of religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
-U+1322A	kEH_Func	Logogram (10th nome of LE)
+U+1322A	kEH_Func	Logogram (10th nome of Lower Egypt)
 U+1322A	kEH_FVal	km-wr
 U+1322A	kEH_UniK	NL010
 U+1322A	kEH_JSesh	NL10
 U+1322B	kEH_Cat	E-23-050
 U+1322B	kEH_Core	C
 U+1322B	kEH_Desc	A pustule or gland, or a packet of mummy bandages (Aa2), in front of a bovid (bull), standing (E1); on top of a standard used for the carrying of religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
-U+1322B	kEH_Func	Logogram (11th nome of LE)
+U+1322B	kEH_Func	Logogram (11th nome of Lower Egypt)
 U+1322B	kEH_FVal	ḥsbw
 U+1322B	kEH_UniK	NL011
 U+1322B	kEH_JSesh	NL11
 U+1322C	kEH_Cat	E-23-051
 U+1322C	kEH_Core	C
 U+1322C	kEH_Desc	A newborn bubalis antelope, lying down, legs folded beneath the body, long tail downwards (E9), in front of a bovid (bull), standing (E1); on top of a standard used for the carrying of religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
-U+1322C	kEH_Func	Logogram (12th nome of LE)
+U+1322C	kEH_Func	Logogram (12th nome of Lower Egypt)
 U+1322C	kEH_FVal	ṯb-nṯr
 U+1322C	kEH_UniK	NL012
 U+1322C	kEH_JSesh	NL12
 U+1322D	kEH_Cat	N-11-044
 U+1322D	kEH_Core	C
 U+1322D	kEH_Desc	A double forked tool for the mending of nets, with a broad middle section (V26), written vertically, in front of a crook (S38); on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
-U+1322D	kEH_Func	Logogram (13th Lower Egyptian nome)
+U+1322D	kEH_Func	Logogram (13th nome of Lower Egypt)
 U+1322D	kEH_FVal	ḥḳꜣ-ꜥnḏ.w
 U+1322D	kEH_UniK	NL013
 U+1322D	kEH_JSesh	NL13
 U+1322E	kEH_Cat	N-11-036
 U+1322E	kEH_Core	C
-U+1322E	kEH_Desc	A schematic representation of three sealed water pots in a rack, without horizontal line at the bottom, with the downward lines descending to the bottom (W17E), in front of a spear made into a standard, with a circle on either side of the spear tip, with a loop over the standard (Jsesh R15); on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
-U+1322E	kEH_Func	Logogram (14th upper Egyptian nome)
+U+1322E	kEH_Desc	A schematic representation of three sealed water pots in a rack, without horizontal line at the bottom, with the downward lines descending to the bottom (W017A), in front of a spear made into a standard, with a circle on either side of the spear tip, with a loop over the standard (Jsesh R15); on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
+U+1322E	kEH_Func	Logogram (14th nome of Upper Egypt)
 U+1322E	kEH_FVal	ḫnt.y-ꞽꜣb.ty
 U+1322E	kEH_UniK	NL014
 U+1322E	kEH_JSesh	NL14
 U+1322F	kEH_Cat	G-11-107
 U+1322F	kEH_Core	C
 U+1322F	kEH_Desc	An African sacred ibis (Threskiornis aethiopicus) (G26A), on top of a standard used for carrying religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
-U+1322F	kEH_Func	Logogram (Thot nome, 15th nome of LE)
+U+1322F	kEH_Func	Logogram (Thot nome, 15th nome of Lower Egypt)
 U+1322F	kEH_FVal	ḏhwty
 U+1322F	kEH_UniK	NL015
 U+1322F	kEH_JSesh	NL15
 U+13230	kEH_Cat	K-01-034
 U+13230	kEH_Core	C
 U+13230	kEH_Desc	A fish, with its tail orientated downwards (K4A), on top of a standard used for carrying religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
-U+13230	kEH_Func	Logogram (First-of-fishes nome (16th nome of LE))
+U+13230	kEH_Func	Logogram (First-of-fishes nome (16th nome of Lower Egypt))
 U+13230	kEH_FVal	ḥꜣ.t-mḥ.yt
 U+13230	kEH_UniK	NL016
 U+13230	kEH_JSesh	NL16
 U+13231	kEH_Cat	N-11-045
 U+13231	kEH_Core	C
 U+13231	kEH_Desc	A tusk of an elephant (F18), above a human hand (D46); above a half round loaf of bread (X1) beside a plan of a crossroads in a village (O49); on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
-U+13231	kEH_Func	Logogram (Behdet, 17th Lower Egyptian nome)
+U+13231	kEH_Func	Logogram (Behdet, 17th nome of Lower Egypt)
 U+13231	kEH_FVal	bḥd.t
 U+13231	kEH_UniK	NL017
 U+13231	kEH_JSesh	NL17
 U+13232	kEH_Cat	N-11-046
 U+13232	kEH_Core	C
 U+13232	kEH_Desc	A windpipe and lungs (F36), in front of a cluster of signs consisting of a tusk of an elephant (F18), above a human hand (D46); above a half round loaf of bread (X1) beside a plan of a crossroads in a village (O49); on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
-U+13232	kEH_Func	Logogram (17th Lower Egyptian nome (Diospolis))
+U+13232	kEH_Func	Logogram (17th nome of Lower Egypt (Diospolis))
 U+13232	kEH_FVal	smꜣ-bḥd.t
 U+13232	kEH_UniK	NL017A
 U+13232	kEH_JSesh	NL17A
@@ -4646,14 +4646,14 @@ U+13235	kEH_JSesh	NL20
 U+13236	kEH_Cat	N-11-047
 U+13236	kEH_Core	C
 U+13236	kEH_Desc	A strip of land (N17), above a cluster of signs consisting of a bow, of an archaic type (Aa23), in front of a half round loaf of bread (X1), over a strip of land (N17); on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
-U+13236	kEH_Func	Logogram (Nubia, 1st Upper Egyptian nome)
+U+13236	kEH_Func	Logogram (Nubia, 1st nome of Upper Egypt)
 U+13236	kEH_FVal	tꜣ-sty
 U+13236	kEH_UniK	NU001
 U+13236	kEH_JSesh	NU1
 U+13237	kEH_Cat	G-12-153
 U+13237	kEH_Core	C
 U+13237	kEH_Desc	The pole of a balance, with the crossbar resembling a feather (H6), written horizontally (U39D), in front of a falcon (G5); on top of a standard used for carrying religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
-U+13237	kEH_Func	Logogram (Throne of Horus (Edfu, 2nd nome of UE))
+U+13237	kEH_Func	Logogram (Throne of Horus (Edfu, 2nd nome of Upper Egypt))
 U+13237	kEH_FVal	wṯs-ḥr
 U+13237	kEH_UniK	NU002
 U+13237	kEH_JSesh	NU2
@@ -4674,14 +4674,14 @@ U+13239	kEH_JSesh	NU4
 U+1323A	kEH_Cat	G-12-154
 U+1323A	kEH_Core	C
 U+1323A	kEH_Desc	Two falcons (G5), arranged horizontally, on top of a standard used for carrying religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
-U+1323A	kEH_Func	Logogram (The two gods, 5th nome of UE)
+U+1323A	kEH_Func	Logogram (The two gods, 5th nome of Upper Egypt)
 U+1323A	kEH_FVal	nṯr.wy
 U+1323A	kEH_UniK	NU005
 U+1323A	kEH_JSesh	NU5
 U+1323B	kEH_Cat	I-03-017
 U+1323B	kEH_Core	C
 U+1323B	kEH_Desc	A Nile crocodile (Crocodylus niloticus), with a feather (H6), angled backwards, on its head; on top of a standard used for carrying religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
-U+1323B	kEH_Func	Logogram (Iqer, 6th nome of UE)
+U+1323B	kEH_Func	Logogram (Iqer, 6th nome of Upper Egypt)
 U+1323B	kEH_FVal	ꞽḳr
 U+1323B	kEH_UniK	NU006
 U+1323B	kEH_JSesh	NU6
@@ -4709,14 +4709,14 @@ U+1323E	kEH_JSesh	NU9
 U+1323F	kEH_Cat	I-09-015
 U+1323F	kEH_Core	C
 U+1323F	kEH_Desc	A cobra in repose (Naja haje) (I10), with a feather (H6) on its back, angling backwards; on top of a standard used for carrying religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
-U+1323F	kEH_Func	Logogram (Wadjet, 10th nome of UE)
+U+1323F	kEH_Func	Logogram (Wadjet, 10th nome of Upper Egypt)
 U+1323F	kEH_FVal	wꜣḏ.t
 U+1323F	kEH_UniK	NU010
 U+1323F	kEH_JSesh	NU10
 U+13240	kEH_Cat	I-09-023
 U+13240	kEH_Core	C
 U+13240	kEH_Desc	A stem of papyrus with a bud (M13), in front of a half round loaf of bread (X1), written below a cobra in repose (Naja haje) (I10); on top of a standard used for carrying religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
-U+13240	kEH_Func	Logogram (Wadjet, 10th nome of UE)
+U+13240	kEH_Func	Logogram (Wadjet, 10th nome of Upper Egypt)
 U+13240	kEH_FVal	wꜣḏ.t
 U+13240	kEH_UniK	NU010A
 U+13240	kEH_JSesh	NU10A
@@ -4730,35 +4730,35 @@ U+13241	kEH_JSesh	NU11
 U+13242	kEH_Cat	N-11-048
 U+13242	kEH_Core	C
 U+13242	kEH_Desc	A wick of twisted flax, consisting of 3 loops (V28), in front of the red crown (S3), in front of three ripples of water, vertically aligned above one another (N35A); on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
-U+13242	kEH_Func	Logogram (11th Upper Egyptian nome (commonly under stẖ/stš/šꜣ)
+U+13242	kEH_Func	Logogram (11th nome of Upper Egypt (commonly under stẖ/stš/šꜣ)
 U+13242	kEH_FVal	ḥw-n.t
 U+13242	kEH_UniK	NU011A
 U+13242	kEH_JSesh	NU11A
 U+13243	kEH_Cat	N-13-027
 U+13243	kEH_Core	C
 U+13243	kEH_Desc	A sand covered mountain over the edge of the cultivated areas (N26), above a horned desert viper (Cerastes cerastes) (I9); on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
-U+13243	kEH_Func	Logogram (12th Upper Egyptian nome)
+U+13243	kEH_Func	Logogram (12th nome of Upper Egypt)
 U+13243	kEH_FVal	ꜣtf.t
 U+13243	kEH_UniK	NU012
 U+13243	kEH_JSesh	NU12
 U+13244	kEH_Cat	N-11-040
 U+13244	kEH_Core	C
-U+13244	kEH_Desc	A horned desert viper (Cerastes cerastes) (I9), written over a tree (M1), in front of a schematic representation of three sealed water pots in a rack, without horizontal line at the bottom, with the downward lines descending to the bottom (W17E); on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
-U+13244	kEH_Func	Logogram (13th Upper Egyptian nome)
+U+13244	kEH_Desc	A horned desert viper (Cerastes cerastes) (I9), written over a tree (M1), in front of a schematic representation of three sealed water pots in a rack, without horizontal line at the bottom, with the downward lines descending to the bottom (W017A); on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
+U+13244	kEH_Func	Logogram (13th nome of Upper Egypt)
 U+13244	kEH_FVal	nḏf.t-ḫnt.t
 U+13244	kEH_UniK	NU013
 U+13244	kEH_JSesh	NU13
 U+13245	kEH_Cat	N-11-041
 U+13245	kEH_Core	C
 U+13245	kEH_Desc	A horned desert viper (Cerastes cerastes) (I9), written over a tree (M1), in front of hindquarters of a seated lion or leopard (F22) above a half round loaf of bread (X1); on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
-U+13245	kEH_Func	Logogram (14th Upper Egyptian nome)
+U+13245	kEH_Func	Logogram (14th nome of Upper Egypt)
 U+13245	kEH_FVal	nḏf.t-pḥ.t
 U+13245	kEH_UniK	NU014
 U+13245	kEH_JSesh	NU14
 U+13246	kEH_Cat	E-16-010
 U+13246	kEH_Core	C
 U+13246	kEH_Desc	A desert hare, lying down (E34), on top of a standard used for the carrying of religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
-U+13246	kEH_Func	Logogram (Hermopolis magna, 15th nome of UE)
+U+13246	kEH_Func	Logogram (Hermopolis magna, 15th nome of Upper Egypt)
 U+13246	kEH_FVal	wnw.t
 U+13246	kEH_UniK	NU015
 U+13246	kEH_JSesh	E34B
@@ -4779,8 +4779,8 @@ U+13248	kEH_UniK	NU017
 U+13248	kEH_JSesh	NU17
 U+13249	kEH_Cat	G-13-028
 U+13249	kEH_Core	C
-U+13249	kEH_Desc	A falcon, standing, with extended wings at either side of the body, at a 45° angle; on top of a standard used for carrying religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
-U+13249	kEH_Func	Logogram (18th nome of UE (known as nmty as well))
+U+13249	kEH_Desc	A falcon, standing, with extended wings at either side of the body, at 45 degree; on top of a standard used for carrying religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
+U+13249	kEH_Func	Logogram (18th nome of Upper Egypt (known as nmty as well))
 U+13249	kEH_FVal	dwn-ꜥn.wy
 U+13249	kEH_UniK	NU018
 U+13249	kEH_JSesh	NU18
@@ -4797,15 +4797,15 @@ U+1324B	kEH_UniK	NU019
 U+1324B	kEH_JSesh	NU19
 U+1324C	kEH_Cat	N-11-042
 U+1324C	kEH_Core	C
-U+1324C	kEH_Desc	A tree (M1), in front of a schematic representation of three sealed water pots in a rack, without horizontal line at the bottom, with the downward lines descending to the bottom (W17E); on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
-U+1324C	kEH_Func	Logogram (20th Upper Egyptian nome)
+U+1324C	kEH_Desc	A tree (M1), in front of a schematic representation of three sealed water pots in a rack, without horizontal line at the bottom, with the downward lines descending to the bottom (W017A); on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
+U+1324C	kEH_Func	Logogram (20th nome of Upper Egypt)
 U+1324C	kEH_FVal	nꜥr.t-ḫnt.t
 U+1324C	kEH_UniK	NU020
 U+1324C	kEH_JSesh	NU20
 U+1324D	kEH_Cat	N-11-043
 U+1324D	kEH_Core	C
 U+1324D	kEH_Desc	A tree (M1), in front of hindquarters of a seated lion or leopard (F22) above a half round loaf of bread (X1); on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
-U+1324D	kEH_Func	Logogram (21th Upper Egyptian nome)
+U+1324D	kEH_Func	Logogram (21th nome of Upper Egypt)
 U+1324D	kEH_FVal	nꜥr.t-ph.t
 U+1324D	kEH_UniK	NU021
 U+1324D	kEH_JSesh	NU21
@@ -4831,7 +4831,7 @@ U+13250	kEH_HG	O1
 U+13250	kEH_IFAO	280,1
 U+13251	kEH_Cat	O-01-005
 U+13251	kEH_Core	L
-U+13251	kEH_Desc	A tie or strap, used with sandals (ankh-sign) (S34), written with its loop inside a house or enclosure (O1).
+U+13251	kEH_Desc	A tie or strap, used with sandals (ankh sign) (S34), written with its loop inside a house or enclosure (O1).
 U+13251	kEH_Func	Logogram (scriptorum, school (house of life))
 U+13251	kEH_FVal	pr-ꜥnḫ
 U+13251	kEH_UniK	O001A
@@ -4953,7 +4953,7 @@ U+13261	kEH_IFAO	289,1
 U+13261	kEH_AltSeq	13257 13439 13143
 U+13262	kEH_Cat	O-03-121
 U+13262	kEH_Core	L
-U+13262	kEH_Desc	A tie or strap, used with sandals (ankh-sign) (S34), written inside a plan of a rectangular enclosure, with an internal rectangle in the lower corner away from the reading direction (O6).
+U+13262	kEH_Desc	A tie or strap, used with sandals (ankh sign) (S34), written inside a plan of a rectangular enclosure, with an internal rectangle in the lower corner away from the reading direction (O6).
 U+13262	kEH_Func	Logogram (mansion of life)
 U+13262	kEH_FVal	ḥw.t-ꜥnḫ
 U+13262	kEH_UniK	O010A
@@ -5208,7 +5208,7 @@ U+13282	kEH_Core	C
 U+13282	kEH_UniK	O033A
 U+13283	kEH_Cat	O-18-006
 U+13283	kEH_Core	C
-U+13283	kEH_Desc	A door-bolt.
+U+13283	kEH_Desc	A door bolt.
 U+13283	kEH_Func	Phonemogram
 U+13283	kEH_FVal	s
 U+13283	kEH_UniK	O034
@@ -5217,7 +5217,7 @@ U+13283	kEH_HG	O34
 U+13283	kEH_IFAO	317,10
 U+13284	kEH_Cat	O-18-015
 U+13284	kEH_Core	C
-U+13284	kEH_Desc	A door-bolt (O34) written on top of legs in a walking posture, feet orientated towards the reading direction (D54).
+U+13284	kEH_Desc	A door bolt (O034) placed above legs in a walking posture, with feet oriented toward the reading direction (D054).
 U+13284	kEH_Func	Phonemogram
 U+13284	kEH_FVal	ꞽs
 U+13284	kEH_UniK	O035
@@ -5375,7 +5375,7 @@ U+13298	kEH_JSesh	Ff8
 U+13298	kEH_AltSeq	13299 13440
 U+13299	kEH_Cat	O-24-051
 U+13299	kEH_Core	C
-U+13299	kEH_Desc	A circle, with two lines at 45° coming from the front of the circle.
+U+13299	kEH_Desc	A circle, with two lines at 45 degree coming from the front of the circle.
 U+13299	kEH_Func	Phono-repeater/classifier (time, occasion)
 U+13299	kEH_FVal	sp
 U+13299	kEH_UniK	O050B
@@ -5584,7 +5584,7 @@ U+132B1	kEH_JSesh	R1G
 U+132B1	kEH_HG	R1G
 U+132B2	kEH_Cat	R-02-009
 U+132B2	kEH_Core	C
-U+132B2	kEH_Desc	A round loaf of bread (X6), a tall water-jug (W14) and a loaf of bread (X3), arranged horizontally on a table with an inwards incline of the legs, with a horizontal beam connecting the legs( R3P).
+U+132B2	kEH_Desc	A round loaf of bread (X6), a tall water-jug (W14) and a loaf of bread (X3), arranged horizontally on a table with an inwards incline of the legs, with a horizontal beam connecting the legs (R3P).
 U+132B2	kEH_Func	Classifier festival
 U+132B2	kEH_FVal	ḥ(ꜣ)b
 U+132B2	kEH_UniK	R003
@@ -5622,7 +5622,7 @@ U+132B6	kEH_HG	R5
 U+132B6	kEH_IFAO	351,14
 U+132B7	kEH_Cat	R-05-003
 U+132B7	kEH_Core	C
-U+132B7	kEH_Desc	A censer for fumigation, written horizontally, with a triangular shape at the front, with a backward, downward line at the back.
+U+132B7	kEH_Desc	A censer for fumigation, written horizontally, with a trapezoidal  shape at the front, with a backward, downward line at the back.
 U+132B7	kEH_Func	Logogram (to fumigate, to cense)
 U+132B7	kEH_FVal	kꜣp
 U+132B7	kEH_UniK	R006
@@ -5907,7 +5907,7 @@ U+132D9	kEH_IFAO	368,1
 U+132DA	kEH_Cat	S-07-002
 U+132DA	kEH_Core	C
 U+132DA	kEH_Desc	The Atef crown with ram horns and a sun disk.
-U+132DA	kEH_Func	Logogram (Atef-crown)
+U+132DA	kEH_Func	Logogram (Atef crown)
 U+132DA	kEH_FVal	ꜣtf
 U+132DA	kEH_UniK	S008
 U+132DA	kEH_JSesh	S8
@@ -6166,7 +6166,7 @@ U+132F8	kEH_HG	S33
 U+132F8	kEH_IFAO	382,8
 U+132F9	kEH_Cat	S-17-001
 U+132F9	kEH_Core	C
-U+132F9	kEH_Desc	A tie or strap, used with sandals (ankh-sign).
+U+132F9	kEH_Desc	A tie or strap, used with sandals (ankh sign).
 U+132F9	kEH_Func	Logogram (life)
 U+132F9	kEH_FVal	ꜥnḫ
 U+132F9	kEH_UniK	S034
@@ -6291,7 +6291,7 @@ U+13307	kEH_JSesh	T1
 U+13307	kEH_HG	T1
 U+13308	kEH_Cat	T-01-001
 U+13308	kEH_Core	C
-U+13308	kEH_Desc	A mace with a pear-shaped head, written at a 45° angle forwards.
+U+13308	kEH_Desc	A mace with a pear-shaped head, written 45 degree forwards.
 U+13308	kEH_Func	Classifier striking, hitting
 U+13308	kEH_FVal	sḳr
 U+13308	kEH_UniK	T002
@@ -6929,7 +6929,7 @@ U+13352	kEH_HG	U29
 U+13352	kEH_IFAO	401,4
 U+13353	kEH_Cat	U-10-006
 U+13353	kEH_Core	L
-U+13353	kEH_Desc	A spiral, winding counterclockwise away from its central point, ending at the right lower corner after about one and a half turns(Z7), written behind a fire-drill in a piece of wood (U28).
+U+13353	kEH_Desc	A spiral, winding counterclockwise away from its central point, ending at the right lower corner after about one and a half turns (Z7), written behind a fire-drill in a piece of wood (U28).
 U+13353	kEH_Func	Phonemogram
 U+13353	kEH_FVal	wḏꜣ
 U+13353	kEH_UniK	U029A
@@ -7894,7 +7894,7 @@ U+133D1	kEH_IFAO	462,7
 U+133D2	kEH_Cat	X-04-010
 U+133D2	kEH_Core	C
 U+133D2	kEH_Desc	A roll of bread, with a diamond in the middle.
-U+133D2	kEH_Func	Classifier Festival
+U+133D2	kEH_Func	Classifier festival
 U+133D2	kEH_UniK	X004
 U+133D2	kEH_JSesh	X4F
 U+133D2	kEH_HG	X4F
@@ -7909,7 +7909,7 @@ U+133D3	kEH_JSesh	X4A
 U+133D4	kEH_Cat	X-04-011
 U+133D4	kEH_Core	C
 U+133D4	kEH_Desc	A roll of bread without internal detail.
-U+133D4	kEH_Func	Classifier bread, Festival; Phonemogram t; Logogram t (bread); Phono-repeater: sn, fḳꜣ
+U+133D4	kEH_Func	Classifier bread, festival; Phonemogram t; Logogram t (bread); Phono-repeater: sn, fḳꜣ
 U+133D4	kEH_FVal	t | sn, fḳꜣ
 U+133D4	kEH_UniK	X004B
 U+133D5	kEH_Cat	X-05-001
@@ -8109,7 +8109,7 @@ U+133ED	kEH_IFAO	469,6
 U+133EE	kEH_Cat	Z-01-009
 U+133EE	kEH_Core	C
 U+133EE	kEH_Desc	Two vertical strokes arranged horizontally.
-U+133EE	kEH_Func	Logogram (2)
+U+133EE	kEH_Func	Logogram (two)
 U+133EE	kEH_FVal	sn.w
 U+133EE	kEH_UniK	Z004A
 U+133EE	kEH_JSesh	Z4A
@@ -8140,7 +8140,7 @@ U+133F1	kEH_JSesh	Z6
 U+133F1	kEH_HG	Z6
 U+133F2	kEH_Cat	Z-07-005
 U+133F2	kEH_Core	C
-U+133F2	kEH_Desc	 A spiral, winding counterclockwise away from its central point, ending at the right lower corner after about 1,5 turns.
+U+133F2	kEH_Desc	 A spiral, winding counterclockwise away from its central point, ending at the right lower corner after about one and a half turns.
 U+133F2	kEH_Func	Phonemogram
 U+133F2	kEH_FVal	w
 U+133F2	kEH_UniK	Z007
@@ -8733,19 +8733,19 @@ U+13475	kEH_HG	A4B
 U+13475	kEH_IFAO	2,13
 U+13476	kEH_Cat	A-01-042
 U+13476	kEH_Core	C
-U+13476	kEH_Desc	Man, seated, right knee raised, back bent forward, both arms raised in front, hand palms outwards.
+U+13476	kEH_Desc	Man, seated, right knee raised, back bent forwards, both arms raised in front, hand palms outwards.
 U+13476	kEH_Func	Logogram (praise, worship)
 U+13476	kEH_FVal	dwꜣ
 U+13476	kEH_UniK	A004G
 U+13477	kEH_Cat	A-01-044
 U+13477	kEH_Core	C
-U+13477	kEH_Desc	Man, seated on heel, right knee raised, with arms raised in front of him, hand-palms facing outwards.
+U+13477	kEH_Desc	Man, seated on heel, right knee raised, with arms raised in front, hand palms facing outwards.
 U+13477	kEH_Func	Classifier adoration
 U+13477	kEH_FVal	ꞽꜣw.t
 U+13477	kEH_UniK	A004H
 U+13478	kEH_Cat	A-01-045
 U+13478	kEH_Core	C
-U+13478	kEH_Desc	Man, kneeling with both knees on the ground, with arms raised in front of him, hand-palms facing outwards.
+U+13478	kEH_Desc	Man, kneeling with both knees on the ground, with arms raised in front, hand palms facing outwards.
 U+13478	kEH_Func	Classifier supplication/hiding/rejection
 U+13478	kEH_UniK	HJ A004C
 U+13478	kEH_JSesh	A4C
@@ -8753,7 +8753,7 @@ U+13478	kEH_HG	A4C
 U+13478	kEH_IFAO	3,1
 U+13479	kEH_Cat	A-01-046
 U+13479	kEH_Core	C
-U+13479	kEH_Desc	Man, kneeling with both knees on the ground, with arms raised in front of him, hand-palms facing inwards.
+U+13479	kEH_Desc	Man, kneeling with both knees on the ground, with arms raised in front, hand palms facing inwards.
 U+13479	kEH_Func	Classifier harpooner/priest
 U+13479	kEH_FVal	msn.ty
 U+13479	kEH_UniK	HJ A478
@@ -8836,7 +8836,7 @@ U+13484	kEH_JSesh	A76
 U+13484	kEH_HG	A76
 U+13485	kEH_Cat	A-01-070
 U+13485	kEH_Core	C
-U+13485	kEH_Desc	Man, seated, right knee raised, with a hair-lock, arm raised in front, hand held horizontal, hand palm upwards.
+U+13485	kEH_Desc	Man, seated, right knee raised, with a hair-lock, arm raised in front, hand held horizontally, hand palm upwards.
 U+13485	kEH_Func	Logogram (musician)
 U+13485	kEH_FVal	ḥs.w
 U+13485	kEH_UniK	HJ A426A
@@ -8871,8 +8871,8 @@ U+13489	kEH_IFAO	3,13
 U+13489	kEH_NoRotate	Y
 U+1348A	kEH_Cat	A-02-006
 U+1348A	kEH_Core	C
-U+1348A	kEH_Desc	Man, standing, bent slightly forwards, with a feather/cone on its head, angled backwards, with the arms hanging at either side of the body.
-U+1348A	kEH_Func	Classifier foreigner (nubian)
+U+1348A	kEH_Desc	Man, standing, bent slightly forwards, with a feather/cone on his head, angled backwards, with the arms hanging at either side of the body.
+U+1348A	kEH_Func	Classifier foreigner (Nubian)
 U+1348A	kEH_FVal	nḥs.y
 U+1348A	kEH_UniK	HJ A109E
 U+1348A	kEH_JSesh	A109E
@@ -8943,7 +8943,7 @@ U+13492	kEH_HG	A359
 U+13492	kEH_IFAO	4,3
 U+13493	kEH_Cat	A-02-022
 U+13493	kEH_Core	C
-U+13493	kEH_Desc	Man, standing, right arm outstretched before him, with the left arm bend, hand on the waist.
+U+13493	kEH_Desc	Man, standing, right arm outstretched before him, with the left arm bent, hand on the waist.
 U+13493	kEH_Func	Phonemogram
 U+13493	kEH_FVal	ꞽn
 U+13493	kEH_UniK	HJ A362
@@ -8952,7 +8952,7 @@ U+13493	kEH_HG	A362
 U+13493	kEH_IFAO	4,8
 U+13494	kEH_Cat	A-02-023
 U+13494	kEH_Core	C
-U+13494	kEH_Desc	Man, standing, bend slightly forward, right arm stretched in front at waist height, left arm hanging beside the body.
+U+13494	kEH_Desc	Man, standing, bent slightly forward, right arm stretched in front at waist height, left arm hanging beside the body.
 U+13494	kEH_Func	Classifier old man
 U+13494	kEH_FVal	kḥkḥ
 U+13494	kEH_UniK	HJ A363
@@ -8995,7 +8995,7 @@ U+13499	kEH_HG	A31B
 U+13499	kEH_IFAO	5,1
 U+1349A	kEH_Cat	A-02-034
 U+1349A	kEH_Core	C
-U+1349A	kEH_Desc	Man, standing, right arm raised with hand held vertical, hand palm outwards, left arm hanging beside the body.
+U+1349A	kEH_Desc	Man, standing, right arm raised with hand held vertically, hand palm outwards, left arm hanging beside the body.
 U+1349A	kEH_Func	Classifier official, noble
 U+1349A	kEH_FVal	sr
 U+1349A	kEH_UniK	HJ A366
@@ -9012,7 +9012,7 @@ U+1349B	kEH_JSesh	A84
 U+1349B	kEH_HG	A84
 U+1349C	kEH_Cat	A-02-037
 U+1349C	kEH_Core	C
-U+1349C	kEH_Desc	Man, standing, right arm raised in front, hand palm outwards, left arm at a 45° angle downwards at the front.
+U+1349C	kEH_Desc	Man, standing, right arm raised in front, hand palm outwards, left arm at 45 degree downwards at the front.
 U+1349C	kEH_Func	Logogram (to bend)
 U+1349C	kEH_FVal	ḳꜥḥ
 U+1349C	kEH_UniK	A083B
@@ -9040,12 +9040,12 @@ U+1349F	kEH_HG	A27A
 U+1349F	kEH_IFAO	5,9
 U+134A0	kEH_Cat	A-02-045
 U+134A0	kEH_Core	C
-U+134A0	kEH_Desc	Man, standing, with arms raised at either side of the body bent at a 90° angle, hand palms inwards.
+U+134A0	kEH_Desc	Man, standing, with arms raised at either side of the body bent at 90 degree, hand palms inwards.
 U+134A0	kEH_UniK	A028A
 U+134A0	kEH_IFAO	5,12
 U+134A1	kEH_Cat	A-02-055
 U+134A1	kEH_Core	C
-U+134A1	kEH_Desc	Man, standing, bend forward, arms hanging beside the body.
+U+134A1	kEH_Desc	Man, standing, bent forward, arms hanging beside the body.
 U+134A1	kEH_Func	Classifier bowing
 U+134A1	kEH_FVal	ksw
 U+134A1	kEH_UniK	HJ A343
@@ -9054,7 +9054,7 @@ U+134A1	kEH_HG	A343
 U+134A2	kEH_Cat	A-02-057
 U+134A2	kEH_Core	C
 U+134A2	kEH_Desc	Man, standing, wearing a lion/leopard-skin, left hand raised in front.
-U+134A2	kEH_Func	Logogram (Sem priest)?
+U+134A2	kEH_Func	Logogram (sem-priest)?
 U+134A2	kEH_FVal	sm
 U+134A2	kEH_UniK	HJ A365
 U+134A2	kEH_JSesh	A365
@@ -9073,7 +9073,7 @@ U+134A4	kEH_FVal	ꞽꜣs
 U+134A4	kEH_UniK	A526
 U+134A5	kEH_Cat	A-04-002
 U+134A5	kEH_Core	C
-U+134A5	kEH_Desc	Man, standing, bend forwards, both arms raised in front, hand palms outwards.
+U+134A5	kEH_Desc	Man, standing, bent forwards, both arms raised in front, hand palms outwards.
 U+134A5	kEH_Func	Classifier adoration
 U+134A5	kEH_FVal	ꞽꜣw
 U+134A5	kEH_UniK	A016D
@@ -9085,13 +9085,13 @@ U+134A6	kEH_HG	A16A
 U+134A6	kEH_IFAO	6,7
 U+134A7	kEH_Cat	A-04-007
 U+134A7	kEH_Core	C
-U+134A7	kEH_Desc	Man standing, bend slightly forwards, both arms extended forwards, right hand at the height of the shoulder, hand palm downwards, left arm below the right arm, hand palm downwards, as if to place the hands on something to leap over it.
+U+134A7	kEH_Desc	Man standing, bent slightly forwards, both arms extended forwards, right hand at the height of the shoulder, hand palm downwards, left arm below the right arm, hand palm downwards, as if to place the hands on something to leap over it.
 U+134A7	kEH_Func	Classifier leaping, bounding
 U+134A7	kEH_FVal	špw
 U+134A7	kEH_UniK	A016G
 U+134A8	kEH_Cat	A-04-008
 U+134A8	kEH_Core	C
-U+134A8	kEH_Desc	Man, standing, bend forwards, front arm hanging downwards towards the front, rear arm bend at a 90° angle, forearm and hand horizontal, rear arm hand extending beyond the front arm, at hip level.
+U+134A8	kEH_Desc	Man, standing, bent forwards, front arm hanging downwards towards the front, rear arm bent at 90 degree, forearm and hand horizontal, rear arm hand extending beyond the front arm, at hip level.
 U+134A8	kEH_Func	Classifier bowing
 U+134A8	kEH_FVal	ksw
 U+134A8	kEH_UniK	HJ A016C
@@ -9105,7 +9105,7 @@ U+134A9	kEH_HG	A16B
 U+134A9	kEH_IFAO	6,13
 U+134AA	kEH_Cat	A-04-011
 U+134AA	kEH_Core	C
-U+134AA	kEH_Desc	Man, standing, bend forwards with back nearly horizontal, arms hanging downwards, extended towards the front.
+U+134AA	kEH_Desc	Man, standing, bent forwards with back nearly horizontal, arms hanging downwards, extended towards the front.
 U+134AA	kEH_Func	Classifier bowing
 U+134AA	kEH_FVal	ḫꜣb
 U+134AA	kEH_UniK	HJ A087
@@ -9114,7 +9114,7 @@ U+134AA	kEH_HG	A87
 U+134AA	kEH_IFAO	7,1
 U+134AB	kEH_Cat	A-04-012
 U+134AB	kEH_Core	C
-U+134AB	kEH_Desc	Man, standing on top of a base, bend forwards with back nearly horizontal, arms hanging downwards, extended towards the front.
+U+134AB	kEH_Desc	Man, standing on top of a base, bent forwards with back nearly horizontal, arms hanging downwards, extended towards the front.
 U+134AB	kEH_Func	Logogram (kissing the land)
 U+134AB	kEH_FVal	sn-tꜣ
 U+134AB	kEH_UniK	HJ A087A
@@ -9123,7 +9123,7 @@ U+134AB	kEH_HG	A87A
 U+134AB	kEH_IFAO	7,2
 U+134AC	kEH_Cat	A-04-015
 U+134AC	kEH_Core	C
-U+134AC	kEH_Desc	Man, standing, back slightly bend forwards, arms twisted together at the front on a downward angle, line angling forwards from the head (braid, hairlock).
+U+134AC	kEH_Desc	Man, standing, back slightly bent forwards, arms twisted together at the front on a downward angle, line angling forwards from the head (braid, hairlock).
 U+134AC	kEH_Func	Classifier to twist
 U+134AC	kEH_FVal	sps
 U+134AC	kEH_UniK	HJ A090
@@ -9132,7 +9132,7 @@ U+134AC	kEH_HG	A90
 U+134AC	kEH_IFAO	7,5
 U+134AD	kEH_Cat	A-04-020
 U+134AD	kEH_Core	C
-U+134AD	kEH_Desc	Man, on an incline line, one leg straight at the bottom, the other bend and raised, right arm holding the top of the incline, left arm hanging beside the body at the back.
+U+134AD	kEH_Desc	Man, on an incline line, one leg straight at the bottom, the other bent and raised, right arm holding the top of the incline, left arm hanging beside the body at the back.
 U+134AD	kEH_Func	Phonemogram
 U+134AD	kEH_FVal	ḳꞽs
 U+134AD	kEH_UniK	A092C
@@ -9151,13 +9151,13 @@ U+134AF	kEH_JSesh	A372
 U+134AF	kEH_HG	A372
 U+134B0	kEH_Cat	A-05-002
 U+134B0	kEH_Core	C
-U+134B0	kEH_Desc	Man, written at a 45° degree angle forward, one leg extended forwards, arms raised in front.
+U+134B0	kEH_Desc	Man, written at 45 degree forward, one leg extended forwards, arms raised in front.
 U+134B0	kEH_Func	Classifier falling
 U+134B0	kEH_FVal	sḫr
 U+134B0	kEH_UniK	A015F
 U+134B1	kEH_Cat	A-05-007
 U+134B1	kEH_Core	C
-U+134B1	kEH_Desc	Man, written at an angle, right knee raised at slightly over 90° degree angle, arms extended forwards, with a knife with a triangular blade and straight handle (T30A) in the head, blade downwards.
+U+134B1	kEH_Desc	Man, written at an angle, right knee raised at slightly over 90 degree, arms extended forwards, with a knife with a triangular blade and straight handle (T30A) in the head, blade downwards.
 U+134B1	kEH_Func	Logogram (to overthrow, to cast down)
 U+134B1	kEH_FVal	sḫr
 U+134B1	kEH_UniK	A015G
@@ -9169,7 +9169,7 @@ U+134B2	kEH_FVal	mmty
 U+134B2	kEH_UniK	A015H
 U+134B3	kEH_Cat	A-05-010
 U+134B3	kEH_Core	C
-U+134B3	kEH_Desc	Man, prostrating, right leg extended, left leg bend and raised, both arms downwards, slightly bend, with the hands at the same level as the left knee and toes of the right leg.
+U+134B3	kEH_Desc	Man, prostrating, right leg extended, left leg bent and raised, both arms downwards, slightly bent, with the hands at the same level as the left knee and toes of the right leg.
 U+134B3	kEH_Func	Classifier bowing/lowering to the ground
 U+134B3	kEH_UniK	HJ A092
 U+134B3	kEH_JSesh	A92
@@ -9177,7 +9177,7 @@ U+134B3	kEH_HG	A92
 U+134B3	kEH_IFAO	7,15
 U+134B4	kEH_Cat	A-05-011
 U+134B4	kEH_Core	C
-U+134B4	kEH_Desc	Man, prostrating on a strip of land, right leg extended, left leg bend and raised, both arms downwards, slightly bend, with the hands at the same level as the left knee and toes of the right leg.
+U+134B4	kEH_Desc	Man, prostrating on a strip of land, right leg extended, left leg bent and raised, both arms downwards, slightly bent, with the hands at the same level as the left knee and toes of the right leg.
 U+134B4	kEH_UniK	A092B
 U+134B5	kEH_Cat	A-05-012
 U+134B5	kEH_Core	C
@@ -9187,7 +9187,7 @@ U+134B5	kEH_FVal	sn-tꜣ
 U+134B5	kEH_UniK	A092E
 U+134B6	kEH_Cat	A-05-013
 U+134B6	kEH_Core	C
-U+134B6	kEH_Desc	Man, prostrating on a strip of land, with grains of sand written below it, right leg extended, left leg bend and raised, both arms downwards, slightly bend, with the hands at the same level as the left knee and toes of the right leg.
+U+134B6	kEH_Desc	Man, prostrating on a strip of land, with grains of sand written below it, right leg extended, left leg bent and raised, both arms downwards, slightly bent, with the hands at the same level as the left knee and toes of the right leg.
 U+134B6	kEH_Func	Logogram (kissing the land)
 U+134B6	kEH_FVal	sn-tꜣ
 U+134B6	kEH_UniK	A092D
@@ -9199,13 +9199,13 @@ U+134B7	kEH_HG	A93
 U+134B7	kEH_IFAO	8,3
 U+134B8	kEH_Cat	A-05-016
 U+134B8	kEH_Core	C
-U+134B8	kEH_Desc	Man, prostrating, right leg extended, left leg bend and raised, left arm downwards, slightly bend, with the hands at the same level as the left knee and toes of the right leg, right arm raised, hand palm outwards.
+U+134B8	kEH_Desc	Man, prostrating, right leg extended, left leg bent and raised, left arm downwards, slightly bent, with the hands at the same level as the left knee and toes of the right leg, right arm raised, hand palm outwards.
 U+134B8	kEH_Func	classifier bowing, lowering to the ground
 U+134B8	kEH_FVal	ksꞽ
 U+134B8	kEH_UniK	A093A
 U+134B9	kEH_Cat	A-05-017
 U+134B9	kEH_Core	C
-U+134B9	kEH_Desc	Man, written horizontally, facing downwards, with knees and hips bend, with arms hanging loosely on either side beside the body (i.e., a corpse lying on the ground).
+U+134B9	kEH_Desc	Man, written horizontally, facing downwards, with knees and hips bent, with arms hanging loosely on either side beside the body (i.e., a corpse lying on the ground).
 U+134B9	kEH_Func	Classifier corpse
 U+134B9	kEH_FVal	ẖꜣ.t
 U+134B9	kEH_UniK	HJ A095
@@ -9214,7 +9214,7 @@ U+134B9	kEH_HG	A95
 U+134B9	kEH_IFAO	8,4
 U+134BA	kEH_Cat	A-05-018
 U+134BA	kEH_Core	C
-U+134BA	kEH_Desc	Man, written horizontally, facing upwards, with knees and hips bend, with the arms bend at either side of the body, elbows downwards, hands upwards, facing outwards at either side.
+U+134BA	kEH_Desc	Man, written horizontally, facing upwards, with knees and hips bent, with the arms bent at either side of the body, elbows downwards, hands upwards, facing outwards at either side.
 U+134BA	kEH_Func	Classifier to overthrow
 U+134BA	kEH_FVal	hdb
 U+134BA	kEH_UniK	HJ A097
@@ -9223,7 +9223,7 @@ U+134BA	kEH_HG	A97
 U+134BA	kEH_IFAO	8,5
 U+134BB	kEH_Cat	A-05-019
 U+134BB	kEH_Core	C
-U+134BB	kEH_Desc	Man, naked, written horizontally, facing upwards, with the head looking downwards, with knees and hips bend, lower arm bend beside the body, elbow downwards, hand upwards, facing outwards, upper arm hanging loosely beside the body.
+U+134BB	kEH_Desc	Man, naked, written horizontally, facing upwards, with the head looking downwards, with knees and hips bent, lower arm bent beside the body, elbow downwards, hand upwards, facing outwards, upper arm hanging loosely beside the body.
 U+134BB	kEH_Func	Classifier corpse
 U+134BB	kEH_UniK	A097A
 U+134BC	kEH_Cat	A-05-020
@@ -9237,7 +9237,7 @@ U+134BC	kEH_HG	A98
 U+134BC	kEH_NoRotate	Y
 U+134BD	kEH_Cat	A-05-021
 U+134BD	kEH_Core	C
-U+134BD	kEH_Desc	Man, written horizontally, facing downwards, one leg extended, one leg bend, top arm hanging beside the body, bottom arm bend, forearm written horizontally, hand palm downwards.
+U+134BD	kEH_Desc	Man, written horizontally, facing downwards, one leg extended, one leg bent, top arm hanging beside the body, bottom arm bent, forearm written horizontally, hand palm downwards.
 U+134BD	kEH_Func	Classifier lying on one side
 U+134BD	kEH_FVal	sḏr
 U+134BD	kEH_UniK	HJ A374
@@ -9250,7 +9250,7 @@ U+134BE	kEH_HG	A99
 U+134BE	kEH_IFAO	8,6
 U+134BF	kEH_Cat	A-05-023
 U+134BF	kEH_Core	C
-U+134BF	kEH_Desc	Man, written horizontally, facing downwards, knees and hips bend, arms raised at either side of the body, elbow bend downwards, hands upwards, facing inwards, with a round dotted line running between the hands (i.e., a man swimming).
+U+134BF	kEH_Desc	Man, written horizontally, facing downwards, knees and hips bent, arms raised at either side of the body, elbow bent downwards, hands upwards, facing inwards, with a round dotted line running between the hands (i.e., a man swimming).
 U+134BF	kEH_Func	Classifier swimming
 U+134BF	kEH_FVal	mḥꞽ
 U+134BF	kEH_UniK	HJ A096
@@ -9279,7 +9279,7 @@ U+134C2	kEH_HG	A102
 U+134C2	kEH_IFAO	8,9
 U+134C3	kEH_Cat	A-05-030
 U+134C3	kEH_Core	C
-U+134C3	kEH_Desc	A man, written at a 35° forwards, as if standing, with both arms raised in front, written inside a circle of wavy lines.
+U+134C3	kEH_Desc	A man, written at 35 degree forwards, as if standing, with both arms raised in front, written inside a circle of wavy lines.
 U+134C3	kEH_Func	Phonemogram
 U+134C3	kEH_FVal	nb
 U+134C3	kEH_UniK	HJ A101
@@ -9287,13 +9287,13 @@ U+134C3	kEH_JSesh	A101
 U+134C3	kEH_HG	A101
 U+134C4	kEH_Cat	A-05-031
 U+134C4	kEH_Core	C
-U+134C4	kEH_Desc	Man, written at a 45° angle forward, hips at a 90° angle, knees at an 90° angle legs slightly spread out, both arms forwards, at a downward angle, forearms separated, written inside a circle of wavy lines.
+U+134C4	kEH_Desc	Man, rotated 45 degree forwards, hips at 90 degree, knees at 90 degree, legs slightly spread out, both arms forwards, at a downward angle, forearms separated, written inside a circle of wavy lines.
 U+134C4	kEH_Func	Phonemogram
 U+134C4	kEH_FVal	nb
 U+134C4	kEH_UniK	A101E
 U+134C5	kEH_Cat	A-05-035
 U+134C5	kEH_Core	C
-U+134C5	kEH_Desc	Man, written at a 45° angle forward, both arms raised at either side of the body, hand palms outwards, inside an oval with a dotted line.
+U+134C5	kEH_Desc	Man, written at 45 degree forward, both arms raised at either side of the body, hand palms outwards, inside an oval with a dotted line.
 U+134C5	kEH_Func	Classifier swimming
 U+134C5	kEH_FVal	nbꞽ
 U+134C5	kEH_UniK	HJ A101D
@@ -9311,7 +9311,7 @@ U+134C6	kEH_IFAO	8,11
 U+134C7	kEH_Cat	A-06-002
 U+134C7	kEH_Core	C
 U+134C7	kEH_Desc	Man, standing, right arm in front, holding a long stick/staff, left arm hanging beside the body, on top of a standard with the support in the center.
-U+134C7	kEH_Func	Logogram (9th nome of UE)
+U+134C7	kEH_Func	Logogram (9th nome of Lower Egypt)
 U+134C7	kEH_FVal	ꜥnḏ.ty
 U+134C7	kEH_UniK	HJ A021B
 U+134C7	kEH_JSesh	A21B
@@ -9351,7 +9351,7 @@ U+134CC	kEH_UniK	A019X
 U+134CC	kEH_HG	A19
 U+134CD	kEH_Cat	A-06-014
 U+134CD	kEH_Core	C
-U+134CD	kEH_Desc	Man, standing, with a bend back, right arm forwards, holding a staff/stick near the top, with the staff at a backward angle, left arm hanging beside the body.
+U+134CD	kEH_Desc	Man, standing, with a bent back, right arm forwards, holding a staff/stick near the top, with the staff at a backward angle, left arm hanging beside the body.
 U+134CD	kEH_Func	Classifier wisdom
 U+134CD	kEH_FVal	sbḳ
 U+134CD	kEH_UniK	A019D
@@ -9588,7 +9588,7 @@ U+134EC	kEH_JSesh	A401
 U+134EC	kEH_HG	A401
 U+134ED	kEH_Cat	A-07-035
 U+134ED	kEH_Core	C
-U+134ED	kEH_Desc	Man, seated, right knee raised, with a circle (sun-disk) on his head, arms raised at either side of the body, supporting the sign for the sky (N1) which has the points at the hands, with the sign on top of the circle.
+U+134ED	kEH_Desc	Man, seated, right knee raised, with a circle (sun disk) on his head, arms raised at either side of the body, supporting the sign for the sky (N1) which has the points at the hands, with the sign on top of the circle.
 U+134ED	kEH_Func	Logogram (Heh (divinity))
 U+134ED	kEH_FVal	ḥḥ
 U+134ED	kEH_UniK	HJ A121
@@ -9670,7 +9670,7 @@ U+134F8	kEH_JSesh	A380
 U+134F8	kEH_HG	A380
 U+134F9	kEH_Cat	A-07-055
 U+134F9	kEH_Core	C
-U+134F9	kEH_Desc	Man, seated, right knee raised, right arm raised in front, holding a papyrus scroll at a 45° degree towards the face, left arm in front of the body.
+U+134F9	kEH_Desc	Man, seated, right knee raised, right arm raised in front, holding a papyrus scroll at 45 degree towards the face, left arm in front of the body.
 U+134F9	kEH_Func	Classifier lector priest
 U+134F9	kEH_FVal	ẖr.y-ḥb.t
 U+134F9	kEH_UniK	A516
@@ -9692,7 +9692,7 @@ U+134FB	kEH_JSesh	A402
 U+134FB	kEH_HG	A402
 U+134FC	kEH_Cat	A-07-060
 U+134FC	kEH_Core	C
-U+134FC	kEH_Desc	Man, seated on heel, both knees down, both arms extended in front, supporting a child (A17: knees at 90° degree, both lower legs visible, slightly apart, right arm raised with hand to mouth, left arm hanging beside the body).
+U+134FC	kEH_Desc	Man, seated on heel, both knees down, both arms extended in front, supporting a child (A17: knees at 90 degree, both lower legs visible, slightly apart, right arm raised with hand to mouth, left arm hanging beside the body).
 U+134FC	kEH_Func	Phonemogram
 U+134FC	kEH_FVal	f
 U+134FC	kEH_UniK	HJ A131C
@@ -9777,14 +9777,14 @@ U+13506	kEH_HG	A406
 U+13506	kEH_IFAO	13,1
 U+13507	kEH_Cat	A-08-022
 U+13507	kEH_Core	C
-U+13507	kEH_Desc	Man, standing, with a child (A17: knees at 90° degree, both lower legs visible, slightly apart, right arm raised with hand to mouth, left arm hanging beside the body) on his head, arms raised at either side of the body, supporting the child.
+U+13507	kEH_Desc	Man, standing, with a child (A17: knees at 90 degree, both lower legs visible, slightly apart, right arm raised with hand to mouth, left arm hanging beside the body) on his head, arms raised at either side of the body, supporting the child.
 U+13507	kEH_Func	Phonemogram
 U+13507	kEH_FVal	f
 U+13507	kEH_UniK	A131B
 U+13507	kEH_IFAO	13,2
 U+13508	kEH_Cat	A-08-025
 U+13508	kEH_Core	C
-U+13508	kEH_Desc	Man, standing, with a child (A17: knees at 90° degree, both lower legs visible, slightly apart, right arm raised with hand to mouth, left arm hanging beside the body) on his head, right arm raised, supporting the child, left arm hanging beside the body.
+U+13508	kEH_Desc	Man, standing, with a child (A17: knees at 90 degree, both lower legs visible, slightly apart, right arm raised with hand to mouth, left arm hanging beside the body) on his head, right arm raised, supporting the child, left arm hanging beside the body.
 U+13508	kEH_Func	Phonemogram
 U+13508	kEH_FVal	f
 U+13508	kEH_UniK	HJ A131A
@@ -9793,7 +9793,7 @@ U+13508	kEH_HG	A131A
 U+13508	kEH_IFAO	13,4
 U+13509	kEH_Cat	A-08-029
 U+13509	kEH_Core	C
-U+13509	kEH_Desc	Man, standing, both arms towards the front, holding an key for a tumbler lock consisting of a slightly bend vertical line with two shorter horizontal lines attached to the top akin to a flag, pointing outwards, as if to strike with it.
+U+13509	kEH_Desc	Man, standing, both arms towards the front, holding an key for a tumbler lock consisting of a slightly bent vertical line with two shorter horizontal lines attached to the top akin to a flag, pointing outwards, as if to strike with it.
 U+13509	kEH_UniK	A338B
 U+1350A	kEH_Cat	A-08-032
 U+1350A	kEH_Core	C
@@ -9821,13 +9821,13 @@ U+1350D	kEH_FVal	nḏr/smꜣ
 U+1350D	kEH_UniK	A399A
 U+1350E	kEH_Cat	A-08-041
 U+1350E	kEH_Core	C
-U+1350E	kEH_Desc	Man, standing, back bent forward, right arm forward, holding a branch, left arm hanging beside the body.
+U+1350E	kEH_Desc	Man, standing, back bent forwards, right arm forward, holding a branch, left arm hanging beside the body.
 U+1350E	kEH_Func	Classifier force/effort
 U+1350E	kEH_FVal	nḫt
 U+1350E	kEH_UniK	A399B
 U+1350F	kEH_Cat	A-08-042
 U+1350F	kEH_Core	C
-U+1350F	kEH_Desc	Man, standing, bend forwards, both arms forwards, holding a cup or vessel at the height of the knees.
+U+1350F	kEH_Desc	Man, standing, bent forwards, both arms forwards, holding a cup or vessel at the height of the knees.
 U+1350F	kEH_Func	Classifier death
 U+1350F	kEH_FVal	mt
 U+1350F	kEH_UniK	HJ A190
@@ -9871,7 +9871,7 @@ U+13515	kEH_JSesh	A133A
 U+13515	kEH_HG	A133A
 U+13516	kEH_Cat	A-09-014
 U+13516	kEH_Core	C
-U+13516	kEH_Desc	Man, standing, knees bend, bend forwards with back nearly horizontal, arms hanging downwards, extended towards the front, touching a block, with a vase with liquid issuing from it floating in front of its head, with the water ending on the block.
+U+13516	kEH_Desc	Man, standing, knees bent, bent forwards with back nearly horizontal, arms hanging downwards, extended towards the front, touching a block, with a vase with liquid issuing from it floating in front of its head, with the water ending on the block.
 U+13516	kEH_Func	Classifier to libate
 U+13516	kEH_FVal	sṯ
 U+13516	kEH_UniK	A133D
@@ -9954,7 +9954,7 @@ U+13521	kEH_HG	A135B
 U+13521	kEH_IFAO	14,6
 U+13522	kEH_Cat	A-10-007
 U+13522	kEH_Core	C
-U+13522	kEH_Desc	Man, standing, right arm forward, holding a tall water pot with a spout at a 45° angle, with water issuing from the spout, left arm hanging beside the body.
+U+13522	kEH_Desc	Man, standing, right arm forward, holding a tall water pot with a spout at 45 degree, with water issuing from the spout, left arm hanging beside the body.
 U+13522	kEH_Func	Logogram (to pour)
 U+13522	kEH_FVal	stꞽ
 U+13522	kEH_UniK	HJ A135C
@@ -10049,7 +10049,7 @@ U+1352D	kEH_HG	A143
 U+1352D	kEH_IFAO	15,13
 U+1352E	kEH_Cat	A-12-007
 U+1352E	kEH_Core	C
-U+1352E	kEH_Desc	Man, kneeling, right leg extended, left leg bend, foot at an angle, toes down, both arms forwards, extending downwards towards a grindstone.
+U+1352E	kEH_Desc	Man, kneeling, right leg extended, left leg bent, foot at an angle, toes down, both arms forwards, extending downwards towards a grindstone.
 U+1352E	kEH_Func	Classifier grinding
 U+1352E	kEH_FVal	nḏ
 U+1352E	kEH_UniK	A143C
@@ -10194,7 +10194,7 @@ U+13540	kEH_JSesh	A143A
 U+13540	kEH_HG	A143A
 U+13541	kEH_Cat	A-12-054
 U+13541	kEH_Core	C
-U+13541	kEH_Desc	Man, standing, back bent forwards, arms raised on either side of the body, bent at the elbow, hands at the height of the shoulders, holding an oar with both hands at 45° with the blade downwards.
+U+13541	kEH_Desc	Man, standing, back bent forwards, arms raised on either side of the body, bent at the elbow, hands at the height of the shoulders, holding an oar with both hands at 45 degree with the blade downwards.
 U+13541	kEH_Func	classifier to punt/pole (a boat)
 U+13541	kEH_FVal	wdꞽ
 U+13541	kEH_UniK	A152A
@@ -10207,7 +10207,7 @@ U+13542	kEH_JSesh	A398
 U+13542	kEH_HG	A398
 U+13543	kEH_Cat	A-12-058
 U+13543	kEH_Core	C
-U+13543	kEH_Desc	Man, standing, bend slightly forward, extending the arms forward, forearms horizontal at the level of the waist, holding a piece of clay or mud.
+U+13543	kEH_Desc	Man, standing, bent slightly forward, extending the arms forward, forearms horizontal at the level of the waist, holding a piece of clay or mud.
 U+13543	kEH_Func	Logogram (builders)
 U+13543	kEH_FVal	ḳd.w
 U+13543	kEH_UniK	HJ A415
@@ -10265,7 +10265,7 @@ U+1354B	kEH_JSesh	A413
 U+1354B	kEH_HG	A413
 U+1354C	kEH_Cat	A-12-077
 U+1354C	kEH_Core	C
-U+1354C	kEH_Desc	Man, standing on top of a branch, back bent forwards, both arms forward, forearms at the height of the waist, hands holding the branch which bend upwards.
+U+1354C	kEH_Desc	Man, standing on top of a branch, back bent forwards, both arms forward, forearms at the height of the waist, hands holding the branch which bends upwards.
 U+1354C	kEH_Func	Logogram (to bend down)
 U+1354C	kEH_FVal	wꜥf
 U+1354C	kEH_UniK	HJ A418
@@ -10302,7 +10302,7 @@ U+13550	kEH_UniK	A047L
 U+13551	kEH_Cat	A-13-013
 U+13551	kEH_Core	C
 U+13551	kEH_Desc	Man (foreigner), seated, both knees raised, with covered legs and arms, wearing foreign headgear, with a bushy beard, holding an axe with a round blade and a curved handle (T7).
-U+13551	kEH_Func	Classifier foreigner (asiatic)
+U+13551	kEH_Func	Classifier foreigner (Asiatic)
 U+13551	kEH_FVal	ꜥꜣm
 U+13551	kEH_UniK	A049E
 U+13552	kEH_Cat	A-13-014
@@ -10340,14 +10340,14 @@ U+13555	kEH_HG	A47C
 U+13555	kEH_IFAO	18,8
 U+13556	kEH_Cat	A-13-021
 U+13556	kEH_Core	C
-U+13556	kEH_Desc	Man, seated, both knees raised, with covered legs and arms, with short hair/wig, holding an object consisting of one long vertical line a one end, with multiple shorter vertical lines connected to a horizontal line, with the shorter vertical line section away from the body.
+U+13556	kEH_Desc	Man, seated, both knees raised, with covered legs and arms, with short hair/wig, holding an object consisting of one long vertical line at one end, with multiple shorter vertical lines connected to a horizontal line, with the shorter vertical line section away from the body.
 U+13556	kEH_Func	Logogram (to guard)
 U+13556	kEH_FVal	sꜣw
 U+13556	kEH_UniK	A047F
 U+13556	kEH_IFAO	18,11
 U+13557	kEH_Cat	A-13-022
 U+13557	kEH_Core	C
-U+13557	kEH_Desc	Man, seated, both knees raised, with covered legs and arms, with short hair/wig, holding an object consisting of one long vertical line a one end, with multiple shorter vertical lines connected to a horizontal line, with the shorter vertical line section towards the body.
+U+13557	kEH_Desc	Man, seated, both knees raised, with covered legs and arms, with short hair/wig, holding an object consisting of one long vertical line at one end, with multiple shorter vertical lines connected to a horizontal line, with the shorter vertical line section towards the body.
 U+13557	kEH_Func	Logogram (to guard)
 U+13557	kEH_FVal	sꜣw
 U+13557	kEH_UniK	A047H
@@ -10361,7 +10361,7 @@ U+13558	kEH_UniK	A461B
 U+13558	kEH_IFAO	18,14
 U+13559	kEH_Cat	A-13-026
 U+13559	kEH_Core	C
-U+13559	kEH_Desc	Man, seated, both knees raised, with covered legs and arms, with short hair/wig, holding an key for a tumbler lock consisting of a slightly bend vertical line with two shorter horizontal lines attached to the top akin to a flag, pointing outwards.
+U+13559	kEH_Desc	Man, seated, both knees raised, with covered legs and arms, with short hair/wig, holding an key for a tumbler lock consisting of a slightly bent vertical line with two shorter horizontal lines attached to the top akin to a flag, pointing outwards.
 U+13559	kEH_Func	Logogram (to guard)
 U+13559	kEH_FVal	sꜣw
 U+13559	kEH_UniK	A047M
@@ -10375,7 +10375,7 @@ U+1355A	kEH_UniK	A047D
 U+1355A	kEH_JSesh	A47D
 U+1355B	kEH_Cat	A-13-028
 U+1355B	kEH_Core	C
-U+1355B	kEH_Desc	Man, seated, both knees raised, with covered legs and arms, with a short straight beard and short hair/wig, holding an object consisting of one long vertical line a one end, with multiple shorter vertical lines connected to a horizontal line, with the shorter vertical line section towards the body.
+U+1355B	kEH_Desc	Man, seated, both knees raised, with covered legs and arms, with a short straight beard and short hair/wig, holding an object consisting of one long vertical line at one end, with multiple shorter vertical lines connected to a horizontal line, with the shorter vertical line section towards the body.
 U+1355B	kEH_Func	Logogram (to guard)
 U+1355B	kEH_FVal	sꜣw
 U+1355B	kEH_UniK	HJ A047E
@@ -10470,7 +10470,7 @@ U+13567	kEH_JSesh	A165
 U+13567	kEH_HG	A165
 U+13568	kEH_Cat	A-14-013
 U+13568	kEH_Core	C
-U+13568	kEH_Desc	Man, standing, right arm forward, holding a stick with a bundle or mat horizontally over his shoulders, bundle behind the back, with the ties downwards, left arm forwards at 45° downwards, holding a stick which curves slightly inwards.
+U+13568	kEH_Desc	Man, standing, right arm forward, holding a stick with a bundle or mat horizontally over his shoulders, bundle behind the back, with the ties downwards, left arm forwards at 45 degree downwards, holding a stick which curves slightly inwards.
 U+13568	kEH_Func	Logogram (herdsman)
 U+13568	kEH_FVal	mnꞽ.w
 U+13568	kEH_UniK	HJ A383
@@ -10527,8 +10527,8 @@ U+1356F	kEH_HG	A170
 U+1356F	kEH_IFAO	19,13
 U+13570	kEH_Cat	A-15-008
 U+13570	kEH_Core	C
-U+13570	kEH_Desc	Man, standing, right arm forward, hand at the height of the waist, left arm back, hand a the height of the waist, holding a rope in both hands which is connected to a djed pillar (R11) written at 45° angle forward.
-U+13570	kEH_Func	Logogram (to erect the Djed pillar)
+U+13570	kEH_Desc	Man, standing, right arm forwards, hand at the height of the waist, left arm back, hand a the height of the waist, holding a rope in both hands which is connected to a djed pillar (R011) written at 45 degree forward.
+U+13570	kEH_Func	Logogram (to erect the djed pillar)
 U+13570	kEH_FVal	sꜥḥꜥ-ḏd
 U+13570	kEH_UniK	HJ A171
 U+13570	kEH_JSesh	A171
@@ -10536,15 +10536,15 @@ U+13570	kEH_HG	A171
 U+13570	kEH_IFAO	20,1
 U+13571	kEH_Cat	A-15-009
 U+13571	kEH_Core	C
-U+13571	kEH_Desc	Man, standing, both arms forward, hand at the height of the waist, hands touching a Djed pillar (R11) written horizontally.
-U+13571	kEH_Func	Classifier erecting the djed-pillar (group classifier for sꜥḥꜥ-ḏd-ꞽn-ꞽr.yw-ḫt-n(y)-sw.t)
+U+13571	kEH_Desc	Man, standing, both arms extended forwards, hands at waist level, touching a djed pillar (R011) written horizontally.
+U+13571	kEH_Func	Classifier erecting the djed pillar (group classifier for sꜥḥꜥ-ḏd-ꞽn-ꞽr.yw-ḫt-n(y)-sw.t)
 U+13571	kEH_FVal	sꜥḥꜥ-ḏd-ꞽn-ꞽr.yw-ḫt-n(y)-sw.t
 U+13571	kEH_UniK	HJ A385
 U+13571	kEH_JSesh	A385
 U+13571	kEH_HG	A385
 U+13572	kEH_Cat	A-15-010
 U+13572	kEH_Core	C
-U+13572	kEH_Desc	Man, standing, facing backwards, both arms raised in front of the man, below the top of a column resembling a stem of papyrus with a bud (M13), without an abacus, angled forwards.
+U+13572	kEH_Desc	Man, standing, facing backwards, both arms raised in front of the man, below the top of a column resembling a stem of papyrus with a bud (M013), without an abacus, angled forwards.
 U+13572	kEH_Func	Classifier erecting
 U+13572	kEH_FVal	sꜥḥꜥ
 U+13572	kEH_UniK	A384A
@@ -10584,7 +10584,7 @@ U+13576	kEH_IFAO	20,10
 U+13577	kEH_Cat	A-15-021
 U+13577	kEH_Core	C
 U+13577	kEH_Desc	Man, standing, wearing a lion/leopard-skin, right hand holding up the tail of the skin angling at the front, left hand raised in front.
-U+13577	kEH_Func	Logogram (Sem-priest)
+U+13577	kEH_Func	Logogram (sem-priest)
 U+13577	kEH_FVal	sm
 U+13577	kEH_UniK	HJ A369
 U+13577	kEH_JSesh	A369
@@ -10652,7 +10652,7 @@ U+1357F	kEH_HG	A186
 U+1357F	kEH_IFAO	21,6
 U+13580	kEH_Cat	A-15-037
 U+13580	kEH_Core	C
-U+13580	kEH_Desc	Man, standing, with a line coming from his back at the waist, going down to the feet, right arm in front, right hand held horizontally at the height of the shoulders, holding D28 (two arms, raised upwards, with the forearms and hands vertical, hand palms inwards), left arm forwards, at a 45° degree downwards.
+U+13580	kEH_Desc	Man, standing, with a line coming from his back at the waist, going down to the feet, right arm in front, right hand held horizontally at the height of the shoulders, holding D28 (two arms, raised upwards, with the forearms and hands vertical, hand palms inwards), left arm forwards, at 45 degree downwards.
 U+13580	kEH_Func	Phonemogram
 U+13580	kEH_FVal	m kꜣ
 U+13580	kEH_UniK	HJ A458
@@ -10678,7 +10678,7 @@ U+13583	kEH_JSesh	A189
 U+13583	kEH_HG	A189
 U+13584	kEH_Cat	A-15-045
 U+13584	kEH_Core	C
-U+13584	kEH_Desc	Man, standing, bend slightly forwards, right arm towards the front, holding a round vessel with an upstanding rim (W24) at the height of the shoulder, left arm hanging beside the body.
+U+13584	kEH_Desc	Man, standing, bent slightly forwards, right arm towards the front, holding a round vessel with an upstanding rim (W24) at the height of the shoulder, left arm hanging beside the body.
 U+13584	kEH_Func	Classifier presenting
 U+13584	kEH_FVal	sfsf
 U+13584	kEH_UniK	HJ A376A
@@ -10708,7 +10708,7 @@ U+13587	kEH_JSesh	A340
 U+13587	kEH_HG	A340
 U+13588	kEH_Cat	A-15-054
 U+13588	kEH_Core	C
-U+13588	kEH_Desc	Man, standing, back slightly bend forward, both arms forward, holding a herb, with three flowers or leaves, curving upwards, with the middle flower/leaf higher than the other two (M2).
+U+13588	kEH_Desc	Man, standing, back slightly bent forward, both arms forward, holding a herb, with three flowers or leaves, curving upwards, with the middle flower/leaf higher than the other two (M2).
 U+13588	kEH_Func	Phono-repeater
 U+13588	kEH_FVal	fd
 U+13588	kEH_UniK	HJ A412
@@ -10716,7 +10716,7 @@ U+13588	kEH_JSesh	A412
 U+13588	kEH_HG	A412
 U+13589	kEH_Cat	A-15-055
 U+13589	kEH_Core	C
-U+13589	kEH_Desc	Man, standing, back slightly bend forward, both arms forward, holding a flower by the stem.
+U+13589	kEH_Desc	Man, standing, back slightly bent forward, both arms forward, holding a flower by the stem.
 U+13589	kEH_Func	Classifier to uproot
 U+13589	kEH_FVal	fdꞽ
 U+13589	kEH_UniK	HJ A412A
@@ -10724,19 +10724,19 @@ U+13589	kEH_JSesh	A412A
 U+13589	kEH_HG	A412A
 U+1358A	kEH_Cat	A-15-071
 U+1358A	kEH_Core	C
-U+1358A	kEH_Desc	Man, walking, with a line (hairlock?) coming from the head, right arm forward, forearm horizontal, holding a leaf, stem (bend forwards) and root of a lotus plant (M12B), left arm hanging beside the body.
+U+1358A	kEH_Desc	Man, walking, with a line (hairlock?) coming from the head, right arm forward, forearm horizontal, holding a leaf, stem (bent forwards) and root of a lotus plant (M12B), left arm hanging beside the body.
 U+1358A	kEH_Func	Phonemogram
 U+1358A	kEH_FVal	ḫꜣ
 U+1358A	kEH_UniK	A174B
 U+1358B	kEH_Cat	A-15-072
 U+1358B	kEH_Core	C
-U+1358B	kEH_Desc	Man, standing, right arm forward, holding a leaf, stem (bend forwards) and root of a lotus plant (M12B), left arm hanging beside the body.
+U+1358B	kEH_Desc	Man, standing, right arm forward, holding a leaf, stem (bent forwards) and root of a lotus plant (M12B), left arm hanging beside the body.
 U+1358B	kEH_Func	Phonemogram
 U+1358B	kEH_FVal	ḫꜣ-dꞽ.t
 U+1358B	kEH_UniK	A174C
 U+1358C	kEH_Cat	A-15-073
 U+1358C	kEH_Core	C
-U+1358C	kEH_Desc	Man, standing, right arm forward, holding a leaf, stem (bend forwards) and root of a lotus plant (M12B), left arm hanging beside the body, holding a knife (T30A) horizontally.
+U+1358C	kEH_Desc	Man, standing, right arm forward, holding a leaf, stem (bent forwards) and root of a lotus plant (M12B), left arm hanging beside the body, holding a knife (T30A) horizontally.
 U+1358C	kEH_Func	Phonemogram
 U+1358C	kEH_FVal	ḫꜣ-dꞽ.t
 U+1358C	kEH_UniK	A174D
@@ -10827,7 +10827,7 @@ U+13598	kEH_Func	Classifier ?
 U+13598	kEH_UniK	A199E
 U+13599	kEH_Cat	A-16-032
 U+13599	kEH_Core	C
-U+13599	kEH_Desc	Man, standing, both arms forwards, holding a scimitar (khopesh), written vertically, blade curving forwards, with the head of a falcon with a sun-disk (N5) on top of it (T73B).
+U+13599	kEH_Desc	Man, standing, both arms forwards, holding a scimitar (khopesh), written vertically, blade curving forwards, with the head of a falcon with a sun disk (N5) on top of it (T073B).
 U+13599	kEH_Func	Logogram (to be strong)
 U+13599	kEH_FVal	nḫt
 U+13599	kEH_UniK	A203A
@@ -10983,7 +10983,7 @@ U+135B0	kEH_HG	A13B
 U+135B0	kEH_IFAO	24,12
 U+135B1	kEH_Cat	A-18-009
 U+135B1	kEH_Core	C
-U+135B1	kEH_Desc	Man, seated on heel, both knees down, right arm forwards, hanging beside the body, left arm hanging beside the body, with a knife (T30A) written at a 45° degree over the elbow of the right arm, point at the groin, blade downwards.
+U+135B1	kEH_Desc	Man, seated on heel, both knees down, right arm forwards, hanging beside the body, left arm hanging beside the body, with a knife (T30A) written at 45 degree over the elbow of the right arm, point at the groin, blade downwards.
 U+135B1	kEH_Func	Classifier enemy?
 U+135B1	kEH_UniK	A013Y
 U+135B2	kEH_Cat	A-18-010
@@ -11088,8 +11088,8 @@ U+135BF	kEH_JSesh	A216B
 U+135BF	kEH_HG	A216B
 U+135BF	kEH_IFAO	26,8
 U+135C0	kEH_Cat	A-18-051
-U+135C0	kEH_UniK	HJ A216C
-U+135C0	kEH_JSesh	A216C
+U+135C0	kEH_Desc	Man, seated on heel, both knees down, with a line of liquid coming from the face/neck, towards the front, curving downwards, both arms behind the back, bound together with rope, in front of a pole which is forked at the top, to which the man is bound.
+U+135C0	kEH_UniK	A216C
 U+135C0	kEH_HG	A216C
 U+135C0	kEH_IFAO	26,10
 U+135C1	kEH_Cat	A-18-052
@@ -11145,12 +11145,13 @@ U+135C7	kEH_UniK	A216O
 U+135C8	kEH_Cat	A-18-060
 U+135C8	kEH_Core	C
 U+135C8	kEH_Desc	Man, seated on heel, both knees down, both arms behind the back, bound together with rope, in front of a pole which is forked at the top, to which the man is bound.
-U+135C8	kEH_Func	Classifier foes, hostile forces`
+U+135C8	kEH_Func	Classifier foes, hostile forces
 U+135C8	kEH_FVal	kꞽ.wy
 U+135C8	kEH_UniK	A216P
+U+135C8	kEH_JSesh	A216C
 U+135C9	kEH_Cat	A-18-061
 U+135C9	kEH_Core	C
-U+135C9	kEH_Desc	Man, seated on heel, both knees down, with a knife at 45° degree, with the tip on the thighs, blade down; both arms behind the back, bound together with rope, in front of a pole which is forked at the top, to which the man is bound.
+U+135C9	kEH_Desc	Man, seated on heel, both knees down, with a knife at 45 degree, with the tip on the thighs, blade down; both arms behind the back, bound together with rope, in front of a pole which is forked at the top, to which the man is bound.
 U+135C9	kEH_Func	Classifier enemy
 U+135C9	kEH_FVal	šnṯ
 U+135C9	kEH_UniK	A216Q
@@ -11281,7 +11282,7 @@ U+135DB	kEH_JSesh	A424
 U+135DB	kEH_HG	A424
 U+135DC	kEH_Cat	A-18-117
 U+135DC	kEH_Core	C
-U+135DC	kEH_Desc	3 men, kneeling/walking on knees, ground together around the neck. First man, right knee before left knee, both arms raised in front, hand palms outward, second man, right knee just in front of left knee, both arms behind the back, as if bound, third man, right knee and foot in front of the left knee, left lower leg raised at 45° degree, right arm in front, hand against the head of the second man, left arm behind the back, hand visible in front of the waist. 
+U+135DC	kEH_Desc	3 men, kneeling/walking on knees, ground together around the neck. First man, right knee before left knee, both arms raised in front, hand palms outward, second man, right knee just in front of left knee, both arms behind the back, as if bound, third man, right knee and foot in front of the left knee, left lower leg raised at 45 degree, right arm in front, hand against the head of the second man, left arm behind the back, hand visible in front of the waist. 
 U+135DC	kEH_Func	Classifier foreign people
 U+135DC	kEH_FVal	ḫꜣs.wt nb.wt
 U+135DC	kEH_UniK	A538
@@ -11318,7 +11319,7 @@ U+135E0	kEH_UniK	A032I
 U+135E0	kEH_IFAO	29,8
 U+135E1	kEH_Cat	A-19-012
 U+135E1	kEH_Core	C
-U+135E1	kEH_Desc	Man, naked, dancing, right leg vertical, left leg forwards, thigh horizontal, lower leg bend downwards, right arm raised in front, left arm hanging beside the body.
+U+135E1	kEH_Desc	Man, naked, dancing, right leg vertical, left leg forwards, thigh horizontal, lower leg bent downwards, right arm raised in front, left arm hanging beside the body.
 U+135E1	kEH_Func	Classifier dance
 U+135E1	kEH_FVal	ꞽbꜣ
 U+135E1	kEH_UniK	HJ A032F
@@ -11327,7 +11328,7 @@ U+135E1	kEH_HG	A32F
 U+135E1	kEH_IFAO	29,10
 U+135E2	kEH_Cat	A-19-013
 U+135E2	kEH_Core	C
-U+135E2	kEH_Desc	Man, naked, dancing, right leg vertical, left leg forwards, thigh horizontal, lower leg bend downwards, right arm towards the front, angling downwards towards the left knee, hand at the height of the left knee, left arm raised at the back, hand at the height of the head.
+U+135E2	kEH_Desc	Man, naked, dancing, right leg vertical, left leg forwards, thigh horizontal, lower leg bent downwards, right arm towards the front, angling downwards towards the left knee, hand at the height of the left knee, left arm raised at the back, hand at the height of the head.
 U+135E2	kEH_Func	Classifier dance
 U+135E2	kEH_FVal	ꞽbꜣ
 U+135E2	kEH_UniK	HJ A032D
@@ -11336,7 +11337,7 @@ U+135E2	kEH_HG	A32D
 U+135E2	kEH_IFAO	29,11
 U+135E3	kEH_Cat	A-19-016
 U+135E3	kEH_Core	C
-U+135E3	kEH_Desc	Man, dancing, knees bend as if seated on nothing, right arm extended in front, forearm horizontal, left arm raised in back, forearm vertical.
+U+135E3	kEH_Desc	Man, dancing, knees bent as if seated on nothing, right arm extended in front, forearm horizontal, left arm raised in back, forearm vertical.
 U+135E3	kEH_Func	Classifier youthful soldier
 U+135E3	kEH_FVal	mgꜣ
 U+135E3	kEH_UniK	HJ A233
@@ -11363,7 +11364,7 @@ U+135E5	kEH_HG	A32B
 U+135E5	kEH_IFAO	30,1
 U+135E6	kEH_Cat	A-19-021
 U+135E6	kEH_Core	C
-U+135E6	kEH_Desc	Man, dancing, knees bend as if seated on nothing, right arm forwards, angling downwards, left arm raised in back, hand at the height of the neck.
+U+135E6	kEH_Desc	Man, dancing, knees bent as if seated on nothing, right arm forwards, angling downwards, left arm raised in back, hand at the height of the neck.
 U+135E6	kEH_Func	Classifier dancing
 U+135E6	kEH_FVal	ḫbꞽ
 U+135E6	kEH_UniK	HJ A320
@@ -11423,8 +11424,8 @@ U+135EE	kEH_HG	A239B
 U+135EE	kEH_IFAO	30,11a
 U+135EF	kEH_Cat	A-20-016
 U+135EF	kEH_Core	C
-U+135EF	kEH_Desc	King, standing, wearing the red crown (S3) and a long straight beard, right arm forwards, on a 45° downward angle, left arm towards the front, left hand in front of the body, at the height of the shoulder, holding a sceptre (S42).
-U+135EF	kEH_Func	Logogram (the King of Lower Egypt)
+U+135EF	kEH_Desc	King, standing, wearing the red crown (S3) and a long straight beard, right arm forwards, 45 degree downwards, left arm towards the front, left hand in front of the body, at the height of the shoulder, holding a sceptre (S42).
+U+135EF	kEH_Func	Logogram (the king of Lower Egypt)
 U+135EF	kEH_FVal	bꞽ.ty
 U+135EF	kEH_UniK	HJ A302D
 U+135EF	kEH_JSesh	A302D
@@ -11438,7 +11439,7 @@ U+135F0	kEH_UniK	A302G
 U+135F0	kEH_IFAO	30,13
 U+135F1	kEH_Cat	A-20-022
 U+135F1	kEH_Core	C
-U+135F1	kEH_Desc	Man, standing, wearing kilt, right arm extended in front, held horizontally, holding a sistrum (Y18), left arm forwards on a 45° degree angle, holding a bead-necklace with counterweight.
+U+135F1	kEH_Desc	Man, standing, wearing kilt, right arm extended in front, held horizontally, holding a sistrum (Y18), left arm forwards  45 degree, holding a bead-necklace with counterweight.
 U+135F1	kEH_Func	Logogram (Ihy (divinity))
 U+135F1	kEH_FVal	ꞽḥy
 U+135F1	kEH_UniK	A239A
@@ -11446,7 +11447,7 @@ U+135F1	kEH_JSesh	A239A
 U+135F1	kEH_IFAO	30,15
 U+135F2	kEH_Cat	A-20-023
 U+135F2	kEH_Core	C
-U+135F2	kEH_Desc	Child, naked, with a side-lock, standing, right arm extended in front, held horizontally, holding a sistrum (Y18), left arm forwards on a 45° degree angle, holding a bead-necklace with counterweight.
+U+135F2	kEH_Desc	Child, naked, with a side-lock, standing, right arm extended in front, held horizontally, holding a sistrum (Y18), left arm forwards 45 degree, holding a bead-necklace with counterweight.
 U+135F2	kEH_Func	Logogram (the musician)
 U+135F2	kEH_FVal	ꞽḥy
 U+135F2	kEH_UniK	A239S
@@ -11454,14 +11455,14 @@ U+135F2	kEH_HG	A239A
 U+135F2	kEH_IFAO	30,15a
 U+135F3	kEH_Cat	A-20-024
 U+135F3	kEH_Core	C
-U+135F3	kEH_Desc	Child, naked, with a side-lock, standing, right arm extended in front, held horizontally, holding a sistrum (Y8), left arm forwards on a 45° degree angle, holding a bead-necklace with counterweight.
+U+135F3	kEH_Desc	Child, naked, with a side-lock, standing, right arm extended in front, held horizontally, holding a sistrum (Y8), left arm forwards 45 degree, holding a bead-necklace with counterweight.
 U+135F3	kEH_Func	Logogram (the great god)
 U+135F3	kEH_FVal	nṯr-ꜥꜣ
 U+135F3	kEH_UniK	A239F
 U+135F4	kEH_Cat	A-20-026
 U+135F4	kEH_Core	C
 U+135F4	kEH_Desc	King, wearing the white crown (S1), standing, right arm in front, right hand at the height of the shoulder, holding a sistrum (Y8), left arm hanging beside the body, holding a flagellum and crook (S38) horizontally.
-U+135F4	kEH_Func	Logogram (King of UE)
+U+135F4	kEH_Func	Logogram (king of Upper Egypt)
 U+135F4	kEH_FVal	n(y)-sw.t
 U+135F4	kEH_UniK	A239N
 U+135F5	kEH_Cat	A-20-027
@@ -11498,7 +11499,7 @@ U+135F9	kEH_FVal	ḥr-smꜣ-tꜣ.wy
 U+135F9	kEH_UniK	A239G
 U+135FA	kEH_Cat	A-20-048
 U+135FA	kEH_Core	C
-U+135FA	kEH_Desc	Child, naked, with side-lock and wearing the hmhm crown (S61), standing, right arm extended in front, held horizontally, holding a sistrum (Y18), left arm forwards on a 45° degree angle, holding a bead-necklace with counterweight.
+U+135FA	kEH_Desc	Child, naked, with side-lock and wearing the hmhm crown (S61), standing, right arm extended in front, held horizontally, holding a sistrum (Y18), left arm forwards 45 degree, holding a bead-necklace with counterweight.
 U+135FA	kEH_Func	Logogram (Harsomtus)
 U+135FA	kEH_FVal	ḥr-smꜣ-tꜣ.wy 
 U+135FA	kEH_UniK	A239M
@@ -11671,7 +11672,7 @@ U+13610	kEH_FVal	(m) ḥb (m) ḥtr (m) tp n rmṯ
 U+13610	kEH_UniK	A253A
 U+13611	kEH_Cat	A-21-022
 U+13611	kEH_Core	C
-U+13611	kEH_Desc	Child, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) upon his head, seated between the horns of a bull (bovid), standing; arms at either side of the child, holding the horns of the bull.
+U+13611	kEH_Desc	Child, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) upon his head, seated between the horns of a bull (bovid), standing; arms at either side of the child, holding the horns of the bull.
 U+13611	kEH_Func	Logogram (part of the sꜣ-rꜥ nb ḫꜥ.w construction)
 U+13611	kEH_FVal	sꜣ-rꜥ-nb
 U+13611	kEH_UniK	HJ A254
@@ -11750,7 +11751,7 @@ U+1361A	kEH_JSesh	A431
 U+1361A	kEH_HG	A431
 U+1361B	kEH_Cat	A-21-036
 U+1361B	kEH_Core	C
-U+1361B	kEH_Desc	Man, standing, both arms forward, holding a fishing rod at 45° degree, fishing line vertical, connecting to a fish, between the fishing line and the toes of the man, slightly tilted upwards.
+U+1361B	kEH_Desc	Man, standing, both arms forward, holding a fishing rod 45 degree upwards, fishing line vertical, connecting to a fish, between the fishing line and the toes of the man, slightly tilted upwards.
 U+1361B	kEH_Func	Phonemogram
 U+1361B	kEH_FVal	wḥꜥ
 U+1361B	kEH_UniK	HJ A430
@@ -11801,7 +11802,7 @@ U+13621	kEH_FVal	ḥwn.w
 U+13621	kEH_UniK	A529
 U+13622	kEH_Cat	A-23-015
 U+13622	kEH_Core	C
-U+13622	kEH_Desc	Child, seated on nothing, forelegs spread, right arm extended forward, holding a clump with one papyrus stem and bud, with two buds bent down (M15Avar), at the stem, below the bud; left arm hanging beside the body.
+U+13622	kEH_Desc	Child, seated on nothing, forelegs spread, right arm extended forward, holding a clump with one papyrus stem and bud, with two buds bent down (M015D), at the stem, below the bud; left arm hanging beside the body.
 U+13622	kEH_Func	Logogram (weaned child)
 U+13622	kEH_FVal	wḏḥ
 U+13622	kEH_UniK	A530
@@ -11821,8 +11822,8 @@ U+13624	kEH_HG	A270
 U+13624	kEH_IFAO	34,13
 U+13625	kEH_Cat	A-23-023
 U+13625	kEH_Core	C
-U+13625	kEH_Desc	Child, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) upon his head, seated on nothing, forelegs spread, right arm raised in front with hand to mouth, left arm hanging beside the body.
-U+13625	kEH_Func	Logogram (Son of Re)
+U+13625	kEH_Desc	Child, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) upon his head, seated on nothing, forelegs spread, right arm raised in front with hand to mouth, left arm hanging beside the body.
+U+13625	kEH_Func	Logogram (son of Re)
 U+13625	kEH_FVal	sꜣ-rꜥ
 U+13625	kEH_UniK	HJ A272
 U+13625	kEH_JSesh	A272
@@ -11830,8 +11831,8 @@ U+13625	kEH_HG	A272
 U+13625	kEH_IFAO	35,1
 U+13626	kEH_Cat	A-23-024
 U+13626	kEH_Core	C
-U+13626	kEH_Desc	Child, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) upon his head, seated on nothing, one leg visible, right arm raised in front with hand to mouth, left arm hanging beside the body.
-U+13626	kEH_Func	Logogram (Son of Re)
+U+13626	kEH_Desc	Child, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) upon his head, seated on nothing, one leg visible, right arm raised in front with hand to mouth, left arm hanging beside the body.
+U+13626	kEH_Func	Logogram (son of Re)
 U+13626	kEH_FVal	sꜣ-rꜥ
 U+13626	kEH_UniK	A272B
 U+13627	kEH_Cat	A-23-025
@@ -11845,7 +11846,7 @@ U+13627	kEH_HG	A273
 U+13627	kEH_IFAO	35,3
 U+13628	kEH_Cat	A-23-026
 U+13628	kEH_Core	C
-U+13628	kEH_Desc	Child, with the head of a cobra (Naja haje), standing up, with expanded hood (Uraeus) on his head, seated on nothing, forelegs spread, right arm raised in front with hand to mouth, left arm hanging beside the body.
+U+13628	kEH_Desc	Child, with the head of a cobra (Naja haje), standing up, with expanded hood (uraeus) on his head, seated on nothing, forelegs spread, right arm raised in front with hand to mouth, left arm hanging beside the body.
 U+13628	kEH_Func	Classifier child
 U+13628	kEH_FVal	nḫn.w
 U+13628	kEH_UniK	A273A
@@ -11923,7 +11924,7 @@ U+13633	kEH_FVal	ḥkꜣ
 U+13633	kEH_UniK	A276A
 U+13634	kEH_Cat	A-23-051
 U+13634	kEH_Core	C
-U+13634	kEH_Desc	A child, seated on a mat, wearing a coif with uraeus, covered in cloth, legs bend in front, feet at the same level as the mat, right arm raised in front with hand to mouth, left arm in front, hand upon the knee.
+U+13634	kEH_Desc	A child, seated on a mat, wearing a coif with uraeus, covered in cloth, legs bent in front, feet at the same level as the mat, right arm raised in front with hand to mouth, left arm in front, hand upon the knee.
 U+13634	kEH_Func	Classifier child
 U+13634	kEH_FVal	sfy
 U+13634	kEH_UniK	HJ A278A
@@ -12053,13 +12054,13 @@ U+13645	kEH_HG	A51D
 U+13645	kEH_IFAO	37,9
 U+13646	kEH_Cat	A-25-021
 U+13646	kEH_Core	C
-U+13646	kEH_Desc	God, with a long-curved beard and long wig, seated on a block throne, both arms extended forwards, forearms horizontal, one above the other, top hand holding a tie or strap, used with sandals (ankh-sign, S34) in one hand, horizontally, with the bottom hand opened with the palm facing upwards.
+U+13646	kEH_Desc	God, with a long-curved beard and long wig, seated on a block throne, both arms extended forwards, forearms horizontal, one above the other, top hand holding a tie or strap, used with sandals (ankh sign, S34) in one hand, horizontally, with the bottom hand opened with the palm facing upwards.
 U+13646	kEH_Func	Logogram (to be noble)
 U+13646	kEH_FVal	špsꞽ
 U+13646	kEH_UniK	A051H
 U+13647	kEH_Cat	A-25-022
 U+13647	kEH_Core	C
-U+13647	kEH_Desc	God, with a long-curved beard and long wig, seated on a block throne, on top of a base, right arm extended forwards, hand at the height of the waist, extended beyond the knee, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40), and a tie or strap, used with sandals (ankh-sign, S34), at the loop, horizontally; left arm forward, hand above the lap, holding a tie or strap, used with sandals (ankh-sign, S34), at the loop, horizontally.
+U+13647	kEH_Desc	God, with a long-curved beard and long wig, seated on a block throne, on top of a base, right arm extended forwards, hand at the height of the waist, extended beyond the knee, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40), and a tie or strap, used with sandals (ankh sign, S34), at the loop, horizontally; left arm forward, hand above the lap, holding a tie or strap, used with sandals (ankh sign, S34), at the loop, horizontally.
 U+13647	kEH_Func	Classifier divinity
 U+13647	kEH_FVal	ꞽtmw
 U+13647	kEH_UniK	A051R
@@ -12121,12 +12122,12 @@ U+1364F	kEH_JSesh	A50G
 U+1364F	kEH_HG	A50G
 U+13650	kEH_Cat	A-25-045
 U+13650	kEH_Core	C
-U+13650	kEH_Desc	Man, with short straight beard, seated on a chair, no arms visible, with a tie or strap, used with sandals (ankh-sign, S34), which angles forward, on the knee.
+U+13650	kEH_Desc	Man, with short straight beard, seated on a chair, no arms visible, with a tie or strap, used with sandals (ankh sign, S34), which angles forward, on the knee.
 U+13650	kEH_Func	Classifier revered person
 U+13650	kEH_UniK	A050I
 U+13651	kEH_Cat	A-25-046
 U+13651	kEH_Core	C
-U+13651	kEH_Desc	Child, naked, wearing the hmhm crown (S61), seated upon a block throne on a base, right arm raised in front with hand to mouth, left arm in front, forearm horizontal, holding a tie or strap, used with sandals (ankh-sign, S34), which angles forward.
+U+13651	kEH_Desc	Child, naked, wearing the hmhm crown (S61), seated upon a block throne on a base, right arm raised in front with hand to mouth, left arm in front, forearm horizontal, holding a tie or strap, used with sandals (ankh sign, S34), which angles forward.
 U+13651	kEH_Func	Logogram (Harsomtus)
 U+13651	kEH_FVal	ḥr-smꜣ-tꜣ.wy
 U+13651	kEH_UniK	A532
@@ -12188,7 +12189,7 @@ U+1365A	kEH_HG	A40D
 U+1365A	kEH_IFAO	39,13
 U+1365B	kEH_Cat	A-26-035
 U+1365B	kEH_Core	C
-U+1365B	kEH_Desc	God, seated, both knees up, with covered legs and arms, with a long-curved beard and long wig, holding a tie or strap, used with sandals (ankh-sign, S34), which angles forward.
+U+1365B	kEH_Desc	God, seated, both knees up, with covered legs and arms, with a long-curved beard and long wig, holding a tie or strap, used with sandals (ankh sign, S34), which angles forward.
 U+1365B	kEH_Func	Classifier divinity
 U+1365B	kEH_FVal	ꞽtmw
 U+1365B	kEH_UniK	A040E
@@ -12196,7 +12197,7 @@ U+1365B	kEH_JSesh	A40E
 U+1365B	kEH_IFAO	40,3
 U+1365C	kEH_Cat	A-26-037
 U+1365C	kEH_Core	C
-U+1365C	kEH_Desc	King, seated, both knees up, with covered legs and arms, with a long straight beard, wearing a coif with uraeus, holding a tie or strap, used with sandals (ankh-sign, S34), which angles forward.
+U+1365C	kEH_Desc	King, seated, both knees up, with covered legs and arms, with a long straight beard, wearing a coif with uraeus, holding a tie or strap, used with sandals (ankh sign, S34), which angles forward.
 U+1365C	kEH_Func	Logogram (first person singular)
 U+1365C	kEH_FVal	ꞽ
 U+1365C	kEH_UniK	HJ A042C
@@ -12253,7 +12254,7 @@ U+13662	kEH_IFAO	40,13
 U+13663	kEH_Cat	A-27-002
 U+13663	kEH_Core	C
 U+13663	kEH_Desc	Man, standing, right arm forward, holding a crook (S38) at the same size as the man vertically, left arm hanging beside the body, standard used for carrying religious symbols, with a loop under the horizontal beam, running over the vertical pole (R12A).
-U+13663	kEH_Func	Logogram (ruler of the 9th nome of UE)
+U+13663	kEH_Func	Logogram (ruler of the 9th nome of Lower Egypt)
 U+13663	kEH_FVal	ḥḳꜣ-ꜥnḏ.ty
 U+13663	kEH_UniK	A021G
 U+13664	kEH_Cat	A-27-003
@@ -12285,7 +12286,7 @@ U+13666	kEH_HG	A296B
 U+13666	kEH_IFAO	41,2
 U+13667	kEH_Cat	A-27-010
 U+13667	kEH_Core	C
-U+13667	kEH_Desc	God, standing, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) upon his head, with long-curved beard and long wig, right arm forward, holding a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (wAs, S40); left arm hanging beside the body.
+U+13667	kEH_Desc	God, standing, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) upon his head, with long-curved beard and long wig, right arm forward, holding a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (wAs, S40); left arm hanging beside the body.
 U+13667	kEH_Func	Logogram (noble, splendid)
 U+13667	kEH_FVal	šps
 U+13667	kEH_UniK	HJ C261
@@ -12353,7 +12354,7 @@ U+13670	kEH_UniK	A043X
 U+13670	kEH_IFAO	41,12
 U+13671	kEH_Cat	A-28-006
 U+13671	kEH_Core	C
-U+13671	kEH_Desc	King, seated, both knees up, with covered legs and arms, with a long straight beard, wearing the white crown with uraeus (S1A), holding a tie or strap, used with sandals (ankh-sign, S34) vertically.
+U+13671	kEH_Desc	King, seated, both knees up, with covered legs and arms, with a long straight beard, wearing the white crown with uraeus (S1A), holding a tie or strap, used with sandals (ankh sign, S34) vertically.
 U+13671	kEH_Func	Classifier king
 U+13671	kEH_FVal	n.y-sw.t
 U+13671	kEH_UniK	A043U
@@ -12394,7 +12395,7 @@ U+13675	kEH_IFAO	42,10
 U+13676	kEH_Cat	A-28-014
 U+13676	kEH_Core	C
 U+13676	kEH_Desc	King, seated, both knees up, with covered legs and arms, with a long straight beard, wearing the white crown with uraeus (S1A), holding a crook (S38) vertically, with the opening outwards.
-U+13676	kEH_Func	Logogram (king of UE)
+U+13676	kEH_Func	Logogram (king of Upper Egypt)
 U+13676	kEH_FVal	n.y-sw.t
 U+13676	kEH_UniK	HJ A043J
 U+13676	kEH_JSesh	A43J
@@ -12427,7 +12428,7 @@ U+13679	kEH_IFAO	43,2
 U+1367A	kEH_Cat	A-28-021
 U+1367A	kEH_Core	C
 U+1367A	kEH_Desc	God, seated, both knees up, with covered legs and arms, with a long-curved beard, wearing the white crown with uraeus (S1A), holding a flagellum (S45) and crook (S38), with the opening inwards.
-U+1367A	kEH_Func	Logogram (king of UE)
+U+1367A	kEH_Func	Logogram (king of Upper Egypt)
 U+1367A	kEH_FVal	n.y-sw.t
 U+1367A	kEH_UniK	HJ A043E
 U+1367A	kEH_JSesh	A43E
@@ -12436,7 +12437,7 @@ U+1367A	kEH_IFAO	43,3
 U+1367B	kEH_Cat	A-28-024
 U+1367B	kEH_Core	C
 U+1367B	kEH_Desc	King, seated, both knees up, with covered legs and arms, with a long straight beard, wearing the white crown with uraeus (S1A), holding a flagellum (S45) and mace (T3).
-U+1367B	kEH_Func	Logogram (king of UE)
+U+1367B	kEH_Func	Logogram (king of Upper Egypt)
 U+1367B	kEH_FVal	n.y-sw.t
 U+1367B	kEH_UniK	HJ A043I
 U+1367B	kEH_JSesh	A43I
@@ -12444,7 +12445,7 @@ U+1367B	kEH_HG	A43I
 U+1367C	kEH_Cat	A-28-025
 U+1367C	kEH_Core	C
 U+1367C	kEH_Desc	King, seated, both knees up, with covered legs and arms, with a long straight beard, wearing the white crown with uraeus (S1A), holding a sedge (M23), with the tip curving outwards.
-U+1367C	kEH_Func	Logogram (king of UE)
+U+1367C	kEH_Func	Logogram (king of Upper Egypt)
 U+1367C	kEH_FVal	n.y-sw.t
 U+1367C	kEH_UniK	HJ A043F
 U+1367C	kEH_JSesh	A43F
@@ -12462,7 +12463,7 @@ U+1367D	kEH_IFAO	43,8
 U+1367E	kEH_Cat	A-28-029
 U+1367E	kEH_Core	C
 U+1367E	kEH_Desc	God, seated, both knees up, with covered legs and arms, wearing the white crown (S1), holding a column with a base, with a tenon at the top (O28B).
-U+1367E	kEH_Func	Logogram (he of heliopolis)
+U+1367E	kEH_Func	Logogram (he of Heliopolis)
 U+1367E	kEH_FVal	ꞽwn.y
 U+1367E	kEH_UniK	A043P
 U+1367F	kEH_Cat	A-28-030
@@ -12494,12 +12495,12 @@ U+13682	kEH_UniK	A299I
 U+13682	kEH_IFAO	43,13
 U+13683	kEH_Cat	A-28-037
 U+13683	kEH_Core	C
-U+13683	kEH_Desc	God, seated on a block-throne, with a long-curved beard, wearing the white crown (S1), no arms visible, with a flagellum (S430 and the crook (S38), opening upwards, on his knee.
+U+13683	kEH_Desc	God, seated on a block-throne, with a long-curved beard, wearing the white crown (S1), no arms visible, with a flagellum (S430 and a crook (S38), opening upwards, on his knee.
 U+13683	kEH_UniK	A299H
 U+13684	kEH_Cat	A-28-042
 U+13684	kEH_Core	C
 U+13684	kEH_Desc	King, standing, with a long straight beard, wearing the white crown with uraeus (S1A), right arm forward, holding a crook (S38) of the size of the king vertically, opening outwards, left arm hanging beside the body, holding a flagellum (S45) horizontally.
-U+13684	kEH_Func	Logogram (king of UE)
+U+13684	kEH_Func	Logogram (king of Upper Egypt)
 U+13684	kEH_FVal	n.y-sw.t
 U+13684	kEH_UniK	HJ A300
 U+13684	kEH_JSesh	A300
@@ -12508,44 +12509,44 @@ U+13684	kEH_IFAO	43,16
 U+13685	kEH_Cat	A-28-043
 U+13685	kEH_Core	C
 U+13685	kEH_Desc	King, standing, with a long straight beard, wearing the white crown with uraeus (S1A), right arm forward, holding a crook (S38) of the size of the king vertically, opening outwards, and a flagellum (S45) in front of the crook, left arm hanging beside the body, holding a flagellum (S45) horizontally.
-U+13685	kEH_Func	Logogram (king of UE)
+U+13685	kEH_Func	Logogram (king of Upper Egypt)
 U+13685	kEH_FVal	n.y-sw.t
 U+13685	kEH_UniK	A300K
 U+13686	kEH_Cat	A-28-054
 U+13686	kEH_Core	C
 U+13686	kEH_Desc	King, standing, with a long straight beard, wearing the white crown (S1), right arm forward, holding a stem of papyrus with a flowering bud (M127), of the height of the king, left arm hanging beside the body, holding a flagellum (S45) horizontally.
-U+13686	kEH_Func	Logogram (king of UE and land, when occurring together with king of LE forms n(.y)-sw.t-bꞽ.ty nb tꜣ.wy)
+U+13686	kEH_Func	Logogram (king of Upper Egypt and land, when occurring together with king of Lower Egypt forms n(.y)-sw.t-bꞽ.ty nb tꜣ.wy)
 U+13686	kEH_FVal	n(.y)-sw.t & tꜣ
 U+13686	kEH_UniK	A300H
 U+13687	kEH_Cat	A-28-055
 U+13687	kEH_Core	C
 U+13687	kEH_Desc	King, standing, with a long straight beard, wearing the white crown (S1), right arm forward, holding a stem of papyrus with a flowering bud (M127), of the height of the king, left arm hanging beside the body.
-U+13687	kEH_Func	Logogram (king of UE and land when occurring together with red crown wearing variant forms n(.y)-sw.t-bꞽ.ty nb tꜣ.wy)
+U+13687	kEH_Func	Logogram (king of Upper Egypt and land when occurring together with red crown wearing variant forms n(.y)-sw.t-bꞽ.ty nb tꜣ.wy)
 U+13687	kEH_FVal	n(.y)-sw.t & tꜣ
 U+13687	kEH_UniK	A300I
 U+13688	kEH_Cat	A-28-056
 U+13688	kEH_Core	C
 U+13688	kEH_Desc	King, standing, with a long straight beard, wearing the white crown (S1), right arm forward, holding a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (wAs, S40) of the height of the king, left arm hanging beside the body, holding a flagellum (S45) horizontally.
-U+13688	kEH_Func	Logogram (King of UE)
+U+13688	kEH_Func	Logogram (king of Upper Egypt)
 U+13688	kEH_FVal	n(.y)-sw.t
 U+13688	kEH_UniK	A300J
 U+13689	kEH_Cat	A-28-057
 U+13689	kEH_Core	C
-U+13689	kEH_Desc	God, in mummy form, standing upright on a platform, with a long-curved beard, wearing the white crown (S1), both arms forward, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the god, vertically, with a tie or strap, used with sandals (ankh-sign, S34), on the middle of the headpiece of the staff, angled forwards.
+U+13689	kEH_Desc	God, in mummy form, standing upright on a platform, with a long-curved beard, wearing the white crown (S1), both arms forward, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the god, vertically, with a tie or strap, used with sandals (ankh sign, S34), on the middle of the headpiece of the staff, angled forwards.
 U+13689	kEH_Func	Logogram (Osiris)
 U+13689	kEH_FVal	wsꞽr
 U+13689	kEH_UniK	A521
 U+1368A	kEH_Cat	A-29-002
 U+1368A	kEH_Core	C
 U+1368A	kEH_Desc	King, seated, both knees up, with covered legs and arms, with a long straight beard, wearing the red crown with (S3).
-U+1368A	kEH_Func	Logogram (king of LE)
+U+1368A	kEH_Func	Logogram (king of Lower Egypt)
 U+1368A	kEH_FVal	bꞽ.ty
 U+1368A	kEH_UniK	A045X
 U+1368A	kEH_IFAO	44,5
 U+1368B	kEH_Cat	A-29-003
 U+1368B	kEH_Core	C
 U+1368B	kEH_Desc	King, seated, both knees up, with covered legs and arms, with a long straight beard, wearing the red crown with (S3), holding a flagellum (S45).
-U+1368B	kEH_Func	Logogram (king of LE)
+U+1368B	kEH_Func	Logogram (king of Lower Egypt)
 U+1368B	kEH_FVal	bꞽ.ty
 U+1368B	kEH_UniK	A045F
 U+1368B	kEH_JSesh	A45A
@@ -12554,7 +12555,7 @@ U+1368B	kEH_IFAO	44,8
 U+1368C	kEH_Cat	A-29-008
 U+1368C	kEH_Core	C
 U+1368C	kEH_Desc	King, seated, both knees up, with covered legs and arms, with a long straight beard, wearing the red crown with (S3), holding a flagellum (S45) and a crook (S38) with the opening inwards.
-U+1368C	kEH_Func	Logogram (king of LE)
+U+1368C	kEH_Func	Logogram (king of Lower Egypt)
 U+1368C	kEH_FVal	bꞽ.ty
 U+1368C	kEH_UniK	HJ A045C
 U+1368C	kEH_JSesh	A45C
@@ -12563,7 +12564,7 @@ U+1368C	kEH_IFAO	44,10
 U+1368D	kEH_Cat	A-29-012
 U+1368D	kEH_Core	C
 U+1368D	kEH_Desc	King, seated, both knees up, with covered legs and arms, with a long straight beard, wearing the red crown with (S3), holding a crook (S38) vertically, with the opening inwards.
-U+1368D	kEH_Func	Logogram (king of LE)
+U+1368D	kEH_Func	Logogram (king of Lower Egypt)
 U+1368D	kEH_FVal	bꞽ.ty
 U+1368D	kEH_UniK	HJ A045D
 U+1368D	kEH_JSesh	A45D
@@ -12572,12 +12573,12 @@ U+1368D	kEH_IFAO	44,14
 U+1368E	kEH_Cat	A-29-013
 U+1368E	kEH_Core	C
 U+1368E	kEH_Desc	King, seated, both knees up, with covered legs and arms, with a long straight beard, wearing the red crown with (S3), holding a crook (S38) vertically, with the opening outwards.
-U+1368E	kEH_Func	Logogram (king of LE)
+U+1368E	kEH_Func	Logogram (king of Lower Egypt)
 U+1368E	kEH_FVal	bꞽ.ty
 U+1368E	kEH_UniK	A045G
 U+1368F	kEH_Cat	A-29-014
 U+1368F	kEH_Core	C
-U+1368F	kEH_Desc	King, seated, both knees up, with covered legs and arms, with a long straight beard, wearing the red crown with (S3), holding a tie or strap, used with sandals (ankh-sign, S34) vertically.
+U+1368F	kEH_Desc	King, seated, both knees up, with covered legs and arms, with a long straight beard, wearing the red crown with (S3), holding a tie or strap, used with sandals (ankh sign, S34) vertically.
 U+1368F	kEH_Func	Classifier king
 U+1368F	kEH_FVal	n(y)-sw.t
 U+1368F	kEH_UniK	HJ A045E
@@ -12586,7 +12587,7 @@ U+1368F	kEH_HG	A45E
 U+13690	kEH_Cat	A-29-017
 U+13690	kEH_Core	C
 U+13690	kEH_Desc	King, standing, with a long straight beard, wearing the red crown (S3), right arm forward, right hand at the height of the shoulder, holding a sceptre (S42), left arm forward, left hand at the height of the waist, holding a stick/staff which runs from the right toe to the left hand, and a mace (T3), angled forward.
-U+13690	kEH_Func	Logogram (king of LE)
+U+13690	kEH_Func	Logogram (king of Lower Egypt)
 U+13690	kEH_FVal	bꞽ.ty
 U+13690	kEH_UniK	HJ A302B
 U+13690	kEH_JSesh	A302B
@@ -12613,19 +12614,19 @@ U+13692	kEH_IFAO	45,3
 U+13693	kEH_Cat	A-29-022
 U+13693	kEH_Core	C
 U+13693	kEH_Desc	King, standing, with a long straight beard, wearing the red crown (S3), right arm forward, holding a stem of papyrus with a bud (M131), of the height of the king, left arm hanging beside the body, holding a flagellum (S45) horizontally.
-U+13693	kEH_Func	Logogram (King of LE and land, when occurring together with King of UE forms n(.y)-sw.t-bꞽ.ty nb tꜣ.wy)
+U+13693	kEH_Func	Logogram (king of Lower Egypt and land, when occurring together with king of Upper Egypt forms n(.y)-sw.t-bꞽ.ty nb tꜣ.wy)
 U+13693	kEH_FVal	bꞽ.ty tꜣ
 U+13693	kEH_UniK	A302H
 U+13694	kEH_Cat	A-29-023
 U+13694	kEH_Core	C
 U+13694	kEH_Desc	King, standing, with a long straight beard, wearing the red crown (S3), right arm forward, holding a stem of papyrus with a bud (M131), of the height of the king, left arm hanging beside the body.
-U+13694	kEH_Func	Logogram (King of LE and land, when occurring together with a white crown variant forms n(.y)-sw.t-bꞽ.ty nb tꜣ.wy)
+U+13694	kEH_Func	Logogram (king of Lower Egypt and land, when occurring together with a white crown variant forms n(.y)-sw.t-bꞽ.ty nb tꜣ.wy)
 U+13694	kEH_FVal	bꞽ.ty tꜣ
 U+13694	kEH_UniK	A302I
 U+13695	kEH_Cat	A-29-024
 U+13695	kEH_Core	C
 U+13695	kEH_Desc	King, standing, with a long straight beard, wearing the red crown (S3), right arm forward, holding a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (wAs, S40) of the height of the king, left arm hanging beside the body, holding a flagellum (S45) horizontally.
-U+13695	kEH_Func	Logogram (King of UE)
+U+13695	kEH_Func	Logogram (king of Upper Egypt)
 U+13695	kEH_FVal	n(.y)-sw.t
 U+13695	kEH_UniK	A302J
 U+13696	kEH_Cat	A-29-027
@@ -12661,7 +12662,7 @@ U+13699	kEH_JSesh	C32B
 U+13699	kEH_HG	C32B
 U+1369A	kEH_Cat	A-30-003
 U+1369A	kEH_Core	C
-U+1369A	kEH_Desc	King, seated, both knees up, with covered legs and arms, with a long straight beard, wearing the double crown (S5), holding a tie or strap, used with sandals (ankh-sign, S34), angled forwards.
+U+1369A	kEH_Desc	King, seated, both knees up, with covered legs and arms, with a long straight beard, wearing the double crown (S5), holding a tie or strap, used with sandals (ankh sign, S34), angled forwards.
 U+1369A	kEH_Func	Logogram (first person singular)
 U+1369A	kEH_FVal	ꞽ
 U+1369A	kEH_UniK	HJ A304A
@@ -12671,7 +12672,7 @@ U+1369A	kEH_IFAO	45,7
 U+1369B	kEH_Cat	A-30-006
 U+1369B	kEH_Core	C
 U+1369B	kEH_Desc	King, seated, both knees up, with covered legs and arms, with a long straight beard, wearing the double crown (S5), holding a flagellum (S45) and a crook (S38) with the opening inwards.
-U+1369B	kEH_Func	Logogram (king of ULE)
+U+1369B	kEH_Func	Logogram (king of Upper and Lower Egypt)
 U+1369B	kEH_FVal	n(y)-sw.t-bꞽ.ty
 U+1369B	kEH_UniK	HJ A304C
 U+1369B	kEH_JSesh	A304C
@@ -12731,7 +12732,7 @@ U+136A1	kEH_IFAO	45,12
 U+136A2	kEH_Cat	A-30-021
 U+136A2	kEH_Core	C
 U+136A2	kEH_Desc	King, standing, with a long straight beard, wearing the double crown (S5), right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the king, vertically, left arm hanging beside the body holding a flagellum (S45) horizontally.
-U+136A2	kEH_Func	Logogram (king of ULE)
+U+136A2	kEH_Func	Logogram (king of Upper and Lower Egypt)
 U+136A2	kEH_FVal	n(y)-sw.t-bꞽ.ty
 U+136A2	kEH_UniK	A310E
 U+136A3	kEH_Cat	A-30-026
@@ -12807,7 +12808,7 @@ U+136AC	kEH_HG	A466
 U+136AD	kEH_Cat	A-30-050
 U+136AD	kEH_Core	C
 U+136AD	kEH_Desc	Man, standing on a standard used for carrying religious symbols (R12), wearing headdress consisting of a double plume mounted on ram horns, right arm forward, holding a staff/stick that angles towards the man, left arm hanging besides the body.
-U+136AD	kEH_Func	Logogram (9th nome of UE)
+U+136AD	kEH_Func	Logogram (9th nome of Lower Egypt)
 U+136AD	kEH_FVal	ꜥnḏ.ty
 U+136AD	kEH_UniK	HJ A466A
 U+136AD	kEH_JSesh	A466A
@@ -12837,7 +12838,7 @@ U+136B1	kEH_HG	A52A
 U+136B1	kEH_IFAO	46,13
 U+136B2	kEH_Cat	A-31-007
 U+136B2	kEH_Core	C
-U+136B2	kEH_Desc	Man, seated, both knees down, with short straight beard, without arms, with a tie or strap, used with sandals (ankh-sign, S34), angled forwards, on its knees.
+U+136B2	kEH_Desc	Man, seated, both knees down, with short straight beard, without arms, with a tie or strap, used with sandals (ankh sign, S34), angled forwards, on its knees.
 U+136B2	kEH_Func	Classifier name (deceased person)
 U+136B2	kEH_UniK	HJ A052B
 U+136B2	kEH_JSesh	A52B
@@ -12958,7 +12959,7 @@ U+136C3	kEH_JSesh	A33C
 U+136C3	kEH_HG	A33C
 U+136C4	kEH_Cat	A-34-004
 U+136C4	kEH_Core	C
-U+136C4	kEH_Desc	A man, lying down on a bed, facing upwards, knees slightly bend, right arm under the body, left arm over the body.
+U+136C4	kEH_Desc	A man, lying down on a bed, facing upwards, knees slightly bent, right arm under the body, left arm over the body.
 U+136C4	kEH_Func	Classifier to awake
 U+136C4	kEH_FVal	nhsꞽ
 U+136C4	kEH_UniK	HJ A103
@@ -12974,7 +12975,7 @@ U+136C5	kEH_JSesh	A104
 U+136C5	kEH_HG	A104
 U+136C6	kEH_Cat	A-34-007
 U+136C6	kEH_Core	C
-U+136C6	kEH_Desc	A naked man, lying face down, arms extended in front of him, on top of a bed with leonid legs and tail.
+U+136C6	kEH_Desc	A naked man, lying face down, arms extended in front, on top of a bed with leonid legs and tail.
 U+136C6	kEH_Func	Classifier
 U+136C6	kEH_FVal	ẖꜣ.t
 U+136C6	kEH_UniK	A104D
@@ -13010,13 +13011,13 @@ U+136CA	kEH_JSesh	A153A
 U+136CA	kEH_HG	A153A
 U+136CB	kEH_Cat	A-34-012
 U+136CB	kEH_Core	C
-U+136CB	kEH_Desc	The king, seated on heel, right knee raised, with long straight beard and uraeus, with arms raised in front of him, hand-palms facing outwards.
+U+136CB	kEH_Desc	The king, seated on heel, right knee raised, with long straight beard and uraeus, with arms raised in front, hand palms facing outwards.
 U+136CB	kEH_Func	Logogram (to venerate)
 U+136CB	kEH_FVal	dwꜣ
 U+136CB	kEH_UniK	A153B
 U+136CC	kEH_Cat	A-34-013
 U+136CC	kEH_Core	C
-U+136CC	kEH_Desc	Man/king, seated, right knee raised, arms raised at either side of the body, right hand holding a tie or strap, used with sandals (ankh-sign, S34) of the same height as the man, left hand holding a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (wAs, S40) in the left hand.
+U+136CC	kEH_Desc	Man/king, seated, right knee raised, arms raised at either side of the body, right hand holding a tie or strap, used with sandals (ankh sign, S34) of the same height as the man, left hand holding a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (wAs, S40) in the left hand.
 U+136CC	kEH_Func	Phonemogram/logogram (million/many)
 U+136CC	kEH_FVal	ḥḥ
 U+136CC	kEH_UniK	A537
@@ -13110,7 +13111,7 @@ U+136D8	kEH_JSesh	B7A
 U+136D8	kEH_HG	B7A
 U+136D9	kEH_Cat	B-01-013
 U+136D9	kEH_Core	C
-U+136D9	kEH_Desc	Woman, seated, both knees up, with covered legs and arms, with long hair, wearing a diadem and uraeus, holding a tie or strap, used with sandals (ankh-sign, S34), which angles forward.
+U+136D9	kEH_Desc	Woman, seated, both knees up, with covered legs and arms, with long hair, wearing a diadem and uraeus, holding a tie or strap, used with sandals (ankh sign, S34), which angles forward.
 U+136D9	kEH_Func	Classifier divinity
 U+136D9	kEH_FVal	tfn.t
 U+136D9	kEH_UniK	B007P
@@ -13194,7 +13195,7 @@ U+136E3	kEH_JSesh	B51
 U+136E3	kEH_HG	B51
 U+136E4	kEH_Cat	B-01-035
 U+136E4	kEH_Core	C
-U+136E4	kEH_Desc	Woman, seated, both knees up, with covered legs and arms, with long hair, with a line coming from the back of the head at 45° upwards.
+U+136E4	kEH_Desc	Woman, seated, both knees up, with covered legs and arms, with long hair, with a line coming from the back of the head 45 degree upwards.
 U+136E4	kEH_Func	Classifier enemy
 U+136E4	kEH_FVal	ḫft.ywt
 U+136E4	kEH_UniK	HJ B053
@@ -13218,7 +13219,7 @@ U+136E6	kEH_JSesh	B76
 U+136E6	kEH_HG	B76
 U+136E7	kEH_Cat	B-01-039
 U+136E7	kEH_Core	C
-U+136E7	kEH_Desc	Woman, seated, both knees up, with covered legs and arms, with long hair, holding a tie or strap, used with sandals (ankh-sign, S34), which angles forward.
+U+136E7	kEH_Desc	Woman, seated, both knees up, with covered legs and arms, with long hair, holding a tie or strap, used with sandals (ankh sign, S34), which angles forward.
 U+136E7	kEH_Func	Phonemogram
 U+136E7	kEH_FVal	ṯ
 U+136E7	kEH_UniK	HJ B001D
@@ -13315,7 +13316,7 @@ U+136F3	kEH_JSesh	B8D
 U+136F3	kEH_HG	B8D
 U+136F4	kEH_Cat	B-02-012
 U+136F4	kEH_Core	C
-U+136F4	kEH_Desc	Woman, seated, both knees down, with long hair, with a spindle or spinning tool coming from her waist at 45°.
+U+136F4	kEH_Desc	Woman, seated, both knees down, with long hair, with a spindle or spinning tool coming from her waist at 45 degree.
 U+136F4	kEH_Func	spindle/spinning tool
 U+136F4	kEH_UniK	HJ B105
 U+136F4	kEH_JSesh	B105
@@ -13511,12 +13512,12 @@ U+1370E	kEH_JSesh	B78
 U+1370E	kEH_HG	B78
 U+1370F	kEH_Cat	B-05-002
 U+1370F	kEH_Core	C
-U+1370F	kEH_Desc	Woman, standing, right arm forward, arm bend, hand slightly higher than the shoulder, holding a flower with a long stem which angles forwards and downwards, just under the flower, which is in front of the face, left arm hanging beside the body.
+U+1370F	kEH_Desc	Woman, standing, right arm forward, arm bent, hand slightly higher than the shoulder, holding a flower with a long stem which angles forwards and downwards, just under the flower, which is in front of the face, left arm hanging beside the body.
 U+1370F	kEH_Func	Classifier name
 U+1370F	kEH_UniK	B032A
 U+13710	kEH_Cat	B-05-003
 U+13710	kEH_Core	C
-U+13710	kEH_Desc	Woman, standing, back slightly bend forwards, arms extended forwards, hands at the height of the waist, hand palms upwards, with a ripple of water (N35) above the hands.
+U+13710	kEH_Desc	Woman, standing, back slightly bent forwards, arms extended forwards, hands at the height of the waist, hand palms upwards, with a ripple of water (N35) above the hands.
 U+13710	kEH_Func	Classifier to welcome
 U+13710	kEH_FVal	nyny
 U+13710	kEH_UniK	HJ B027
@@ -13525,7 +13526,7 @@ U+13710	kEH_HG	B27
 U+13710	kEH_IFAO	52,2
 U+13711	kEH_Cat	B-05-005
 U+13711	kEH_Core	C
-U+13711	kEH_Desc	Woman, standing, wearing a diadem, back slightly bend forwards, arms extended forwards, hands at the height of the waist, hand palms upwards, with a ripple of water (N35) above both hands.
+U+13711	kEH_Desc	Woman, standing, wearing a diadem, back slightly bent forwards, arms extended forwards, hands at the height of the waist, hand palms upwards, with a ripple of water (N35) above both hands.
 U+13711	kEH_Func	Classifier to welcome
 U+13711	kEH_FVal	nyny
 U+13711	kEH_UniK	B027B
@@ -13599,7 +13600,7 @@ U+1371A	kEH_HG	B35
 U+1371A	kEH_IFAO	52,8
 U+1371B	kEH_Cat	B-05-024
 U+1371B	kEH_Core	C
-U+1371B	kEH_Desc	Woman, standing, with long hair, bend forward, back nearly horizontal, arms extended forward, hands in an object which resembles a sand covered mountain over the edge of the cultivated areas (N26), in front of the feet.
+U+1371B	kEH_Desc	Woman, standing, with long hair, bent forward, back nearly horizontal, arms extended forward, hands in an object which resembles a sand covered mountain over the edge of the cultivated areas (N26), in front of the feet.
 U+1371B	kEH_Func	Phonemogram
 U+1371B	kEH_FVal	nḏ
 U+1371B	kEH_UniK	B036C
@@ -13631,7 +13632,7 @@ U+1371F	kEH_FVal	ꞽt.yt
 U+1371F	kEH_UniK	B049B
 U+13720	kEH_Cat	B-05-032
 U+13720	kEH_Core	C
-U+13720	kEH_Desc	Woman, standing, with long hair, right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the woman, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34), at the loop.
+U+13720	kEH_Desc	Woman, standing, with long hair, right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the woman, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34), at the loop.
 U+13720	kEH_Func	Phonemogram
 U+13720	kEH_FVal	w
 U+13720	kEH_UniK	HJ B072
@@ -13647,7 +13648,7 @@ U+13721	kEH_JSesh	B68
 U+13721	kEH_HG	B68
 U+13722	kEH_Cat	B-05-035
 U+13722	kEH_Core	C
-U+13722	kEH_Desc	Woman, standing, with long hair, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34), at the loop.
+U+13722	kEH_Desc	Woman, standing, with long hair, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34), at the loop.
 U+13722	kEH_Func	Logogram (noble lady)
 U+13722	kEH_FVal	rpy.t
 U+13722	kEH_UniK	B106
@@ -13659,9 +13660,9 @@ U+13723	kEH_FVal	ꞽt.yt
 U+13723	kEH_UniK	B122
 U+13724	kEH_Cat	B-05-037
 U+13724	kEH_Core	C
-U+13724	kEH_Desc	Woman, standing, with long hair, right arm forward, hand at the height of the waist, holding a palm branch, stripped of leaves, with multiple sharp notches (M4A), tip curving outwards, notches towards the body, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34), at the loop.
+U+13724	kEH_Desc	Woman, standing, with long hair, right arm forward, hand at the height of the waist, holding a palm branch, stripped of leaves, with multiple sharp notches (M4A), tip curving outwards, notches towards the body, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34), at the loop.
 U+13724	kEH_Func	Phonemogram (cryptography)
-U+13724	kEH_FVal	t; r
+U+13724	kEH_FVal	t/r
 U+13724	kEH_UniK	HJ B070
 U+13724	kEH_JSesh	B70
 U+13724	kEH_HG	B70
@@ -13675,7 +13676,7 @@ U+13725	kEH_JSesh	B77
 U+13725	kEH_HG	B77
 U+13726	kEH_Cat	B-05-040
 U+13726	kEH_Core	C
-U+13726	kEH_Desc	Woman, standing, back slight bend forwards, with two lines coming from the head, one bending forward, one bending backwards, both arms forward, twisted together.
+U+13726	kEH_Desc	Woman, standing, back slight bent forwards, with two lines coming from the head, one bending forward, one bending backwards, both arms forward, twisted together.
 U+13726	kEH_Func	Classifier?
 U+13726	kEH_FVal	šꜣ.tw
 U+13726	kEH_UniK	B077B
@@ -13734,8 +13735,8 @@ U+1372E	kEH_HG	B41
 U+1372E	kEH_IFAO	53,2
 U+1372F	kEH_Cat	B-07-007
 U+1372F	kEH_Core	C
-U+1372F	kEH_Desc	Woman, standing, wearing the white crown (S1), right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the size of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34), at the loop.
-U+1372F	kEH_Func	Logogram (king of UE)
+U+1372F	kEH_Desc	Woman, standing, wearing the white crown (S1), right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the size of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34), at the loop.
+U+1372F	kEH_Func	Logogram (king of Upper Egypt)
 U+1372F	kEH_FVal	n.y-sw.t
 U+1372F	kEH_UniK	HJ B043
 U+1372F	kEH_JSesh	B43
@@ -13781,7 +13782,7 @@ U+13734	kEH_HG	B45A
 U+13734	kEH_IFAO	53,8
 U+13735	kEH_Cat	B-08-006
 U+13735	kEH_Core	C
-U+13735	kEH_Desc	Woman, seated, both knees down, wearing a diadem, right arm extended forward, held horizontally, holding a tie or strap, used with sandals (ankh-sign, S34) vertically, left arm extended forwards, between the legs and the right arm, holding a bead-necklace with counterweight.
+U+13735	kEH_Desc	Woman, seated, both knees down, wearing a diadem, right arm extended forward, held horizontally, holding a tie or strap, used with sandals (ankh sign, S34) vertically, left arm extended forwards, between the legs and the right arm, holding a bead-necklace with counterweight.
 U+13735	kEH_Func	Classifier sistrum player
 U+13735	kEH_FVal	sḫm.y(t)
 U+13735	kEH_UniK	HJ B057
@@ -13890,13 +13891,13 @@ U+13743	kEH_JSesh	B6B
 U+13743	kEH_HG	B6B
 U+13744	kEH_Cat	B-10-003
 U+13744	kEH_Core	C
-U+13744	kEH_Desc	Woman, bend backwards, facing up, arms and feet on the ground, hair hanging downwards.
+U+13744	kEH_Desc	Woman, bent backwards, facing up, arms and feet on the ground, hair hanging downwards.
 U+13744	kEH_Func	classifier (dancer/acrobat)
 U+13744	kEH_FVal	ḫb.t
 U+13744	kEH_UniK	B037A
 U+13745	kEH_Cat	B-10-004
 U+13745	kEH_Core	C
-U+13745	kEH_Desc	Woman, standing, bend forward arms extended forward, hands towards a rectangular object in front of the feet.
+U+13745	kEH_Desc	Woman, standing, bent forwards, arms extended forwards, hands towards a rectangular object in front of the feet.
 U+13745	kEH_Func	Phonemogram
 U+13745	kEH_FVal	nḏ
 U+13745	kEH_UniK	HJ B036A
@@ -13908,7 +13909,7 @@ U+13746	kEH_JSesh	B67
 U+13746	kEH_HG	B67
 U+13747	kEH_Cat	B-10-007
 U+13747	kEH_Core	C
-U+13747	kEH_Desc	Woman, standing, bend forwards, back horizontal, hair hanging forwards in front of the face, arms extended towards the ground, hands horizontal at the height of the middle of the shins, hand palms downwards.
+U+13747	kEH_Desc	Woman, standing, bent forwards, back horizontal, hair hanging forwards in front of the face, arms extended towards the ground, hands horizontal at the height of the middle of the shins, hand palms downwards.
 U+13747	kEH_Func	Classifier moving back and forth
 U+13747	kEH_FVal	wnwn
 U+13747	kEH_UniK	B067A
@@ -13939,7 +13940,7 @@ U+1374A	kEH_JSesh	C118
 U+1374A	kEH_HG	C118
 U+1374B	kEH_Cat	C-01-004
 U+1374B	kEH_Core	C
-U+1374B	kEH_Desc	God, seated, both knees up, with covered legs and arms, with a long-curved beard and long hair/wig, with a crescent moon with the entire moon disk (N62) on its head, holding a tie or strap, used with sandals (ankh-sign, S34), angling forward.
+U+1374B	kEH_Desc	God, seated, both knees up, with covered legs and arms, with a long-curved beard and long hair/wig, with a crescent moon with the entire moon disk (N62) on its head, holding a tie or strap, used with sandals (ankh sign, S34), angling forward.
 U+1374B	kEH_Func	Classifier moon/light (together with Re, representing the sun and the moon as the two lights)
 U+1374B	kEH_FVal	ḥꜣy.ty
 U+1374B	kEH_UniK	C118B
@@ -13988,19 +13989,19 @@ U+13751	kEH_HG	C123
 U+13751	kEH_IFAO	55,10
 U+13752	kEH_Cat	C-01-014
 U+13752	kEH_Core	C
-U+13752	kEH_Desc	God, standing, with long-curved beard and long wig, with an elephant tusk (F18) upon his head, right arm forward, holding a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (S40); left arm hanging beside the body, holding tie or strap, used with sandals (ankh-sign S34) at the loop.
+U+13752	kEH_Desc	God, standing, with long-curved beard and long wig, with an elephant tusk (F18) upon his head, right arm forward, holding a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (S40); left arm hanging beside the body, holding tie or strap, used with sandals (ankh sign S34) at the loop.
 U+13752	kEH_Func	Logogram (the utterance, divinity)
 U+13752	kEH_FVal	ḥw
 U+13752	kEH_UniK	C340
 U+13753	kEH_Cat	C-01-016
 U+13753	kEH_Core	C
 U+13753	kEH_Desc	God, seated, both knees up, with covered legs and arms, with a long-curved beard and short hair/wig, with a rectangular piece of cloth, with fringes on one of its short sides (S32) upon his head, holding a sceptre with a straight shaft, topped with the head of the Seth animal vertically.
-U+13753	kEH_Func	Logogram (perception/knowledge (divinity)
+U+13753	kEH_Func	Logogram (perception/knowledge (divinity))
 U+13753	kEH_FVal	sꞽꜣ
 U+13753	kEH_UniK	C124B
 U+13754	kEH_Cat	C-01-017
 U+13754	kEH_Core	C
-U+13754	kEH_Desc	God, standing, with long-curved beard and long wig, with a rectangular piece of cloth, with fringes on one of its short sides (S32) upon his head, right arm forward, holding a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (S40); left arm hanging beside the body, holding tie or strap, used with sandals (ankh-sign S34) at the loop.
+U+13754	kEH_Desc	God, standing, with long-curved beard and long wig, with a rectangular piece of cloth, with fringes on one of its short sides (S32) upon his head, right arm forward, holding a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (S40); left arm hanging beside the body, holding tie or strap, used with sandals (ankh sign S34) at the loop.
 U+13754	kEH_Func	Logogram (perception/knowledge (divinity))
 U+13754	kEH_FVal	sꞽꜣ
 U+13754	kEH_UniK	C341
@@ -14061,7 +14062,7 @@ U+1375C	kEH_JSesh	C262A
 U+1375C	kEH_HG	C262A
 U+1375D	kEH_Cat	C-01-042
 U+1375D	kEH_Core	C
-U+1375D	kEH_Desc	God, seated, both knees up, with covered legs and arms, with a long-curved beard and long hair/wig, with an uraeus on the forehead, wearing a headdress consisting of two feathers and a sun-disk on ram horns, with an uraeus at either side of the feathers; holding a sceptre with a straight shaft, topped with the head of the Seth animal vertically.
+U+1375D	kEH_Desc	God, seated, both knees up, with covered legs and arms, with a long-curved beard and long hair/wig, with an uraeus on the forehead, wearing a headdress consisting of two feathers and a sun disk on ram horns, with an uraeus at either side of the feathers; holding a sceptre with a straight shaft, topped with the head of the Seth animal vertically.
 U+1375D	kEH_Func	Classifier divinity
 U+1375D	kEH_FVal	tꜣ-ṯnn
 U+1375D	kEH_UniK	C342
@@ -14126,7 +14127,7 @@ U+13765	kEH_HG	C12B
 U+13765	kEH_IFAO	57,13
 U+13766	kEH_Cat	C-03-006
 U+13766	kEH_Core	C
-U+13766	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long-curved beard, wearing the double-plume headdress (S72A), with a line running from the crown down the back, holding a tie or strap, used with sandals (ankh-sign, S34), vertically.
+U+13766	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long-curved beard, wearing the double-plume headdress (S72A), with a line running from the crown down the back, holding a tie or strap, used with sandals (ankh sign, S34), vertically.
 U+13766	kEH_Func	Logogram (Amon)
 U+13766	kEH_FVal	ꞽmn
 U+13766	kEH_UniK	HJ C012C
@@ -14135,7 +14136,7 @@ U+13766	kEH_HG	C12C
 U+13766	kEH_IFAO	58,1
 U+13767	kEH_Cat	C-03-007
 U+13767	kEH_Core	C
-U+13767	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long-curved beard, wearing the double-plume headdress (S72A), holding a tie or strap, used with sandals (ankh-sign, S34), vertically.
+U+13767	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long-curved beard, wearing the double-plume headdress (S72A), holding a tie or strap, used with sandals (ankh sign, S34), vertically.
 U+13767	kEH_Func	Logogram (Amon)
 U+13767	kEH_FVal	ꞽmn
 U+13767	kEH_UniK	HJ C012L
@@ -14153,7 +14154,7 @@ U+13768	kEH_HG	C12D
 U+13768	kEH_IFAO	58,4
 U+13769	kEH_Cat	C-03-009
 U+13769	kEH_Core	C
-U+13769	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long-curved beard, wearing the double-plume headdress (S72A), with a line running from the crown down the back, holding a tie or strap, used with sandals (ankh-sign, S34), written over a sceptre with a straight shaft, topped with the head of the Seth animal vertically. 
+U+13769	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long-curved beard, wearing the double-plume headdress (S72A), with a line running from the crown down the back, holding a tie or strap, used with sandals (ankh sign, S34), written over a sceptre with a straight shaft, topped with the head of the Seth animal vertically. 
 U+13769	kEH_Func	Logogram divinity
 U+13769	kEH_FVal	ꞽr-ṯꜥw
 U+13769	kEH_UniK	HJ C012E
@@ -14206,7 +14207,7 @@ U+13770	kEH_JSesh	C6E
 U+13770	kEH_HG	C6E
 U+13771	kEH_Cat	C-04-007
 U+13771	kEH_Core	C
-U+13771	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a jackal, holding a tie or strap, used with sandals (ankh-sign, S34), angling forward.
+U+13771	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a jackal, holding a tie or strap, used with sandals (ankh sign, S34), angling forward.
 U+13771	kEH_Func	Phonemogram
 U+13771	kEH_FVal	n
 U+13771	kEH_UniK	HJ C006A
@@ -14351,7 +14352,7 @@ U+13784	kEH_Core	C
 U+13784	kEH_Desc	God, seated, right knee raised, with the head of a jackal, right arm forward, forearm horizontal, hand in front of the chest, left arm raised, forearm vertical, holding a stick which extends over the head.
 U+13784	kEH_Func	Logogram (to drive away)
 U+13784	kEH_FVal	sḥrꞽ
-U+13784	kEH_UniK	C022P
+U+13784	kEH_UniK	C022Q
 U+13785	kEH_Cat	C-04-043
 U+13785	kEH_Core	C
 U+13785	kEH_Desc	God, seated on nothing, with the head of a jackal and tail, right arm forwards, hand at the height of the shoulder, holding a knife (T30A) vertically, left arm raised at the back, forearm vertical, holding a knife (T30A) with the blade downwards.
@@ -14408,7 +14409,7 @@ U+1378C	kEH_JSesh	Q44
 U+1378C	kEH_HG	Q44
 U+1378D	kEH_Cat	C-05-001
 U+1378D	kEH_Core	C
-U+1378D	kEH_Desc	God/Goddess, seated, knees up, with covered legs and arms, with the head of a bovid, holding a sceptre with a straight shaft, topped with the head of the Seth animal vertically.
+U+1378D	kEH_Desc	God/goddess, seated, knees up, with covered legs and arms, with the head of a bovid, holding a sceptre with a straight shaft, topped with the head of the Seth animal vertically.
 U+1378D	kEH_Func	Classifier protector
 U+1378D	kEH_FVal	(nḏ.t(y)t)
 U+1378D	kEH_UniK	HJ C030
@@ -14532,7 +14533,7 @@ U+1379C	kEH_JSesh	C39F
 U+1379C	kEH_HG	C39F
 U+1379D	kEH_Cat	C-09-020
 U+1379D	kEH_Core	C
-U+1379D	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on its head.
+U+1379D	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on its head.
 U+1379D	kEH_Func	Logogram (Re)
 U+1379D	kEH_FVal	rꜥ
 U+1379D	kEH_UniK	HJ C268A
@@ -14550,7 +14551,7 @@ U+1379E	kEH_HG	C2B
 U+1379E	kEH_IFAO	62,15
 U+1379F	kEH_Cat	C-09-024
 U+1379F	kEH_Core	C
-U+1379F	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on its head, holding a sceptre with a straight shaft, topped with the head of the Seth animal vertically. 
+U+1379F	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on its head, holding a sceptre with a straight shaft, topped with the head of the Seth animal vertically. 
 U+1379F	kEH_Func	Logogram (Re)
 U+1379F	kEH_FVal	rꜥ
 U+1379F	kEH_UniK	HJ C268B
@@ -14559,7 +14560,7 @@ U+1379F	kEH_HG	C268B
 U+1379F	kEH_IFAO	63,2
 U+137A0	kEH_Cat	C-09-028
 U+137A0	kEH_Core	C
-U+137A0	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on its head, holding a harpoon head made of bone, with one curl (T19), with the curl facing forward.
+U+137A0	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on its head, holding a harpoon head made of bone, with one curl (T19), with the curl facing forward.
 U+137A0	kEH_Func	Logogram (day)
 U+137A0	kEH_FVal	hrw
 U+137A0	kEH_UniK	HJ C268C
@@ -14568,7 +14569,7 @@ U+137A0	kEH_HG	C268C
 U+137A0	kEH_IFAO	63,6
 U+137A1	kEH_Cat	C-09-031
 U+137A1	kEH_Core	C
-U+137A1	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on its head, holding a tie or strap, used with sandals (ankh-sign, S34), angling forward. 
+U+137A1	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on its head, holding a tie or strap, used with sandals (ankh sign, S34), angling forward. 
 U+137A1	kEH_Func	Logogram (Re)
 U+137A1	kEH_FVal	rꜥ
 U+137A1	kEH_UniK	HJ C268
@@ -14585,7 +14586,7 @@ U+137A2	kEH_JSesh	C2F
 U+137A2	kEH_HG	C2F
 U+137A3	kEH_Cat	C-09-036
 U+137A3	kEH_Core	C
-U+137A3	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on its head, holding an eye, with the markings of the head of a falcon (wdꜣ.t) on top of a basket.
+U+137A3	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on its head, holding an eye, with the markings of the head of a falcon (wdꜣ.t) on top of a basket.
 U+137A3	kEH_UniK	C002M
 U+137A4	kEH_Cat	C-09-038
 U+137A4	kEH_Core	C
@@ -14606,7 +14607,7 @@ U+137A5	kEH_HG	C2D
 U+137A5	kEH_IFAO	63,11
 U+137A6	kEH_Cat	C-09-040
 U+137A6	kEH_Core	C
-U+137A6	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on its head, holding a sceptre (S42) vertically.
+U+137A6	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on its head, holding a sceptre (S42) vertically.
 U+137A6	kEH_Func	Logogram (Re and image)
 U+137A6	kEH_FVal	rꜥ & sḫm
 U+137A6	kEH_UniK	HJ C268D
@@ -14615,7 +14616,7 @@ U+137A6	kEH_HG	C268D
 U+137A6	kEH_IFAO	63,12
 U+137A7	kEH_Cat	C-09-043
 U+137A7	kEH_Core	C
-U+137A7	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on its head, holding an eye, with the markings of the head of a falcon (wdꜣ.t, D10).
+U+137A7	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on its head, holding an eye, with the markings of the head of a falcon (wdꜣ.t, D10).
 U+137A7	kEH_Func	Logogram (the eye of Re)
 U+137A7	kEH_FVal	ꞽr.t-rꜥ
 U+137A7	kEH_UniK	HJ C268G
@@ -14624,14 +14625,14 @@ U+137A7	kEH_HG	C268G
 U+137A7	kEH_IFAO	63,16
 U+137A8	kEH_Cat	C-09-047
 U+137A8	kEH_Core	C
-U+137A8	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on its head, holding a round vessel with an upstanding rim (W24).
+U+137A8	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on its head, holding a round vessel with an upstanding rim (W24).
 U+137A8	kEH_Func	Logogram (of Re)
 U+137A8	kEH_FVal	n rꜥ
 U+137A8	kEH_UniK	C268L
 U+137A9	kEH_Cat	C-09-048
 U+137A9	kEH_Core	C
-U+137A9	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on its head, holding an egg (H8).
-U+137A9	kEH_Func	Logogram (Son of Re)
+U+137A9	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on its head, holding an egg (H8).
+U+137A9	kEH_Func	Logogram (son of Re)
 U+137A9	kEH_FVal	sꜣ-rꜥ
 U+137A9	kEH_UniK	C268M
 U+137AA	kEH_Cat	C-09-051
@@ -14654,7 +14655,7 @@ U+137AB	kEH_HG	C43A
 U+137AB	kEH_IFAO	64,6
 U+137AC	kEH_Cat	C-09-055
 U+137AC	kEH_Core	C
-U+137AC	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, wearing the double crown (S5), holding a tie or strap, used with sandals (ankh-sign, S34), angling forward. 
+U+137AC	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, wearing the double crown (S5), holding a tie or strap, used with sandals (ankh sign, S34), angling forward. 
 U+137AC	kEH_Func	Logogram (to live)
 U+137AC	kEH_FVal	ꜥnḫ
 U+137AC	kEH_UniK	HJ C043B
@@ -14719,7 +14720,7 @@ U+137B3	kEH_HG	C291
 U+137B4	kEH_Cat	C-09-065
 U+137B4	kEH_Core	C
 U+137B4	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, wearing the double crown (S5), holding a sceptre with a straight shaft, topped with the head of the Seth animal vertically, upon a canal (N36).
-U+137B4	kEH_Func	Logogram (Beloved of Horus)
+U+137B4	kEH_Func	Logogram (beloved of Horus)
 U+137B4	kEH_FVal	mr.y-ḥr
 U+137B4	kEH_UniK	HJ C292
 U+137B4	kEH_JSesh	C292
@@ -14785,7 +14786,7 @@ U+137BC	kEH_HG	C49
 U+137BC	kEH_IFAO	65,9
 U+137BD	kEH_Cat	C-09-085
 U+137BD	kEH_Core	C
-U+137BD	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with a crescent moon with the entire moon disk (N62) on its head, holding a tie or strap, used with sandals (ankh-sign, S34), angling forward. 
+U+137BD	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with a crescent moon with the entire moon disk (N62) on its head, holding a tie or strap, used with sandals (ankh sign, S34), angling forward. 
 U+137BD	kEH_Func	Classifier Khonsu (divinity)
 U+137BD	kEH_UniK	HJ C049A
 U+137BD	kEH_JSesh	C49A
@@ -14819,7 +14820,7 @@ U+137C1	kEH_HG	C52A
 U+137C1	kEH_IFAO	65,15
 U+137C2	kEH_Cat	C-09-094
 U+137C2	kEH_Core	C
-U+137C2	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with the hindquarters of a seated lion or leopard (F22) on its head, holding a tie or strap, used with sandals (ankh-sign, S34), angling forward. 
+U+137C2	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with the hindquarters of a seated lion or leopard (F22) on its head, holding a tie or strap, used with sandals (ankh sign, S34), angling forward. 
 U+137C2	kEH_Func	Logogram (in the ꜥnḫ-nṯr-nfr construction)
 U+137C2	kEH_FVal	ꜥnḫ-nṯr
 U+137C2	kEH_UniK	HJ C052B
@@ -14828,7 +14829,7 @@ U+137C2	kEH_HG	C52B
 U+137C2	kEH_IFAO	66,1
 U+137C3	kEH_Cat	C-09-096
 U+137C3	kEH_Core	C
-U+137C3	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with the hindquarters of a seated lion or leopard (F22) on its head, holding a cobra (Naja haje), standing up, with expanded hood (Uraeus, I64).
+U+137C3	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a falcon, with the hindquarters of a seated lion or leopard (F22) on its head, holding a cobra (Naja haje), standing up, with expanded hood (uraeus, I64).
 U+137C3	kEH_Func	Logogram (god and goddess)
 U+137C3	kEH_FVal	nṯr nṯr.t
 U+137C3	kEH_UniK	HJ C052D
@@ -14842,7 +14843,7 @@ U+137C4	kEH_FVal	nṯr
 U+137C4	kEH_UniK	C344
 U+137C5	kEH_Cat	C-09-100
 U+137C5	kEH_Core	C
-U+137C5	kEH_Desc	God, seated on a block throne, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on its head, right arm forward, holding a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (wAs, S40) of the length of the god, left arm forward, hand on the knee, holding a tie or strap, used with sandals (ankh-sign, S34), angling forward.
+U+137C5	kEH_Desc	God, seated on a block throne, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on its head, right arm forward, holding a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (wAs, S40) of the length of the god, left arm forward, hand on the knee, holding a tie or strap, used with sandals (ankh sign, S34), angling forward.
 U+137C5	kEH_Func	Logogram (Re)
 U+137C5	kEH_FVal	rꜥ
 U+137C5	kEH_UniK	HJ C053B
@@ -14864,14 +14865,14 @@ U+137C7	kEH_UniK	C055A
 U+137C7	kEH_IFAO	66,6
 U+137C8	kEH_Cat	C-09-109
 U+137C8	kEH_Core	C
-U+137C8	kEH_Desc	God, seated on a block throne on a base, with the head of a falcon, wearing the double crown (S5), right arm forward, hand a the height of the face, holding a tie or strap, used with sandals (ankh-sign, S34) horizontally at the base, left arm forward, hand at the knee, holding a tie or strap, used with sandals (ankh-sign, S34) horizontally at the loop.
+U+137C8	kEH_Desc	God, seated on a block throne on a base, with the head of a falcon, wearing the double crown (S5), right arm forward, hand a the height of the face, holding a tie or strap, used with sandals (ankh sign, S34) horizontally at the base, left arm forward, hand at the knee, holding a tie or strap, used with sandals (ankh sign, S34) horizontally at the loop.
 U+137C8	kEH_Func	Logogram (Horus)
 U+137C8	kEH_FVal	ḥr
 U+137C8	kEH_UniK	C056B
 U+137C8	kEH_IFAO	66,8
 U+137C9	kEH_Cat	C-09-111
 U+137C9	kEH_Core	C
-U+137C9	kEH_Desc	God, seated on a block throne on a base, with the head of a falcon, wearing the double crown (S5), left arm forward, hand near the knee, holding a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (wAs, S40), right arm forward, holding a tie or strap, used with sandals (ankh-sign, S34) horizontally at the base, above the wAs scepter.
+U+137C9	kEH_Desc	God, seated on a block throne on a base, with the head of a falcon, wearing the double crown (S5), left arm forward, hand near the knee, holding a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (wAs, S40), right arm forward, holding a tie or strap, used with sandals (ankh sign, S34) horizontally at the base, above the wAs scepter.
 U+137C9	kEH_Func	Logogram (Horus, protector of his father, Behedety, the many-coloured of plumage, giving life)
 U+137C9	kEH_FVal	ḥr-nḏ-ꞽt=f-bḥd.ty-sꜣb-šw.t-dꞽ-ꜥnḫ
 U+137C9	kEH_UniK	C056C
@@ -14887,7 +14888,7 @@ U+137CB	kEH_FVal	nṯr
 U+137CB	kEH_UniK	C337
 U+137CC	kEH_Cat	C-10-002
 U+137CC	kEH_Core	C
-U+137CC	kEH_Desc	God, standing, with the head of a falcon, wearing the double crown (S5), right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the god, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34) vertically at the loop.
+U+137CC	kEH_Desc	God, standing, with the head of a falcon, wearing the double crown (S5), right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the god, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34) vertically at the loop.
 U+137CC	kEH_Func	Logogram (the one of the horizon)
 U+137CC	kEH_FVal	ꜣḫ.ty
 U+137CC	kEH_UniK	HJ C058
@@ -14896,7 +14897,7 @@ U+137CC	kEH_HG	C58
 U+137CC	kEH_IFAO	66,13
 U+137CD	kEH_Cat	C-10-004
 U+137CD	kEH_Core	C
-U+137CD	kEH_Desc	God, standing, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on its head, right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the god, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34) vertically at the loop.
+U+137CD	kEH_Desc	God, standing, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on its head, right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the god, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34) vertically at the loop.
 U+137CD	kEH_Func	Logogram (Re)
 U+137CD	kEH_FVal	rꜥ
 U+137CD	kEH_UniK	HJ C059C
@@ -14905,7 +14906,7 @@ U+137CD	kEH_HG	C59C
 U+137CD	kEH_IFAO	66,14
 U+137CE	kEH_Cat	C-10-009
 U+137CE	kEH_Core	C
-U+137CE	kEH_Desc	God, standing, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on its head, right arm forward, hand at the height of the waist, holding a spear made into a standard (R15A), left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34) vertically at the loop.
+U+137CE	kEH_Desc	God, standing, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on its head, right arm forward, hand at the height of the waist, holding a spear made into a standard (R15A), left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34) vertically at the loop.
 U+137CE	kEH_Func	Logogram (Horus of the east)
 U+137CE	kEH_FVal	ḥr-ꞽꜣb.ty
 U+137CE	kEH_UniK	C345
@@ -14973,7 +14974,7 @@ U+137D6	kEH_IFAO	67,11
 U+137D7	kEH_Cat	C-10-020
 U+137D7	kEH_Core	C
 U+137D7	kEH_Desc	God, standing, with the head of a falcon, right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the god, vertically, left arm hanging beside the body.
-U+137D7	kEH_Func	Logogram (lord of the two lands, when used in connection with a Seth headed figure)
+U+137D7	kEH_Func	Logogram (lord of the two lands, when used in connection with a Seth-headed figure)
 U+137D7	kEH_FVal	nb-tꜣ.wy
 U+137D7	kEH_UniK	HJ C065A
 U+137D7	kEH_JSesh	C65A
@@ -14994,7 +14995,7 @@ U+137D9	kEH_HG	C68
 U+137D9	kEH_IFAO	67,13
 U+137DA	kEH_Cat	C-10-025
 U+137DA	kEH_Core	C
-U+137DA	kEH_Desc	God, standing, with the head of a falcon, wearing the double crown (S5), right arm extended forwards, arm horizontal, holding a scimitar (khopesh), written vertically, blade curving forwards, with the head of a falcon with a sun-disk (N5) on top of it, left arm forwards, hand at the height of the waist, holding a tie or strap, used with sandals (ankh-sign, S34) at an downward angle at the loop.
+U+137DA	kEH_Desc	God, standing, with the head of a falcon, wearing the double crown (S5), right arm extended forwards, arm horizontal, holding a scimitar (khopesh), written vertically, blade curving forwards, with the head of a falcon with a sun disk (N5) on top of it, left arm forwards, hand at the height of the waist, holding a tie or strap, used with sandals (ankh sign, S34) at an downward angle at the loop.
 U+137DA	kEH_Func	Logogram (valour, strength)
 U+137DA	kEH_FVal	ḳn.t
 U+137DA	kEH_UniK	HJ C069
@@ -15003,7 +15004,7 @@ U+137DA	kEH_HG	C69
 U+137DA	kEH_IFAO	67,15
 U+137DB	kEH_Cat	C-10-026
 U+137DB	kEH_Core	C
-U+137DB	kEH_Desc	God, standing, with the head of a falcon, wearing the double crown (S5), right arm extended forwards, arm horizontal, holding a scimitar (khopesh), written vertically, blade curving forwards, with the head of a falcon with a sun-disk (N5) on top of it, left arm hanging beside the body.
+U+137DB	kEH_Desc	God, standing, with the head of a falcon, wearing the double crown (S5), right arm extended forwards, arm horizontal, holding a scimitar (khopesh), written vertically, blade curving forwards, with the head of a falcon with a sun disk (N5) on top of it, left arm hanging beside the body.
 U+137DB	kEH_Func	Logogram (valour, strength)
 U+137DB	kEH_FVal	ḳn.t
 U+137DB	kEH_UniK	HJ C069A
@@ -15140,13 +15141,13 @@ U+137EC	kEH_HG	C11L
 U+137EC	kEH_IFAO	69,4
 U+137ED	kEH_Cat	C-13-011
 U+137ED	kEH_Core	C
-U+137ED	kEH_Desc	God, seated, right knee raised, with long-curved beard and long wig, with a tie or strap, used with sandals (ankh-sign, S34) vertically on its head, raised arms at either side of the body, hands held vertically, with the hand palms inwards.
+U+137ED	kEH_Desc	God, seated, right knee raised, with long-curved beard and long wig, with a tie or strap, used with sandals (ankh sign, S34) vertically on its head, raised arms at either side of the body, hands held vertically, with the hand palms inwards.
 U+137ED	kEH_Func	Logogram (millions of years)
 U+137ED	kEH_FVal	ḥḥ (n) ꜥnḫ
 U+137ED	kEH_UniK	C110
 U+137EE	kEH_Cat	C-13-013
 U+137EE	kEH_Core	C
-U+137EE	kEH_Desc	Man/god, seated, right knee up, with coif/short hair, without beard, with a palm branch, stripped of leaves and notched on his head (M4), notch forward, raised arms at either side of the body, forearms vertical, holding a tie or strap, used with sandals (ankh-sign, S34) vertically at the base in each hand.
+U+137EE	kEH_Desc	Man/god, seated, right knee up, with coif/short hair, without beard, with a palm branch, stripped of leaves and notched on his head (M4), notch forward, raised arms at either side of the body, forearms vertical, holding a tie or strap, used with sandals (ankh sign, S34) vertically at the base in each hand.
 U+137EE	kEH_Func	Logogram (million, many)
 U+137EE	kEH_FVal	ḥḥ
 U+137EE	kEH_UniK	C011I
@@ -15232,7 +15233,7 @@ U+137F9	kEH_HG	C78C
 U+137F9	kEH_IFAO	69,14
 U+137FA	kEH_Cat	C-13-031
 U+137FA	kEH_Core	C
-U+137FA	kEH_Desc	Man/god, seated on heel, right knee raised, with coif/short hair, without beard, with a sun disk (N5) on his head, arms extended at either side of the body, holding a lotus bud with a long stem, with the buds orientated towards the sun disk, with a tie or strap, used with sandals (ankh-sign, S34) around each elbow.
+U+137FA	kEH_Desc	Man/god, seated on heel, right knee raised, with coif/short hair, without beard, with a sun disk (N5) on his head, arms extended at either side of the body, holding a lotus bud with a long stem, with the buds orientated towards the sun disk, with a tie or strap, used with sandals (ankh sign, S34) around each elbow.
 U+137FA	kEH_Func	Logogram (million, many)
 U+137FA	kEH_FVal	ḥḥ
 U+137FA	kEH_UniK	HJ C078B
@@ -15396,7 +15397,7 @@ U+13811	kEH_FVal	ẖnm.w
 U+13811	kEH_UniK	C004M
 U+13812	kEH_Cat	C-15-018
 U+13812	kEH_Core	C
-U+13812	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a ram, wearing the atef crown (without sun disk), holding a sceptre with a straight shaft, topped with the head of the Seth animal vertically. 
+U+13812	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a ram, wearing the Atef crown (without sun disk), holding a sceptre with a straight shaft, topped with the head of the Seth animal vertically. 
 U+13812	kEH_Func	Classifier Khnum
 U+13812	kEH_FVal	ẖnm.w
 U+13812	kEH_UniK	HJ C004F
@@ -15679,7 +15680,7 @@ U+1383A	kEH_HG	C102
 U+1383A	kEH_IFAO	75,1
 U+1383B	kEH_Cat	C-23-007
 U+1383B	kEH_Core	C
-U+1383B	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long straight beard, wearing a cap, holding a tie or strap, used with sandals (ankh-sign, S34), angling forward. 
+U+1383B	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long straight beard, wearing a cap, holding a tie or strap, used with sandals (ankh sign, S34), angling forward. 
 U+1383B	kEH_Func	Logogram (Ptah)
 U+1383B	kEH_FVal	ptḥ
 U+1383B	kEH_UniK	HJ C102D
@@ -15693,7 +15694,7 @@ U+1383C	kEH_Func	Classifier divinity (Imhotep)
 U+1383C	kEH_UniK	C102I
 U+1383D	kEH_Cat	C-23-013
 U+1383D	kEH_Core	C
-U+1383D	kEH_Desc	God, in mummy form, standing upright, with a long straight beard, wearing a cap, both arms forward, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the god, vertically, adorned with an ankh-sign (S34) and a djed-pillar (R11).
+U+1383D	kEH_Desc	God, in mummy form, standing upright, with a long straight beard, wearing a cap, both arms forwards, holding a sceptre with a straight shaft, forked bottom, and the vertically oriented head of the Seth animal (S040), of the same size as the god, adorned with an ankh sign (S034) and a djed pillar (R011).
 U+1383D	kEH_Func	Logogram (Ptah)
 U+1383D	kEH_FVal	ptḥ
 U+1383D	kEH_UniK	HJ C019A
@@ -15718,7 +15719,7 @@ U+1383F	kEH_UniK	C020C
 U+1383F	kEH_IFAO	75,14
 U+13840	kEH_Cat	C-23-021
 U+13840	kEH_Core	C
-U+13840	kEH_Desc	God, in mummy form, standing upright on a platform, with a long straight beard, wearing a cap, both arms forward, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the god, vertically, adorned with an ankh-sign (S34) and a djed-pillar (R11); inside the facade of a shrine (O21), inside a shrine supported by pillars resembling a stem of papyrus with a bud (M13).
+U+13840	kEH_Desc	God, in mummy form, standing upright on a platform, with a long straight beard, wearing a cap, both arms forward, holding a sceptre with a straight shaft, forked bottom, and the vertically oriented head of the Seth animal (S040), of the same size as the god, adorned with an ankh sign (S034) and a djed pillar (R011); placed within the façade of a shrine (O021), itself located inside a larger shrine supported by columns resembling papyrus stems with buds (M013).
 U+13840	kEH_Func	Logogram (divine, godly)
 U+13840	kEH_FVal	nṯr.y
 U+13840	kEH_UniK	HJ C020A
@@ -15733,13 +15734,13 @@ U+13841	kEH_FVal	ptḥ
 U+13841	kEH_UniK	C020D
 U+13842	kEH_Cat	C-23-026
 U+13842	kEH_Core	C
-U+13842	kEH_Desc	God, seated on a block-throne on a base, with a long straight beard, wearing a cap, both arms forwards, holding a sceptre with a straight shaft, topped with the head of the Seth animal vertically, adorned with an ankh-sign (S34) and a djed-pillar (R11).
+U+13842	kEH_Desc	God, seated on a block-throne on a base, with a long straight beard, wearing a cap, both arms forward, holding a sceptre with a straight shaft, topped with the vertically oriented head of the Seth animal, adorned with an ankh sign (S034) and a djed pillar (R011).
 U+13842	kEH_Func	Classifier divinity
 U+13842	kEH_FVal	nfr-ḥr
 U+13842	kEH_UniK	C020E
 U+13843	kEH_Cat	C-24-001
 U+13843	kEH_Core	C
-U+13843	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long-curved beard and long wig/hair, with a sun-disk (N5) on his head.
+U+13843	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long-curved beard and long wig/hair, with a sun disk (N5) on his head.
 U+13843	kEH_Func	Logogram (Re)
 U+13843	kEH_FVal	rꜥ
 U+13843	kEH_UniK	HJ C001D
@@ -15748,8 +15749,8 @@ U+13843	kEH_HG	C1D
 U+13843	kEH_IFAO	76,4
 U+13844	kEH_Cat	C-24-003
 U+13844	kEH_Core	C
-U+13844	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long-curved beard and long wig/hair, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on its head, holding a sceptre with a straight shaft, topped with the head of the Seth animal vertically. 
-U+13844	kEH_Func	Classifier King of UE
+U+13844	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long-curved beard and long wig/hair, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on its head, holding a sceptre with a straight shaft, topped with the head of the Seth animal vertically. 
+U+13844	kEH_Func	Classifier king of Upper Egypt
 U+13844	kEH_FVal	n(.y)-sw.t
 U+13844	kEH_UniK	HJ C001A
 U+13844	kEH_JSesh	C1A
@@ -15757,7 +15758,7 @@ U+13844	kEH_HG	C1A
 U+13844	kEH_IFAO	76,6
 U+13845	kEH_Cat	C-24-004
 U+13845	kEH_Core	C
-U+13845	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long-curved beard and long wig/hair, with a sun-disk (N5) on his head, holding a sceptre with a straight shaft, topped with the head of the Seth animal vertically. 
+U+13845	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long-curved beard and long wig/hair, with a sun disk (N5) on his head, holding a sceptre with a straight shaft, topped with the head of the Seth animal vertically. 
 U+13845	kEH_Func	Logogram (Re)
 U+13845	kEH_FVal	rꜥ
 U+13845	kEH_UniK	HJ C001B
@@ -15765,13 +15766,13 @@ U+13845	kEH_JSesh	C1B
 U+13845	kEH_HG	C1B
 U+13846	kEH_Cat	C-24-005
 U+13846	kEH_Core	C
-U+13846	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long-curved beard and long wig/hair, with a sun-disk (N5) on his head, holding a dung-beetle (scarab, L1).
+U+13846	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long-curved beard and long wig/hair, with a sun disk (N5) on his head, holding a dung-beetle (scarab, L1).
 U+13846	kEH_Func	Logogram (Khepri)
 U+13846	kEH_FVal	ḫprꞽ
 U+13846	kEH_UniK	C001F
 U+13847	kEH_Cat	C-24-006
 U+13847	kEH_Core	C
-U+13847	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long-curved beard and long wig/hair, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on its head, holding a sceptre (S42).
+U+13847	kEH_Desc	God, seated, knees up, with covered legs and arms, with a long-curved beard and long wig/hair, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on its head, holding a sceptre (S42).
 U+13847	kEH_Func	Logogram (powerful one)
 U+13847	kEH_FVal	sḫm
 U+13847	kEH_UniK	C001G
@@ -15791,7 +15792,7 @@ U+13849	kEH_HG	C7A
 U+13849	kEH_IFAO	76,11
 U+1384A	kEH_Cat	C-26-005
 U+1384A	kEH_Core	C
-U+1384A	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a Seth animal, holding a tie or strap, used with sandals (ankh-sign, S34), angling forward. 
+U+1384A	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a Seth animal, holding a tie or strap, used with sandals (ankh sign, S34), angling forward. 
 U+1384A	kEH_Func	Logogram (one who belongs to Seth)
 U+1384A	kEH_FVal	stẖ.y
 U+1384A	kEH_UniK	HJ C007D
@@ -15857,7 +15858,7 @@ U+13852	kEH_HG	C107A
 U+13852	kEH_IFAO	77,6
 U+13853	kEH_Cat	C-27-005
 U+13853	kEH_Core	C
-U+13853	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a crocodile, with ram horns and a N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on its head, holding a sceptre with a straight shaft, topped with the head of the Seth animal vertically. 
+U+13853	kEH_Desc	God, seated, knees up, with covered legs and arms, with the head of a crocodile, with ram horns and a N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on its head, holding a sceptre with a straight shaft, topped with the head of the Seth animal vertically. 
 U+13853	kEH_Func	Phonemogram (first person for sbk-šmꜥ-nfr)
 U+13853	kEH_FVal	ꞽ 
 U+13853	kEH_UniK	C107B
@@ -16067,7 +16068,7 @@ U+13870	kEH_IFAO	79,6
 U+13871	kEH_Cat	C-32-001
 U+13871	kEH_Core	C
 U+13871	kEH_Desc	God, standing, with a long sash-kilt, no beard and short hair/wig, wearing a headdress consisting of four plumes and a sun disk, right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the god, vertically, left arm hanging beside the body.
-U+13871	kEH_Func	Logogram (Son of Re)
+U+13871	kEH_Func	Logogram (son of Re)
 U+13871	kEH_FVal	sꜣ-rꜥ
 U+13871	kEH_UniK	HJ C285
 U+13871	kEH_JSesh	C285
@@ -16111,7 +16112,7 @@ U+13876	kEH_UniK	C148
 U+13876	kEH_JSesh	C148
 U+13877	kEH_Cat	C-33-004
 U+13877	kEH_Core	C
-U+13877	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, wearing a headdress of outwards waving plumes, holding a tie or strap, used with sandals (ankh-sign, S34), angling forward. 
+U+13877	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, wearing a headdress of outwards waving plumes, holding a tie or strap, used with sandals (ankh sign, S34), angling forward. 
 U+13877	kEH_Func	Classifier Anubis
 U+13877	kEH_FVal	ꜥnḳ.t
 U+13877	kEH_UniK	C148A
@@ -16173,7 +16174,7 @@ U+1387E	kEH_IFAO	81,1
 U+1387F	kEH_Cat	C-35-008
 U+1387F	kEH_Core	C
 U+1387F	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, with a headdress of bovine horns with a sun disk (F102), holding a holding a stem of papyrus with a bud (M131) or flower vertically. 
-U+1387F	kEH_Func	Classifier female divinity (Usually associated with Hathor)
+U+1387F	kEH_Func	Classifier female divinity (usually associated with Hathor)
 U+1387F	kEH_UniK	HJ C009A
 U+1387F	kEH_JSesh	C9A
 U+1387F	kEH_HG	C9A
@@ -16223,7 +16224,7 @@ U+13884	kEH_JSesh	C9h
 U+13884	kEH_HG	C9H
 U+13885	kEH_Cat	C-35-017
 U+13885	kEH_Core	C
-U+13885	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, with a headdress of bovine horns with a sun disk (F102), holding a tie or strap, used with sandals (ankh-sign, S34), vertically at the base.
+U+13885	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, with a headdress of bovine horns with a sun disk (F102), holding a tie or strap, used with sandals (ankh sign, S34), vertically at the base.
 U+13885	kEH_Func	Logogram (life)
 U+13885	kEH_FVal	ꜥnḫ
 U+13885	kEH_UniK	HJ C009E
@@ -16306,7 +16307,7 @@ U+13890	kEH_HG	C153
 U+13890	kEH_IFAO	82,2
 U+13891	kEH_Cat	C-35-034
 U+13891	kEH_Core	C
-U+13891	kEH_Desc	Goddess, standing, with a headdress of bovine horns with a sun disk (F102), right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the woman, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34), at the loop.
+U+13891	kEH_Desc	Goddess, standing, with a headdress of bovine horns with a sun disk (F102), right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the woman, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34), at the loop.
 U+13891	kEH_Func	Logogram (gold)
 U+13891	kEH_FVal	nbw
 U+13891	kEH_UniK	HJ C228
@@ -16320,7 +16321,7 @@ U+13892	kEH_FVal	ḥḳꜣ.t
 U+13892	kEH_UniK	C228A
 U+13893	kEH_Cat	C-35-038
 U+13893	kEH_Core	C
-U+13893	kEH_Desc	Goddess, standing, with a headdress of bovine horns with a sun disk (F102), with a seat (Q1) on the sun disk, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34), at the loop.
+U+13893	kEH_Desc	Goddess, standing, with a headdress of bovine horns with a sun disk (F102), with a seat (Q1) on the sun disk, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34), at the loop.
 U+13893	kEH_Func	Logogram (the heavens/sky)
 U+13893	kEH_FVal	p.t
 U+13893	kEH_UniK	C299A
@@ -16346,7 +16347,7 @@ U+13896	kEH_FVal	ꜣs.t
 U+13896	kEH_UniK	C315A
 U+13897	kEH_Cat	C-35-047
 U+13897	kEH_Core	C
-U+13897	kEH_Desc	Goddess, seated on a block throne with a base, wearing a headdress of bovine horns with a sun disk (F102), with a seat (Q1) on the sun disk, right arm forward, hand at the height of the shoulder, holding a tie or strap, used with sandals (ankh-sign, S34), horizontally at the base, left arm forward, hand upon the knee, holding a tie or strap, used with sandals (ankh-sign, S34), at the loop.
+U+13897	kEH_Desc	Goddess, seated on a block throne with a base, wearing a headdress of bovine horns with a sun disk (F102), with a seat (Q1) on the sun disk, right arm forward, hand at the height of the shoulder, holding a tie or strap, used with sandals (ankh sign, S34), horizontally at the base, left arm forward, hand upon the knee, holding a tie or strap, used with sandals (ankh sign, S34), at the loop.
 U+13897	kEH_Func	Logogram (Isis)
 U+13897	kEH_FVal	ꜣs.t
 U+13897	kEH_UniK	C155E
@@ -16358,7 +16359,7 @@ U+13898	kEH_HG	C157
 U+13898	kEH_IFAO	82,8
 U+13899	kEH_Cat	C-35-051
 U+13899	kEH_Core	C
-U+13899	kEH_Desc	Goddess, seated on a block throne with a base, wearing a headdress of bovine horns with a sun disk (F102), with a seat (Q1) on the sun disk, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the length of the seated figure, vertically, left arm forward, hand upon the knee, holding a tie or strap, used with sandals (ankh-sign, S34), at the loop.
+U+13899	kEH_Desc	Goddess, seated on a block throne with a base, wearing a headdress of bovine horns with a sun disk (F102), with a seat (Q1) on the sun disk, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the length of the seated figure, vertically, left arm forward, hand upon the knee, holding a tie or strap, used with sandals (ankh sign, S34), at the loop.
 U+13899	kEH_Func	Logogram (Isis)
 U+13899	kEH_FVal	ꜣs.t
 U+13899	kEH_UniK	C154A
@@ -16370,13 +16371,13 @@ U+1389A	kEH_HG	C155B
 U+1389A	kEH_IFAO	82,12
 U+1389B	kEH_Cat	C-35-054
 U+1389B	kEH_Core	C
-U+1389B	kEH_Desc	Goddess, seated on a block throne with a base, wearing a headdress of bovine horns with a sun disk (F102), right arm forward, hand at the height of the shoulder, holding a tie or strap, used with sandals (ankh-sign, S34), horizontally at the base, left arm forward, hand upon the knee, holding a tie or strap, used with sandals (ankh-sign, S34), at the loop.
+U+1389B	kEH_Desc	Goddess, seated on a block throne with a base, wearing a headdress of bovine horns with a sun disk (F102), right arm forward, hand at the height of the shoulder, holding a tie or strap, used with sandals (ankh sign, S34), horizontally at the base, left arm forward, hand upon the knee, holding a tie or strap, used with sandals (ankh sign, S34), at the loop.
 U+1389B	kEH_Func	Classifier divinity
 U+1389B	kEH_FVal	ꞽp.t-wr.t
 U+1389B	kEH_UniK	C155F
 U+1389C	kEH_Cat	C-35-057
 U+1389C	kEH_Core	C
-U+1389C	kEH_Desc	Goddess, seated on a block throne with a base, wearing a headdress of bovine horns with a sun disk (F102), right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the length of the seated figure, vertically, left arm forward, hand above the height of the bud of the papyrus, holding a tie or strap, used with sandals (ankh-sign, S34), horizontally at the base. 
+U+1389C	kEH_Desc	Goddess, seated on a block throne with a base, wearing a headdress of bovine horns with a sun disk (F102), right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the length of the seated figure, vertically, left arm forward, hand above the height of the bud of the papyrus, holding a tie or strap, used with sandals (ankh sign, S34), horizontally at the base. 
 U+1389C	kEH_Func	Logogram (Hathor)
 U+1389C	kEH_FVal	ḥw.t-ḥr
 U+1389C	kEH_UniK	C155X
@@ -16400,7 +16401,7 @@ U+1389E	kEH_HG	C159A
 U+1389E	kEH_IFAO	83,6
 U+1389F	kEH_Cat	C-35-066
 U+1389F	kEH_Core	C
-U+1389F	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, with a seat (Q1) on her head, holding a holding a tie or strap, used with sandals (ankh-sign, S34), angling forward. 
+U+1389F	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, with a seat (Q1) on her head, holding a holding a tie or strap, used with sandals (ankh sign, S34), angling forward. 
 U+1389F	kEH_Func	Logogram (Isis)
 U+1389F	kEH_FVal	ꜣs.t
 U+1389F	kEH_UniK	HJ C159B
@@ -16471,7 +16472,7 @@ U+138A8	kEH_HG	C161
 U+138A8	kEH_IFAO	83,11
 U+138A9	kEH_Cat	C-35-084
 U+138A9	kEH_Core	C
-U+138A9	kEH_Desc	Goddess, standing, wearing a vulture headdress, with a seat (Q3) on her head, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34), at the loop.
+U+138A9	kEH_Desc	Goddess, standing, wearing a vulture headdress, with a seat (Q3) on her head, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34), at the loop.
 U+138A9	kEH_Func	Logogram (lord)
 U+138A9	kEH_FVal	nb
 U+138A9	kEH_UniK	C161B
@@ -16495,7 +16496,7 @@ U+138AB	kEH_HG	C163A
 U+138AB	kEH_IFAO	83,16
 U+138AC	kEH_Cat	C-35-090
 U+138AC	kEH_Core	C
-U+138AC	kEH_Desc	Goddess, standing, with a headdress of bovine horns with a sun disk (F102), right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the woman, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34); on top of a collar of beads (S12).
+U+138AC	kEH_Desc	Goddess, standing, with a headdress of bovine horns with a sun disk (F102), right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the woman, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34); on top of a collar of beads (S12).
 U+138AC	kEH_Func	Phonemogram
 U+138AC	kEH_FVal	snṯ-ꞽnbw
 U+138AC	kEH_UniK	HJ C310
@@ -16566,7 +16567,7 @@ U+138B5	kEH_HG	C164E
 U+138B5	kEH_IFAO	84,7
 U+138B6	kEH_Cat	C-36-014
 U+138B6	kEH_Core	C
-U+138B6	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, with the head of a lion/lioness, holding a tie or strap, used with sandals (ankh-sign, S34), angling forward. 
+U+138B6	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, with the head of a lion/lioness, holding a tie or strap, used with sandals (ankh sign, S34), angling forward. 
 U+138B6	kEH_Func	Classifier leonid divinity (female)
 U+138B6	kEH_FVal	bꜣs.tt
 U+138B6	kEH_UniK	HJ C164F
@@ -16574,7 +16575,7 @@ U+138B6	kEH_JSesh	C164F
 U+138B6	kEH_HG	C164F
 U+138B7	kEH_Cat	C-36-016
 U+138B7	kEH_Core	C
-U+138B7	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, with the head of a lion/lioness, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on her head, holding a stem of papyrus with a bud (M13).
+U+138B7	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, with the head of a lion/lioness, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on her head, holding a stem of papyrus with a bud (M13).
 U+138B7	kEH_Func	Classifier leonid divinity (female)
 U+138B7	kEH_FVal	sḫm.t
 U+138B7	kEH_UniK	HJ C165A
@@ -16589,7 +16590,7 @@ U+138B8	kEH_FVal	nꞽw.t
 U+138B8	kEH_UniK	C165G
 U+138B9	kEH_Cat	C-36-020
 U+138B9	kEH_Core	C
-U+138B9	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, with the head of a lion/lioness, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on her head, holding a tie or strap, used with sandals (ankh-sign, S34), angled forwards.
+U+138B9	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, with the head of a lion/lioness, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on her head, holding a tie or strap, used with sandals (ankh sign, S34), angled forwards.
 U+138B9	kEH_Func	Logogram (Sekhmet)
 U+138B9	kEH_FVal	sḫm.t
 U+138B9	kEH_UniK	HJ C165D
@@ -16597,7 +16598,7 @@ U+138B9	kEH_JSesh	C165D
 U+138B9	kEH_HG	C165D
 U+138BA	kEH_Cat	C-36-021
 U+138BA	kEH_Core	C
-U+138BA	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, with the head of a lion/lioness, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on her head, holding a holding a stem of papyrus with a bud (M131) or flower vertically. 
+U+138BA	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, with the head of a lion/lioness, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on her head, holding a holding a stem of papyrus with a bud (M131) or flower vertically. 
 U+138BA	kEH_Func	Classifier leonid divinity (female)
 U+138BA	kEH_FVal	sḫm.t
 U+138BA	kEH_UniK	C165E
@@ -16671,13 +16672,13 @@ U+138C4	kEH_FVal	bꜣs.tt
 U+138C4	kEH_UniK	C360
 U+138C5	kEH_Cat	C-36-040
 U+138C5	kEH_Core	C
-U+138C5	kEH_Desc	Goddess, standing, with the head of a lion/lioness, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on her head, right arm raised in front, hand at the height of the face, hand palm outwards, left arm hanging beside the body.
+U+138C5	kEH_Desc	Goddess, standing, with the head of a lion/lioness, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on her head, right arm raised in front, hand at the height of the face, hand palm outwards, left arm hanging beside the body.
 U+138C5	kEH_Func	Logogram (vocative interjection)
 U+138C5	kEH_FVal	ꞽ
 U+138C5	kEH_UniK	C353
 U+138C6	kEH_Cat	C-36-041
 U+138C6	kEH_Core	C
-U+138C6	kEH_Desc	Goddess, standing, with the head of a lion/lioness, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on her head, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34), at the loop.
+U+138C6	kEH_Desc	Goddess, standing, with the head of a lion/lioness, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on her head, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34), at the loop.
 U+138C6	kEH_Func	Logogram (daughter of Re)
 U+138C6	kEH_FVal	sꜣ.t-rꜥ
 U+138C6	kEH_UniK	C354
@@ -16747,7 +16748,7 @@ U+138CE	kEH_FVal	mꜣꜥ.t
 U+138CE	kEH_UniK	C175B
 U+138CF	kEH_Cat	C-37-014
 U+138CF	kEH_Core	C
-U+138CF	kEH_Desc	Goddess, standing, with a cloth band around her head, with a feather (H6) on her head, right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the woman, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34).
+U+138CF	kEH_Desc	Goddess, standing, with a cloth band around her head, with a feather (H6) on her head, right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the woman, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34).
 U+138CF	kEH_Func	Classifier truth
 U+138CF	kEH_FVal	mꜥꜣ.t
 U+138CF	kEH_UniK	HJ C175
@@ -16756,7 +16757,7 @@ U+138CF	kEH_HG	C175
 U+138CF	kEH_IFAO	86,7
 U+138D0	kEH_Cat	C-37-015
 U+138D0	kEH_Core	C
-U+138D0	kEH_Desc	Goddess, standing, with a cloth band around her head, with a feather (H6) on her head, right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the woman, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34); on top of a canal (N36).
+U+138D0	kEH_Desc	Goddess, standing, with a cloth band around her head, with a feather (H6) on her head, right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the woman, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34); on top of a canal (N36).
 U+138D0	kEH_Func	Logogram/phonemogram (whom truth/Maat loves)
 U+138D0	kEH_FVal	mr(.y)-mꜣꜥ.t
 U+138D0	kEH_UniK	HJ C175A
@@ -16764,20 +16765,20 @@ U+138D0	kEH_JSesh	C175A
 U+138D0	kEH_HG	C175A
 U+138D1	kEH_Cat	C-37-016
 U+138D1	kEH_Core	C
-U+138D1	kEH_Desc	Goddess, standing, with a cloth band around her head, with a feather (H6) on her head, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34); on top of a platform (Aa11).
+U+138D1	kEH_Desc	Goddess, standing, with a cloth band around her head, with a feather (H6) on her head, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34); on top of a platform (Aa11).
 U+138D1	kEH_Func	Logogram (Maat)
 U+138D1	kEH_FVal	mꜣꜥ.t
 U+138D1	kEH_UniK	C176A
 U+138D2	kEH_Cat	C-37-019
 U+138D2	kEH_Core	C
-U+138D2	kEH_Desc	Goddess, seated on a block throne, with a cloth band around her head, with a feather (H6) on her head, right arm forward, hand at the height of the waist, holding the head and neck of a canine animal (F12) of the length of the figure, vertically, left arm forward, hand on the knee, holding a tie or strap, used with sandals (ankh-sign, S34), angled forwards.
+U+138D2	kEH_Desc	Goddess, seated on a block throne, with a cloth band around her head, with a feather (H6) on her head, right arm forward, hand at the height of the waist, holding the head and neck of a canine animal (F12) of the length of the figure, vertically, left arm forward, hand on the knee, holding a tie or strap, used with sandals (ankh sign, S34), angled forwards.
 U+138D2	kEH_Func	Logogram (in name Ramses II)
 U+138D2	kEH_FVal	wsr-mꜣꜥ.t
 U+138D2	kEH_UniK	C177A
 U+138D2	kEH_IFAO	86,10
 U+138D3	kEH_Cat	C-37-020
 U+138D3	kEH_Core	C
-U+138D3	kEH_Desc	Goddess, seated on a block throne, with a cloth band around her head, with a feather (H6) on her head, right arm forward, hand at the height of the waist, holding the head and neck of a canine animal (F12) of the length of the figure, vertically, left arm forward, hand on the knee, holding a tie or strap, used with sandals (ankh-sign, S34), horizontally at the loop.
+U+138D3	kEH_Desc	Goddess, seated on a block throne, with a cloth band around her head, with a feather (H6) on her head, right arm forward, hand at the height of the waist, holding the head and neck of a canine animal (F12) of the length of the figure, vertically, left arm forward, hand on the knee, holding a tie or strap, used with sandals (ankh sign, S34), horizontally at the loop.
 U+138D3	kEH_Func	Logogram (in name Ramses II)
 U+138D3	kEH_FVal	wsr-mꜣꜥ.t
 U+138D3	kEH_UniK	HJ C177
@@ -16795,7 +16796,7 @@ U+138D4	kEH_HG	C178A
 U+138D5	kEH_Cat	C-37-023
 U+138D5	kEH_Core	C
 U+138D5	kEH_Desc	Goddess, seated, knees up, with covered legs and arms, with a cloth band around her head, with a feather (H6) on her head, holding a feather (H6), vertically; on top of a gateway (O32B), with a conical loaf of bread (X8) written inside.
-U+138D5	kEH_Func	Logogram (Gate which gives truth)
+U+138D5	kEH_Func	Logogram (gate which gives truth)
 U+138D5	kEH_FVal	rw.t-dꞽ(.t)-mꜣꜥ.t
 U+138D5	kEH_UniK	HJ C179
 U+138D5	kEH_JSesh	C179
@@ -16884,13 +16885,13 @@ U+138E0	kEH_FVal	ḥm
 U+138E0	kEH_UniK	C183C
 U+138E1	kEH_Cat	C-39-006
 U+138E1	kEH_Core	C
-U+138E1	kEH_Desc	Goddess, standing, wearing the double crown (S5), right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the woman, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34)
+U+138E1	kEH_Desc	Goddess, standing, wearing the double crown (S5), right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the woman, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34)
 U+138E1	kEH_Func	Logogram (Mut)
 U+138E1	kEH_FVal	mw.t
 U+138E1	kEH_UniK	C184A
 U+138E2	kEH_Cat	C-39-007
 U+138E2	kEH_Core	C
-U+138E2	kEH_Desc	Goddess, standing, wearing the double crown (S5), right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34), at the loop.
+U+138E2	kEH_Desc	Goddess, standing, wearing the double crown (S5), right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34), at the loop.
 U+138E2	kEH_Func	Logogram (Hathor)
 U+138E2	kEH_FVal	ḥw.t-ḥr
 U+138E2	kEH_UniK	HJ C224
@@ -16899,7 +16900,7 @@ U+138E2	kEH_HG	C224
 U+138E2	kEH_IFAO	91,12
 U+138E3	kEH_Cat	C-39-011
 U+138E3	kEH_Core	C
-U+138E3	kEH_Desc	Goddess, seated on a block throne on a base, wearing the double crown (S5) and vulture headdress, right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40), which has a horizontal tie or strap, used with sandals (ankh-sign, S34) at the head of the sceptre; left arm forward, hand on knee.
+U+138E3	kEH_Desc	Goddess, seated on a block throne on a base, wearing the double crown (S5) and vulture headdress, right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40), which has a horizontal tie or strap, used with sandals (ankh sign, S34) at the head of the sceptre; left arm forward, hand on knee.
 U+138E3	kEH_Func	Logogram (Hathor, giving life)
 U+138E3	kEH_FVal	ḥw.t-ḥr-dꞽ-ꜥnḫ
 U+138E3	kEH_UniK	C356
@@ -16965,14 +16966,14 @@ U+138EB	kEH_HG	C188
 U+138EB	kEH_IFAO	88,4
 U+138EC	kEH_Cat	C-40-016
 U+138EC	kEH_Core	C
-U+138EC	kEH_Desc	Goddess, standing, wearing the red crown (S3), right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34), at the loop.
-U+138EC	kEH_Func	Logogram (king of LE)
+U+138EC	kEH_Desc	Goddess, standing, wearing the red crown (S3), right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34), at the loop.
+U+138EC	kEH_Func	Logogram (king of Lower Egypt)
 U+138EC	kEH_FVal	bꞽ.ty
 U+138EC	kEH_UniK	C188Y
 U+138EC	kEH_IFAO	88,6
 U+138ED	kEH_Cat	C-40-017
 U+138ED	kEH_Core	C
-U+138ED	kEH_Desc	Goddess, standing, wearing the red crown (S3), right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the woman, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34).
+U+138ED	kEH_Desc	Goddess, standing, wearing the red crown (S3), right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the woman, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34).
 U+138ED	kEH_Func	Phonemogram
 U+138ED	kEH_FVal	nt
 U+138ED	kEH_UniK	HJ C188B
@@ -16987,7 +16988,7 @@ U+138EE	kEH_FVal	n.t
 U+138EE	kEH_UniK	C187A
 U+138EF	kEH_Cat	C-40-022
 U+138EF	kEH_Core	C
-U+138EF	kEH_Desc	Goddess, standing, wearing the red crown, right arm forward, hand at the height of the waist, holding a griffon vulture (Gyps fulvus, G14), left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34).
+U+138EF	kEH_Desc	Goddess, standing, wearing the red crown, right arm forward, hand at the height of the waist, holding a griffon vulture (Gyps fulvus, G14), left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34).
 U+138EF	kEH_Func	Phonemogram
 U+138EF	kEH_FVal	wnn
 U+138EF	kEH_UniK	C188D
@@ -17059,7 +17060,7 @@ U+138F7	kEH_JSesh	C195A
 U+138F7	kEH_HG	C195A
 U+138F8	kEH_Cat	C-43-006
 U+138F8	kEH_Core	C
-U+138F8	kEH_Desc	Goddess, standing, with round vessel with upstanding rim (W24) on her head, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34), at the loop.
+U+138F8	kEH_Desc	Goddess, standing, with round vessel with upstanding rim (W24) on her head, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34), at the loop.
 U+138F8	kEH_Func	Logogram (the heavens/sky)
 U+138F8	kEH_FVal	p.t
 U+138F8	kEH_UniK	HJ C196
@@ -17175,7 +17176,7 @@ U+13906	kEH_IFAO	89,15
 U+13907	kEH_Cat	C-47-001
 U+13907	kEH_Core	C
 U+13907	kEH_Desc	Goddess, seated, knees up, with covered arms and legs, with the head of a bovid.
-U+13907	kEH_Func	Classifier Bovid divinity
+U+13907	kEH_Func	Classifier bovid divinity
 U+13907	kEH_FVal	ḥsꜣ.t
 U+13907	kEH_UniK	HJ C231
 U+13907	kEH_JSesh	C231
@@ -17183,7 +17184,7 @@ U+13907	kEH_HG	C231
 U+13907	kEH_IFAO	91,5
 U+13908	kEH_Cat	C-47-002
 U+13908	kEH_Core	C
-U+13908	kEH_Desc	Goddess, standing, with the head of a bovid, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34), at the loop.
+U+13908	kEH_Desc	Goddess, standing, with the head of a bovid, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34), at the loop.
 U+13908	kEH_Func	Logogram/phonemogram (lord)
 U+13908	kEH_FVal	nb
 U+13908	kEH_UniK	C352
@@ -17272,13 +17273,13 @@ U+13913	kEH_HG	C234
 U+13913	kEH_IFAO	92,1
 U+13914	kEH_Cat	C-47-028
 U+13914	kEH_Core	C
-U+13914	kEH_Desc	Goddess, standing, with the head of a desert hare, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34).
+U+13914	kEH_Desc	Goddess, standing, with the head of a desert hare, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the height of the woman, vertically, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34).
 U+13914	kEH_Func	Phonemogram
 U+13914	kEH_FVal	wn
 U+13914	kEH_UniK	C234A
 U+13915	kEH_Cat	C-47-031
 U+13915	kEH_Core	C
-U+13915	kEH_Desc	Goddess, seated, knees up, with covered arms and legs, wearing the Atef crown with horns, holding a tie or strap, used with sandals (ankh-sign, S34), vertically. 
+U+13915	kEH_Desc	Goddess, seated, knees up, with covered arms and legs, wearing the Atef crown with horns, holding a tie or strap, used with sandals (ankh sign, S34), vertically. 
 U+13915	kEH_Func	Classifier divinity
 U+13915	kEH_FVal	ꜥnṯ
 U+13915	kEH_UniK	HJ C216B
@@ -17338,7 +17339,7 @@ U+1391B	kEH_JSesh	C277
 U+1391B	kEH_HG	C277
 U+1391C	kEH_Cat	C-47-048
 U+1391C	kEH_Core	C
-U+1391C	kEH_Desc	Goddess, seated, knees up, with covered arms and legs, with long hair, with a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal, with a fillet and feather (R19), on top of a canal (N36) on her head, holding a tie or strap, used with sandals (ankh-sign, S34), angling forward.
+U+1391C	kEH_Desc	Goddess, seated, knees up, with covered arms and legs, with long hair, with a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal, with a fillet and feather (R19), on top of a canal (N36) on her head, holding a tie or strap, used with sandals (ankh sign, S34), angling forward.
 U+1391C	kEH_Func	Logogram (Thebes)
 U+1391C	kEH_FVal	wꜣs.t
 U+1391C	kEH_UniK	HJ C278
@@ -17363,14 +17364,14 @@ U+1391E	kEH_HG	C222B
 U+1391F	kEH_Cat	C-47-057
 U+1391F	kEH_Core	C
 U+1391F	kEH_Desc	Woman/goddess, standing, right arm forward, hand at the height of the waist, holding a duck or goose at the wings, left arm hanging beside the body.
-U+1391F	kEH_Func	Classifier (Sekhet, goddes of the marshlands)
+U+1391F	kEH_Func	Classifier (Sekhet, goddess of the marshlands)
 U+1391F	kEH_FVal	sḫ.t
 U+1391F	kEH_UniK	HJ C229
 U+1391F	kEH_JSesh	C229
 U+1391F	kEH_HG	C229
 U+13920	kEH_Cat	C-47-059
 U+13920	kEH_Core	C
-U+13920	kEH_Desc	Goddess, seated, knees up, with covered arms and legs, with long hair, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on her head.
+U+13920	kEH_Desc	Goddess, seated, knees up, with covered arms and legs, with long hair, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on her head.
 U+13920	kEH_Func	Classifier divinity
 U+13920	kEH_FVal	ḏd.t
 U+13920	kEH_UniK	HJ C255B
@@ -17378,7 +17379,7 @@ U+13920	kEH_JSesh	C255B
 U+13920	kEH_HG	C255B
 U+13921	kEH_Cat	C-47-060
 U+13921	kEH_Core	C
-U+13921	kEH_Desc	Goddess, seated, knees up, with covered arms and legs, with long hair, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on her head, holding a stem of papyrus with a bud (M13).
+U+13921	kEH_Desc	Goddess, seated, knees up, with covered arms and legs, with long hair, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on her head, holding a stem of papyrus with a bud (M13).
 U+13921	kEH_Func	Classifier divinity
 U+13921	kEH_FVal	wr.t-šꜥ.t
 U+13921	kEH_UniK	HJ C255C
@@ -17451,7 +17452,7 @@ U+1392A	kEH_HG	C242
 U+1392A	kEH_IFAO	93,6
 U+1392B	kEH_Cat	C-48-017
 U+1392B	kEH_Core	C
-U+1392B	kEH_Desc	Goddess, seated on a block throne, wearing a headdress consisting of the double crown on horns with a feather in the front, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the length of the seated figure, vertically, left arm forward, hand upon the knee; facing a god, seated on a block throne, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on his head, right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40), of the length of the seated figure, vertically, left arm forward, hand upon the knee; both on top of a base.
+U+1392B	kEH_Desc	Goddess, seated on a block throne, wearing a headdress consisting of the double crown on horns with a feather in the front, right arm forward, hand at the height of the waist, holding a stem of papyrus with a bud (M131) or flower, of the length of the seated figure, vertically, left arm forward, hand upon the knee; facing a god, seated on a block throne, with the head of a falcon, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on his head, right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40), of the length of the seated figure, vertically, left arm forward, hand upon the knee; both on top of a base.
 U+1392B	kEH_Func	Logogram (Hathor)
 U+1392B	kEH_FVal	ḥw.t-ḥr
 U+1392B	kEH_UniK	C358
@@ -17536,7 +17537,7 @@ U+13936	kEH_FVal	ḥr
 U+13936	kEH_UniK	D440
 U+13937	kEH_Cat	D-03-001
 U+13937	kEH_Core	C
-U+13937	kEH_Desc	The head of human male in profile, with two arms, on raised in front, forearm at 45° degree, hand at the height of the face, hand palm outwards, other arm with the hand below the head.
+U+13937	kEH_Desc	The head of human male in profile, with two arms, on raised in front, forearm 45 degree, hand at the height of the face, hand palm outwards, other arm with the hand below the head.
 U+13937	kEH_Func	Classifier human being
 U+13937	kEH_FVal	tm.yw
 U+13937	kEH_UniK	HJ D077
@@ -17545,7 +17546,7 @@ U+13937	kEH_HG	D77
 U+13937	kEH_IFAO	95,4
 U+13938	kEH_Cat	D-03-002
 U+13938	kEH_Core	C
-U+13938	kEH_Desc	The head of human male in profile, with two arms, on raised in front, forearm at 45° degree, hand at the height of the face, other arm with the hand below the head, both hands as fists.
+U+13938	kEH_Desc	The head of human male in profile, with two arms, on raised in front, forearm 45 degree, hand at the height of the face, other arm with the hand below the head, both hands as fists.
 U+13938	kEH_Func	Classifier occupation
 U+13938	kEH_FVal	sr
 U+13938	kEH_UniK	D077B
@@ -18164,7 +18165,7 @@ U+1398B	kEH_UniK	D143D
 U+1398C	kEH_Cat	D-08-001
 U+1398C	kEH_Core	C
 U+1398C	kEH_Desc	An eye, with the markings of the head of a falcon, with a vertical line at the back with a triangle at the curl.
-U+1398C	kEH_Func	Logogram (The dazzling eye (=Egypt))
+U+1398C	kEH_Func	Logogram (the ""dazzling-eye"" (Egypt))
 U+1398C	kEH_FVal	bꜣḳ.t
 U+1398C	kEH_UniK	HJ D010A
 U+1398C	kEH_JSesh	D10A
@@ -18528,7 +18529,7 @@ U+139BD	kEH_JSesh	D346
 U+139BD	kEH_HG	D346
 U+139BE	kEH_Cat	D-21-018
 U+139BE	kEH_Core	C
-U+139BE	kEH_Desc	Two arms, connected at the shoulder, one arm forwards, forearm straight, holding a mace (T3), the other arm downwards, forearm at 90° of the upper arm, holding a stick.
+U+139BE	kEH_Desc	Two arms, connected at the shoulder, one arm forwards, forearm straight, holding a mace (T3), the other arm downwards, forearm at 90 degree of the upper arm, holding a stick.
 U+139BE	kEH_Func	Logogram (to fight) (in ꜥḥꜣ.t (fighter (female))
 U+139BE	kEH_FVal	ꜥḥꜣ
 U+139BE	kEH_UniK	HJ D369
@@ -18536,7 +18537,7 @@ U+139BE	kEH_JSesh	D369
 U+139BE	kEH_HG	D369
 U+139BF	kEH_Cat	D-21-019
 U+139BF	kEH_Core	C
-U+139BF	kEH_Desc	Two arms, connected at the shoulder, one arm forwards, forearm horizontal, holding a wand or brush, the other arm downwards, forearm at 90° of the upper arm, holding a sceptre (S42).
+U+139BF	kEH_Desc	Two arms, connected at the shoulder, one arm forwards, forearm horizontal, holding a wand or brush, the other arm downwards, forearm at 90 degree of the upper arm, holding a sceptre (S42).
 U+139BF	kEH_Func	Logogram (to fight)
 U+139BF	kEH_FVal	ꜥḥꜣ
 U+139BF	kEH_UniK	HJ D371
@@ -18544,7 +18545,7 @@ U+139BF	kEH_JSesh	D371
 U+139BF	kEH_HG	D371
 U+139C0	kEH_Cat	D-21-020
 U+139C0	kEH_Core	C
-U+139C0	kEH_Desc	Two arms, connected at the shoulder, one arm forwards, holding a round shield, seen in profile, other arm downwards, forearm at 90° of the upper arm, holding a mace (T3) vertically.
+U+139C0	kEH_Desc	Two arms, connected at the shoulder, one arm forwards, holding a round shield, seen in profile, other arm downwards, forearm 90 degree of the upper arm, holding a mace (T3) vertically.
 U+139C0	kEH_Func	Logogram (to fight)
 U+139C0	kEH_FVal	ꜥḥꜣ
 U+139C0	kEH_UniK	HJ D372
@@ -18716,7 +18717,7 @@ U+139D6	kEH_FVal	ꞽꜥꞽ
 U+139D6	kEH_UniK	D212C
 U+139D7	kEH_Cat	D-25-039
 U+139D7	kEH_Core	C
-U+139D7	kEH_Desc	A forearm with the palm of the hand facing upwards, with a downward curving wavy line above the arm, with the lower end ending in the hand-palm.
+U+139D7	kEH_Desc	A forearm with the palm of the hand facing upwards, with a downward curving wavy line above the arm, with the lower end ending in the hand palm.
 U+139D7	kEH_Func	Logogram (to wash)
 U+139D7	kEH_FVal	ꞽꜥꞽ
 U+139D7	kEH_UniK	D212D
@@ -18740,7 +18741,7 @@ U+139DA	kEH_JSesh	D382
 U+139DA	kEH_HG	D382
 U+139DB	kEH_Cat	D-26-001
 U+139DB	kEH_Core	C
-U+139DB	kEH_Desc	An arm, bend at the elbow, hand horizontal, hand palm upwards.
+U+139DB	kEH_Desc	An arm, bent at the elbow, hand horizontal, hand palm upwards.
 U+139DB	kEH_Func	Classifier washing
 U+139DB	kEH_FVal	ꞽꜥꞽ
 U+139DB	kEH_UniK	HJ D234
@@ -18749,7 +18750,7 @@ U+139DB	kEH_HG	D234
 U+139DB	kEH_IFAO	112,13
 U+139DC	kEH_Cat	D-26-002
 U+139DC	kEH_Core	C
-U+139DC	kEH_Desc	An arm, bend at the elbow, hand horizontal, hand palm upwards, with a forward, downward angling dotted line coming from the hand.
+U+139DC	kEH_Desc	An arm, bent at the elbow, hand horizontal, hand palm upwards, with a forward, downward angling dotted line coming from the hand.
 U+139DC	kEH_Func	Logogram (to wash)
 U+139DC	kEH_FVal	ꞽꜥꞽ
 U+139DC	kEH_UniK	HJ D236A
@@ -18758,7 +18759,7 @@ U+139DC	kEH_HG	D236A
 U+139DC	kEH_IFAO	112,14
 U+139DD	kEH_Cat	D-26-004
 U+139DD	kEH_Core	C
-U+139DD	kEH_Desc	An arm, bend at the elbow, hand horizontal, hand palm downwards.
+U+139DD	kEH_Desc	An arm, bent at the elbow, hand horizontal, hand palm downwards.
 U+139DD	kEH_Func	Classifier stretching out
 U+139DD	kEH_FVal	hn
 U+139DD	kEH_UniK	HJ D235
@@ -18767,13 +18768,13 @@ U+139DD	kEH_HG	D235
 U+139DD	kEH_IFAO	113,1
 U+139DE	kEH_Cat	D-26-005
 U+139DE	kEH_Core	C
-U+139DE	kEH_Desc	An arm, bend at the elbow, with the hand held as a fist, orientated backwards.
+U+139DE	kEH_Desc	An arm, bent at the elbow, with the hand held as a fist, orientated backwards.
 U+139DE	kEH_Func	Classifier negative action
 U+139DE	kEH_FVal	ḫb
 U+139DE	kEH_UniK	D235A
 U+139DF	kEH_Cat	D-26-006
 U+139DF	kEH_Core	C
-U+139DF	kEH_Desc	An arm, bend at the elbow, upper arm horizontal, hand palm outwards.
+U+139DF	kEH_Desc	An arm, bent at the elbow, upper arm horizontal, hand palm outwards.
 U+139DF	kEH_Func	Classifier to rejoice
 U+139DF	kEH_FVal	nḥrḥr
 U+139DF	kEH_UniK	HJ D263
@@ -18781,7 +18782,7 @@ U+139DF	kEH_JSesh	D263
 U+139DF	kEH_HG	D263
 U+139E0	kEH_Cat	D-26-007
 U+139E0	kEH_Core	C
-U+139E0	kEH_Desc	An arm, bend at the elbow, upper arm horizontal, hand held horizontal, hand palm upwards.
+U+139E0	kEH_Desc	An arm, bent at the elbow, upper arm horizontal, hand held horizontally, hand palm upwards.
 U+139E0	kEH_Func	Classifier to call
 U+139E0	kEH_FVal	nꞽs
 U+139E0	kEH_UniK	HJ D264
@@ -18789,7 +18790,7 @@ U+139E0	kEH_JSesh	D264
 U+139E0	kEH_HG	D264
 U+139E1	kEH_Cat	D-26-008
 U+139E1	kEH_Core	C
-U+139E1	kEH_Desc	An arm, bend at the elbow, forearm nearly horizontal, holding a flagellum (S45).
+U+139E1	kEH_Desc	An arm, bent at the elbow, forearm nearly horizontal, holding a flagellum (S45).
 U+139E1	kEH_Func	Logogram (to protect)
 U+139E1	kEH_FVal	ḫwꞽ
 U+139E1	kEH_UniK	HJ D237
@@ -18798,7 +18799,7 @@ U+139E1	kEH_HG	D237
 U+139E1	kEH_IFAO	113,2
 U+139E2	kEH_Cat	D-26-013
 U+139E2	kEH_Core	C
-U+139E2	kEH_Desc	An arm, bend at the elbow, forearm nearly horizontal, holding a tall wand or brush, vertically.
+U+139E2	kEH_Desc	An arm, bent at the elbow, forearm nearly horizontal, holding a tall wand or brush, vertically.
 U+139E2	kEH_Func	Logogram (to make holy)
 U+139E2	kEH_FVal	ḏsr
 U+139E2	kEH_UniK	HJ D238
@@ -18822,7 +18823,7 @@ U+139E5	kEH_HG	D241
 U+139E5	kEH_IFAO	113,11
 U+139E6	kEH_Cat	D-26-018
 U+139E6	kEH_Core	C
-U+139E6	kEH_Desc	An arm, bend at the elbow, forearm nearly horizontal, holding a sceptre (S42).
+U+139E6	kEH_Desc	An arm, bent at the elbow, forearm nearly horizontal, holding a sceptre (S42).
 U+139E6	kEH_Func	Classifier to govern/to control
 U+139E6	kEH_FVal	ḫrp
 U+139E6	kEH_UniK	HJ D242
@@ -18831,7 +18832,7 @@ U+139E6	kEH_HG	D242
 U+139E6	kEH_IFAO	113,12
 U+139E7	kEH_Cat	D-26-019
 U+139E7	kEH_Core	C
-U+139E7	kEH_Desc	An arm, bend at the elbow, forearm nearly horizontal, holding a feather (H6).
+U+139E7	kEH_Desc	An arm, bent at the elbow, forearm nearly horizontal, holding a feather (H6).
 U+139E7	kEH_Func	Classifier messenger
 U+139E7	kEH_FVal	ḥw(w).t(y)
 U+139E7	kEH_UniK	HJ D243
@@ -18840,7 +18841,7 @@ U+139E7	kEH_HG	D243
 U+139E7	kEH_IFAO	113,13
 U+139E8	kEH_Cat	D-26-020
 U+139E8	kEH_Core	C
-U+139E8	kEH_Desc	An arm, bend at the elbow, forearm nearly horizontal, holding a wick of twisted flax, consisting of 3 loops (V28).
+U+139E8	kEH_Desc	An arm, bent at the elbow, forearm nearly horizontal, holding a wick of twisted flax, consisting of 3 loops (V28).
 U+139E8	kEH_Func	Logogram (to make holy, to be holy, to be splendid)
 U+139E8	kEH_FVal	ḏsr
 U+139E8	kEH_UniK	HJ D244
@@ -18849,19 +18850,19 @@ U+139E8	kEH_HG	D244
 U+139E8	kEH_IFAO	113,14
 U+139E9	kEH_Cat	D-26-023
 U+139E9	kEH_Core	C
-U+139E9	kEH_Desc	An arm, bend at the elbow, forearm nearly horizontal, holding a conical loaf of bread (X8).
+U+139E9	kEH_Desc	An arm, bent at the elbow, forearm nearly horizontal, holding a conical loaf of bread (X8).
 U+139E9	kEH_Func	Phonemogram
 U+139E9	kEH_FVal	dꞽ
 U+139E9	kEH_UniK	D442
 U+139EA	kEH_Cat	D-26-028
 U+139EA	kEH_Core	C
-U+139EA	kEH_Desc	An arm, bend at the elbow, forearm nearly horizontal, holding a neck and head of a gazelle
+U+139EA	kEH_Desc	An arm, bent at the elbow, forearm nearly horizontal, holding a neck and head of a gazelle
 U+139EA	kEH_Func	Classifier netherworld
 U+139EA	kEH_FVal	dwꜣ.t
 U+139EA	kEH_UniK	D258A
 U+139EB	kEH_Cat	D-26-030
 U+139EB	kEH_Core	C
-U+139EB	kEH_Desc	An arm, bend at the elbow, forearm nearly horizontal, holding a knife with a triangular blade and straight handle.
+U+139EB	kEH_Desc	An arm, bent at the elbow, forearm nearly horizontal, holding a knife with a triangular blade and straight handle.
 U+139EB	kEH_Func	Phonemogram
 U+139EB	kEH_FVal	ḏsr
 U+139EB	kEH_UniK	HJ D336A
@@ -18869,7 +18870,7 @@ U+139EB	kEH_JSesh	D336A
 U+139EB	kEH_HG	D336A
 U+139EC	kEH_Cat	D-26-032
 U+139EC	kEH_Core	C
-U+139EC	kEH_Desc	An arm, bend at the elbow, in a V shape, hand holding a stick at the top.
+U+139EC	kEH_Desc	An arm, bent at the elbow, in a V shape, hand holding a stick at the top.
 U+139EC	kEH_Func	Classifier to write, to inscribe
 U+139EC	kEH_FVal	spẖr
 U+139EC	kEH_UniK	D245
@@ -18877,7 +18878,7 @@ U+139EC	kEH_HG	D245
 U+139EC	kEH_IFAO	113,16
 U+139ED	kEH_Cat	D-26-033
 U+139ED	kEH_Core	C
-U+139ED	kEH_Desc	An arm, bend at the elbow, in a V shape, hand holding a brush.
+U+139ED	kEH_Desc	An arm, bent at the elbow, in a V shape, hand holding a brush.
 U+139ED	kEH_Func	Logogram (to write, to inscribe)
 U+139ED	kEH_FVal	spẖr
 U+139ED	kEH_UniK	HJ D246
@@ -18886,7 +18887,7 @@ U+139ED	kEH_HG	D246
 U+139ED	kEH_IFAO	114,1
 U+139EE	kEH_Cat	D-26-034
 U+139EE	kEH_Core	C
-U+139EE	kEH_Desc	An arm, bend at the elbow, in a V shape, hand on top of a wall or shrine.
+U+139EE	kEH_Desc	An arm, bent at the elbow, in a V shape, hand on top of a wall or shrine.
 U+139EE	kEH_Func	Classifier to destroy, to overthrow
 U+139EE	kEH_FVal	ḫmꞽ
 U+139EE	kEH_UniK	HJ D259
@@ -18894,7 +18895,7 @@ U+139EE	kEH_JSesh	D259
 U+139EE	kEH_HG	D259
 U+139EF	kEH_Cat	D-26-035
 U+139EF	kEH_Core	C
-U+139EF	kEH_Desc	An arm, bend at the elbow, in a V shape, hand holding a staff or pole with a two-pronged end piece for holding down snakes (U116).
+U+139EF	kEH_Desc	An arm, bent at the elbow, in a V shape, hand holding a staff or pole with a two-pronged end piece for holding down snakes (U116).
 U+139EF	kEH_Func	Classifier elder/official
 U+139EF	kEH_FVal	sr
 U+139EF	kEH_UniK	HJ D262
@@ -18902,7 +18903,7 @@ U+139EF	kEH_JSesh	D262
 U+139EF	kEH_HG	D262
 U+139F0	kEH_Cat	D-27-001
 U+139F0	kEH_Core	C
-U+139F0	kEH_Desc	Two arms, elbows bend, upper arms overlapping, in a V shape, forearms separated, hand palms outwards.
+U+139F0	kEH_Desc	Two arms, elbows bent, upper arms overlapping, in a V shape, forearms separated, hand palms outwards.
 U+139F0	kEH_Func	Classifier adoration
 U+139F0	kEH_FVal	dwꜣ
 U+139F0	kEH_UniK	HJ D260
@@ -18954,7 +18955,7 @@ U+139F5	kEH_JSesh	D358
 U+139F5	kEH_HG	D358
 U+139F6	kEH_Cat	D-27-012
 U+139F6	kEH_Core	C
-U+139F6	kEH_Desc	An arm, bend at the elbow, forearm horizontal, holding a stick, facing its mirror, sticks crossing.
+U+139F6	kEH_Desc	An arm, bent at the elbow, forearm horizontal, holding a stick, facing its mirror, sticks crossing.
 U+139F6	kEH_Func	Classifier fighting
 U+139F6	kEH_FVal	ẖnn.w
 U+139F6	kEH_UniK	HJ D257
@@ -18980,7 +18981,7 @@ U+139F8	kEH_HG	D46A
 U+139F8	kEH_IFAO	115,1
 U+139F9	kEH_Cat	D-28-012
 U+139F9	kEH_Core	C
-U+139F9	kEH_Desc	A spiral, winding counterclockwise away from its central point, ending at the right lower corner after about one and a half turns(Z7), written over a human hand (D46).
+U+139F9	kEH_Desc	A spiral, winding counterclockwise away from its central point, ending at the right lower corner after about one and a half turns (Z7), written over a human hand (D46).
 U+139F9	kEH_Func	Phonemogram
 U+139F9	kEH_FVal	wd
 U+139F9	kEH_UniK	D443
@@ -19082,7 +19083,7 @@ U+13A05	kEH_IFAO	116,10
 U+13A06	kEH_Cat	D-30-018
 U+13A06	kEH_Core	C
 U+13A06	kEH_Desc	Two vertical human fingers on top of a standard used for carrying religious symbols (R12).
-U+13A06	kEH_Func	Logogram (Prospopite nome)
+U+13A06	kEH_Func	Logogram (Prosopopite nome)
 U+13A06	kEH_FVal	mtr
 U+13A06	kEH_UniK	D445
 U+13A07	kEH_Cat	D-31-004
@@ -19181,7 +19182,7 @@ U+13A12	kEH_IFAO	118,8
 U+13A12	kEH_NoRotate	Y
 U+13A13	kEH_Cat	D-34-005
 U+13A13	kEH_Core	C
-U+13A13	kEH_Desc	Legs in a walking posture, rotated roughly 90° forward, feet towards the bottom.
+U+13A13	kEH_Desc	Legs in a walking posture, rotated roughly 90 degree forward, feet towards the bottom.
 U+13A13	kEH_Func	Classifier to fall
 U+13A13	kEH_FVal	ḫr
 U+13A13	kEH_UniK	HJ D287
@@ -19394,7 +19395,7 @@ U+13A2E	kEH_JSesh	D326B
 U+13A2E	kEH_HG	D326B
 U+13A2F	kEH_Cat	D-36-038
 U+13A2F	kEH_Core	C
-U+13A2F	kEH_Desc	Two harpoon-heads with two horizontal strokes on top and a single curl on top of the point (HG T19), on top of a forward bend feather (H27)/a wide tongue (F20A), or a wide band of string or fabric (V12A).
+U+13A2F	kEH_Desc	Two harpoon-heads with two horizontal strokes on top and a single curl on top of the point (HG T19), on top of a forward bent feather (H27)/a wide tongue (F20A), or a wide band of string or fabric (V12A).
 U+13A2F	kEH_Func	Phonemogram
 U+13A2F	kEH_FVal	sꜣḥ
 U+13A2F	kEH_UniK	HJ D373
@@ -19722,7 +19723,7 @@ U+13A5C	kEH_IFAO	126,6
 U+13A5D	kEH_Cat	E-03-008
 U+13A5D	kEH_Core	C
 U+13A5D	kEH_Desc	An oryx, standing, on top of a standard used for the carrying of religious symbols on top of a parcel of land with irrigation ditches.
-U+13A5D	kEH_Func	Logogram (Oryx nome, 16th nome of Upper Egypt
+U+13A5D	kEH_Func	Logogram (Oryx nome, 16th nome of Upper Egypt)
 U+13A5D	kEH_FVal	mꜣ-ḥḏ
 U+13A5D	kEH_UniK	HJ E198
 U+13A5D	kEH_JSesh	E198
@@ -19818,13 +19819,13 @@ U+13A68	kEH_HG	E179
 U+13A68	kEH_IFAO	127,11
 U+13A69	kEH_Cat	E-04-006
 U+13A69	kEH_Core	C
-U+13A69	kEH_Desc	A ram (Ovis longipes palaeo-aegyptiacus), standing, with a beard, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on top of the horns.
-U+13A69	kEH_Func	Logogram (Son of Re)
+U+13A69	kEH_Desc	A ram (Ovis longipes palaeo-aegyptiacus), standing, with a beard, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on top of the horns.
+U+13A69	kEH_Func	Logogram (son of Re)
 U+13A69	kEH_FVal	sꜣ-rꜥ
 U+13A69	kEH_UniK	E180B
 U+13A6A	kEH_Cat	E-04-008
 U+13A6A	kEH_Core	C
-U+13A6A	kEH_Desc	A ram (Ovis longipes palaeo-aegyptiacus), standing, with a beard, with a headdress consisting of two feathers and a sun-disk (S76) on top of the horns.
+U+13A6A	kEH_Desc	A ram (Ovis longipes palaeo-aegyptiacus), standing, with a beard, with a headdress consisting of two feathers and a sun disk (S76) on top of the horns.
 U+13A6A	kEH_Func	Logogram (he of Edfu)
 U+13A6A	kEH_FVal	bḥd.ty
 U+13A6A	kEH_UniK	HJ E181
@@ -19833,7 +19834,7 @@ U+13A6A	kEH_HG	E181
 U+13A6A	kEH_IFAO	127,13
 U+13A6B	kEH_Cat	E-04-011
 U+13A6B	kEH_Core	C
-U+13A6B	kEH_Desc	A ram (Ovis longipes palaeo-aegyptiacus), standing, with a beard, with a cobra (Naja haje), standing up, with expanded hood (Uraeus, I64) on its horns.
+U+13A6B	kEH_Desc	A ram (Ovis longipes palaeo-aegyptiacus), standing, with a beard, with a cobra (Naja haje), standing up, with expanded hood (uraeus, I64) on its horns.
 U+13A6B	kEH_Func	Phonemogram (in bꜣ-n-rꜥ-mr.y-ꞽmn)
 U+13A6B	kEH_FVal	bꜣ
 U+13A6B	kEH_UniK	HJ E191
@@ -19857,7 +19858,7 @@ U+13A6D	kEH_JSesh	E224
 U+13A6D	kEH_HG	E224
 U+13A6E	kEH_Cat	E-04-015
 U+13A6E	kEH_Core	C
-U+13A6E	kEH_Desc	A ram (Ovis longipes palaeo-aegyptiacus), standing, without a beard, with a cobra (Naja haje), standing up, with expanded hood (Uraeus)(I64) on its head, with the wings of a bird on its back, spread in a V-shape.
+U+13A6E	kEH_Desc	A ram (Ovis longipes palaeo-aegyptiacus), standing, without a beard, with a cobra (Naja haje), standing up, with expanded hood (uraeus)(I64) on its head, with the wings of a bird on its back, spread in a V-shape.
 U+13A6E	kEH_Func	Logogram (to the north of)
 U+13A6E	kEH_FVal	mḥ
 U+13A6E	kEH_UniK	HJ E226
@@ -19899,7 +19900,7 @@ U+13A73	kEH_Desc	A ram (Ovis longipes palaeo-aegyptiacus), standing, with a bear
 U+13A73	kEH_UniK	E193A
 U+13A74	kEH_Cat	E-04-030
 U+13A74	kEH_Core	C
-U+13A74	kEH_Desc	A ram (Ovis longipes palaeo-aegyptiacus), standing, with a beard, with a headdress consisting of two feathers and a sun-disk (S76) on top of the horns, with a flagellum (S45) on its back; in front of a ram (Ovis longipes palaeo-aegyptiacus), standing, with a beard, with a flagellum (S45) on its back; on top of a standard used for carrying religious symbols (R12).
+U+13A74	kEH_Desc	A ram (Ovis longipes palaeo-aegyptiacus), standing, with a beard, with a headdress consisting of two feathers and a sun disk (S76) on top of the horns, with a flagellum (S45) on its back; in front of a ram (Ovis longipes palaeo-aegyptiacus), standing, with a beard, with a flagellum (S45) on its back; on top of a standard used for carrying religious symbols (R12).
 U+13A74	kEH_Func	?
 U+13A74	kEH_UniK	E310
 U+13A75	kEH_Cat	E-05-001
@@ -20027,7 +20028,7 @@ U+13A84	kEH_UniK	E019B
 U+13A84	kEH_IFAO	130,2
 U+13A85	kEH_Cat	E-06-024
 U+13A85	kEH_Core	C
-U+13A85	kEH_Desc	Three jackals, standing, tail down, overlapping each other, bound with rope to a boat/ship with a prow and stern resembling the handle of a sickle (U1), on top of a rectangle resembling water, with an oar/rudder at the back (P28); with a god, seated, knees up, with covered legs and arms, with the head of a falcon, with a sun disk (N5) on its head, holding a tie or strap, used with sandals (ankh-sign, S34), angling forward (C2) within it.
+U+13A85	kEH_Desc	Three jackals, standing, tail down, overlapping each other, bound with rope to a boat/ship with a prow and stern resembling the handle of a sickle (U1), on top of a rectangle resembling water, with an oar/rudder at the back (P28); with a god, seated, knees up, with covered legs and arms, with the head of a falcon, with a sun disk (N5) on its head, holding a tie or strap, used with sandals (ankh sign, S34), angling forward (C2) within it.
 U+13A85	kEH_Func	Logogram (those who conduct the bark of Re)
 U+13A85	kEH_FVal	sb.yw-wꞽꜣ-n-rꜥ
 U+13A85	kEH_UniK	HJ E228
@@ -20130,7 +20131,7 @@ U+13A92	kEH_FVal	wp-wꜣ.wt
 U+13A92	kEH_UniK	E145D
 U+13A93	kEH_Cat	E-07-025
 U+13A93	kEH_Core	C
-U+13A93	kEH_Desc	A jackal, lying down, tail down (E15), on top of a standard used for the carrying of religious symbols, with an uraeus and šdšd-protuberance at the front of the standard, with a mace (T3) written horizontally over the vertical pole of the standard, mace head towards the back.
+U+13A93	kEH_Desc	A jackal, lying down, tail downwards (E15), on top of a standard used for the carrying of religious symbols, with an uraeus and šdšd-protuberance at the front of the standard, with a mace (T3) written horizontally over the vertical pole of the standard, mace head towards the back.
 U+13A93	kEH_Func	Classifier canine divinity
 U+13A93	kEH_FVal	wp-wꜣ.wt
 U+13A93	kEH_UniK	E019C
@@ -20179,7 +20180,7 @@ U+13A99	kEH_UniK	E013C
 U+13A99	kEH_IFAO	131,7
 U+13A9A	kEH_Cat	E-08-006
 U+13A9A	kEH_Core	C
-U+13A9A	kEH_Desc	A cat, seated, tail curled over the body towards the back, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on top of its head.
+U+13A9A	kEH_Desc	A cat, seated, tail curled over the body towards the back, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on top of its head.
 U+13A9A	kEH_Func	Logogram (like Re)
 U+13A9A	kEH_FVal	mꞽ-rꜥ
 U+13A9A	kEH_UniK	HJ E086A
@@ -20196,7 +20197,7 @@ U+13A9B	kEH_JSesh	E88
 U+13A9B	kEH_HG	E88
 U+13A9C	kEH_Cat	E-08-010
 U+13A9C	kEH_Core	C
-U+13A9C	kEH_Desc	A cat, seated, tail curled over the body towards the back, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on top of its head, with a tie or strap, used with sandals (ankh-sign, S34), angling forward on top of its front paw.
+U+13A9C	kEH_Desc	A cat, seated, tail curled over the body towards the back, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on top of its head, with a tie or strap, used with sandals (ankh sign, S34), angling forward on top of its front paw.
 U+13A9C	kEH_Func	Logogram (given life like Re)
 U+13A9C	kEH_FVal	dꞽ-ꜥnḫ-mꞽ-rꜥ 
 U+13A9C	kEH_UniK	HJ E232
@@ -20394,7 +20395,7 @@ U+13AB6	kEH_HG	E134A
 U+13AB6	kEH_IFAO	134,8
 U+13AB7	kEH_Cat	E-14-021
 U+13AB7	kEH_Core	C
-U+13AB7	kEH_Desc	A hippopotamus, with the limbs of a feline, head and tail of a crocodile, standing on its hind legs, front leg extended forwards (E134), with a headdress consisting of two plumes and a sun-disk (S63A), paw upon a rolled-up herdsman's shelter of papyrus (V17).
+U+13AB7	kEH_Desc	A hippopotamus, with the limbs of a feline, head and tail of a crocodile, standing on its hind legs, front leg extended forwards (E134), with a headdress consisting of two plumes and a sun disk (S63A), paw upon a rolled-up herdsman's shelter of papyrus (V17).
 U+13AB7	kEH_Func	Logogram/Phonemogram (great one (female))
 U+13AB7	kEH_FVal	wr.t
 U+13AB7	kEH_UniK	HJ E137
@@ -20409,7 +20410,7 @@ U+13AB8	kEH_FVal	wr.t
 U+13AB8	kEH_UniK	E298
 U+13AB9	kEH_Cat	E-14-027
 U+13AB9	kEH_Core	C
-U+13AB9	kEH_Desc	A hippopotamus, with the limbs of a feline, head and tail of a crocodile, with a headdress consisting of two plumes and a sun-disk (S63A), standing on its hind legs, front legs raised in front of the head, holding a tambourine or drum.
+U+13AB9	kEH_Desc	A hippopotamus, with the limbs of a feline, head and tail of a crocodile, with a headdress consisting of two plumes and a sun disk (S63A), standing on its hind legs, front legs raised in front of the head, holding a tambourine or drum.
 U+13AB9	kEH_Func	Logogram (to rejoice)
 U+13AB9	kEH_FVal	bnhm
 U+13AB9	kEH_UniK	E273B
@@ -20453,7 +20454,7 @@ U+13ABE	kEH_IFAO	135,1
 U+13ABF	kEH_Cat	E-16-009
 U+13ABF	kEH_Core	C
 U+13ABF	kEH_Desc	A desert hare, lying down (E34), on top of a standard used for the carrying of religious symbols (R12)
-U+13ABF	kEH_Func	Logogram (Hermopolis magna, 15th nome of UE)
+U+13ABF	kEH_Func	Logogram (Hermopolis magna, 15th nome of Upper Egypt)
 U+13ABF	kEH_FVal	wnw.t 
 U+13ABF	kEH_UniK	E034C
 U+13ABF	kEH_JSesh	E34A
@@ -20518,7 +20519,7 @@ U+13AC7	kEH_HG	E108
 U+13AC7	kEH_IFAO	136,3
 U+13AC8	kEH_Cat	E-17-016
 U+13AC8	kEH_Core	C
-U+13AC8	kEH_Desc	A lion, standing, tail upwards (E22A), with a sun-disk on its head.
+U+13AC8	kEH_Desc	A lion, standing, tail upwards (E22A), with a sun disk on its head.
 U+13AC8	kEH_Func	Logogram (lion)
 U+13AC8	kEH_FVal	mꜣꞽ
 U+13AC8	kEH_UniK	HJ E238
@@ -20531,7 +20532,7 @@ U+13AC9	kEH_HG	E107
 U+13AC9	kEH_IFAO	136,1
 U+13ACA	kEH_Cat	E-17-019
 U+13ACA	kEH_Core	C
-U+13ACA	kEH_Desc	A lion, standing, tail downwards, right front leg raised, holding a tie or strap, used with sandals (ankh-sign, S34).
+U+13ACA	kEH_Desc	A lion, standing, tail downwards, right front leg raised, holding a tie or strap, used with sandals (ankh sign, S34).
 U+13ACA	kEH_Func	Logogram (living lion)
 U+13ACA	kEH_FVal	mꜣꞽ-ꜥnḫ
 U+13ACA	kEH_UniK	HJ E110
@@ -20540,7 +20541,7 @@ U+13ACA	kEH_HG	E110
 U+13ACA	kEH_IFAO	136,4
 U+13ACB	kEH_Cat	E-17-020
 U+13ACB	kEH_Core	C
-U+13ACB	kEH_Desc	A lion, standing, tail downwards, with a tie or strap, used with sandals (ankh-sign, S34) on its front paw.
+U+13ACB	kEH_Desc	A lion, standing, tail downwards, with a tie or strap, used with sandals (ankh sign, S34) on its front paw.
 U+13ACB	kEH_Func	Logogram (living lion)
 U+13ACB	kEH_FVal	mꜣꞽ-ꜥnḫ
 U+13ACB	kEH_UniK	HJ E110A
@@ -20585,14 +20586,14 @@ U+13ACF	kEH_IFAO	136,10
 U+13AD0	kEH_Cat	E-17-027
 U+13AD0	kEH_Core	C
 U+13AD0	kEH_Desc	A lion, standing, tail downwards (E22), wearing the double crown (S5).
-U+13AD0	kEH_Func	Logogram/phonemogram (King of UE and LE, lord)
+U+13AD0	kEH_Func	Logogram/phonemogram (king of Upper Egypt and Lower Egypt, lord)
 U+13AD0	kEH_FVal	n(.y)-sw.t-bꞽ.ty nb
 U+13AD0	kEH_UniK	HJ E116
 U+13AD0	kEH_JSesh	E116
 U+13AD0	kEH_HG	E116
 U+13AD1	kEH_Cat	E-17-030
 U+13AD1	kEH_Core	C
-U+13AD1	kEH_Desc	A lion, standing, tail downwards (E22), with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on its head.
+U+13AD1	kEH_Desc	A lion, standing, tail downwards (E22), with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on its head.
 U+13AD1	kEH_Func	Logogram (in the construction sꜣ-rꜥ nb ḫꜥ.w)
 U+13AD1	kEH_FVal	rꜥ + nb
 U+13AD1	kEH_UniK	E116A
@@ -20629,7 +20630,7 @@ U+13AD5	kEH_FVal	n
 U+13AD5	kEH_UniK	E118A
 U+13AD6	kEH_Cat	E-17-043
 U+13AD6	kEH_Core	C
-U+13AD6	kEH_Desc	A lion, standing, tail in the form of a cobra (Naja haje), standing up, with expanded hood (Uraeus).
+U+13AD6	kEH_Desc	A lion, standing, tail in the form of a cobra (Naja haje), standing up, with expanded hood (uraeus).
 U+13AD6	kEH_Func	Classifier divinity
 U+13AD6	kEH_FVal	twtw
 U+13AD6	kEH_UniK	E312
@@ -20668,7 +20669,7 @@ U+13ADA	kEH_FVal	kr
 U+13ADA	kEH_UniK	E302
 U+13ADB	kEH_Cat	E-17-052
 U+13ADB	kEH_Core	C
-U+13ADB	kEH_Desc	A lion, lying down, tail curled over the body towards the back, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on its head, with a wide cup (W10) on the front paw.
+U+13ADB	kEH_Desc	A lion, lying down, tail curled over the body towards the back, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on its head, with a wide cup (W10) on the front paw.
 U+13ADB	kEH_Func	Logogram (Re)
 U+13ADB	kEH_FVal	rꜥ
 U+13ADB	kEH_UniK	HJ E120A
@@ -20681,7 +20682,7 @@ U+13ADC	kEH_HG	E124
 U+13ADD	kEH_Cat	E-17-055
 U+13ADD	kEH_Core	C
 U+13ADD	kEH_Desc	A lion, lying down, tail curled over the body towards the back, on top of a standard used for the carrying of religious symbols (R12).
-U+13ADD	kEH_Func	Logogram (Matit, Goddess of 12th nome of Upper Egypt)
+U+13ADD	kEH_Func	Logogram (Matit, goddess of 12th nome of Upper Egypt)
 U+13ADD	kEH_FVal	mꜣt.yt
 U+13ADD	kEH_UniK	HJ E127
 U+13ADD	kEH_JSesh	E127
@@ -20689,14 +20690,14 @@ U+13ADD	kEH_HG	E127
 U+13ADE	kEH_Cat	E-17-058
 U+13ADE	kEH_Core	C
 U+13ADE	kEH_Desc	A lion, lying down, tail curled over the body towards the back, rear half enclosed in a rectangle which is open at the front.
-U+13ADE	kEH_Func	Logogram (door-bolt)
+U+13ADE	kEH_Func	Logogram (door bolt)
 U+13ADE	kEH_FVal	ḥkn
 U+13ADE	kEH_UniK	HJ E125
 U+13ADE	kEH_JSesh	E125
 U+13ADE	kEH_HG	E125
 U+13ADF	kEH_Cat	E-17-060
 U+13ADF	kEH_Core	C
-U+13ADF	kEH_Desc	A lion, lying down, tail curled over the body towards the back, with the sun-disk (N5) on its back.
+U+13ADF	kEH_Desc	A lion, lying down, tail curled over the body towards the back, with the sun disk (N5) on its back.
 U+13ADF	kEH_Func	Logogram (every day)
 U+13ADF	kEH_FVal	rꜥ-nb
 U+13ADF	kEH_UniK	HJ E242
@@ -20712,7 +20713,7 @@ U+13AE0	kEH_JSesh	E266
 U+13AE0	kEH_HG	E266
 U+13AE1	kEH_Cat	E-17-063
 U+13AE1	kEH_Core	C
-U+13AE1	kEH_Desc	A lion, lying down, tail curled over the body towards the back, with a pole/staff with the head of a falcon with the sun-disk on the head; on the front paw of the lion.
+U+13AE1	kEH_Desc	A lion, lying down, tail curled over the body towards the back, with a pole/staff with the head of a falcon with the sun disk on the head; on the front paw of the lion.
 U+13AE1	kEH_Func	Phonemogram
 U+13AE1	kEH_FVal	nb-ḫpš
 U+13AE1	kEH_UniK	E295
@@ -20774,7 +20775,7 @@ U+13AE9	kEH_UniK	E035B
 U+13AEA	kEH_Cat	E-20-011
 U+13AEA	kEH_Core	C
 U+13AEA	kEH_Desc	A hamadryas baboon (Papio hamadryas), seated, arms forward, holding an eye, with the markings of the head of a falcon (D10).
-U+13AEA	kEH_Func	Logogram (King (of UE))
+U+13AEA	kEH_Func	Logogram (king (of Upper Egypt))
 U+13AEA	kEH_FVal	n(.y)-sw.t
 U+13AEA	kEH_UniK	E036B
 U+13AEA	kEH_JSesh	E36
@@ -20818,7 +20819,7 @@ U+13AEE	kEH_IFAO	138,12
 U+13AEF	kEH_Cat	E-20-017
 U+13AEF	kEH_Core	C
 U+13AEF	kEH_Desc	A hamadryas baboon (Papio hamadryas), seated, arms forward, holding a palm branch, stripped of leaves and notched with a round notch, with the notch towards the body.
-U+13AEF	kEH_Func	Logogram (new years day)
+U+13AEF	kEH_Func	Logogram (New Year's Day)
 U+13AEF	kEH_FVal	wp-rnp.t
 U+13AEF	kEH_UniK	E040A
 U+13AEF	kEH_IFAO	138,13
@@ -20920,7 +20921,7 @@ U+13AFD	kEH_HG	E50
 U+13AFD	kEH_IFAO	139,9
 U+13AFE	kEH_Cat	E-20-042
 U+13AFE	kEH_Core	C
-U+13AFE	kEH_Desc	A hamadryas baboon (Papio hamadryas), seated, with a cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64) on its head.
+U+13AFE	kEH_Desc	A hamadryas baboon (Papio hamadryas), seated, with a cobra (Naja haje), standing up, with expanded hood (uraeus) (I64) on its head.
 U+13AFE	kEH_Func	Logogram (lady of writing)
 U+13AFE	kEH_FVal	nb.t-sš
 U+13AFE	kEH_UniK	HJ E194
@@ -20928,7 +20929,7 @@ U+13AFE	kEH_JSesh	E194
 U+13AFE	kEH_HG	E194
 U+13AFF	kEH_Cat	E-20-045
 U+13AFF	kEH_Core	C
-U+13AFF	kEH_Desc	A hamadryas baboon (Papio hamadryas), seated, arms forward, holding a spiral, winding counterclockwise away from its central point, ending at the right lower corner after about one and a half turns(Z7).
+U+13AFF	kEH_Desc	A hamadryas baboon (Papio hamadryas), seated, arms forward, holding a spiral, winding counterclockwise away from its central point, ending at the right lower corner after about one and a half turns (Z7).
 U+13AFF	kEH_Func	Phonemogram
 U+13AFF	kEH_FVal	t
 U+13AFF	kEH_UniK	E301
@@ -21011,7 +21012,7 @@ U+13B09	kEH_IFAO	140,10
 U+13B0A	kEH_Cat	E-20-061
 U+13B0A	kEH_Core	C
 U+13B0A	kEH_Desc	A baboon, standing on its hind legs, tail down, arms extended forwards, holding a palm branch, stripped of leaves, with multiple sharp notches (M4A), on top of a half round loaf of bread (X1), with the curve outwards.
-U+13B0A	kEH_Func	Logogram (new years day)
+U+13B0A	kEH_Func	Logogram (New Year's Day)
 U+13B0A	kEH_FVal	wp-rnp.t
 U+13B0A	kEH_UniK	E061A
 U+13B0B	kEH_Cat	E-20-063
@@ -21023,7 +21024,7 @@ U+13B0B	kEH_JSesh	E63
 U+13B0B	kEH_HG	E63
 U+13B0C	kEH_Cat	E-20-064
 U+13B0C	kEH_Core	C
-U+13B0C	kEH_Desc	Two baboon, standing on their hind legs, tail down, facing each other, arms extended forwards, left forearm horizontal, holding the same windpipe and heart, with a single horizontal stroke at the top (F35), with the right arm angled upwards with the hand near the tops stroke.
+U+13B0C	kEH_Desc	Two baboons, standing on their hind legs, tail down, facing each other, arms extended forwards, left forearm horizontal, holding the same windpipe and heart, with a single horizontal stroke at the top (F35), with the right arm angled upwards with the hand near the tops stroke.
 U+13B0C	kEH_Func	Phonemogram
 U+13B0C	kEH_FVal	nfr.w
 U+13B0C	kEH_UniK	E063B
@@ -21107,7 +21108,7 @@ U+13B16	kEH_HG	E151
 U+13B16	kEH_IFAO	141,6
 U+13B17	kEH_Cat	E-22-006
 U+13B17	kEH_Core	C
-U+13B17	kEH_Desc	 A lion, lying down, with the face of a man, with a long, curved beard and coif, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)) on its head. 
+U+13B17	kEH_Desc	 A lion, lying down, with the face of a man, with a long, curved beard and coif, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)) on its head. 
 U+13B17	kEH_Func	Logogram rꜥ and nb (in sꜣ-rꜥ nb ḫꜥ.w)
 U+13B17	kEH_FVal	rꜥ nb
 U+13B17	kEH_UniK	HJ E153
@@ -21116,8 +21117,8 @@ U+13B17	kEH_HG	E153
 U+13B17	kEH_IFAO	141,10
 U+13B18	kEH_Cat	E-22-008
 U+13B18	kEH_Core	C
-U+13B18	kEH_Desc	A lion, lying down, with the face of a man, with a long, curved beard and coif, with the sun, with a cobra (Naja haje), standing up, with expanded hood (Uraeus) at either side (N6B), on its head.
-U+13B18	kEH_Func	Logogram (King of UE and LE, lord)
+U+13B18	kEH_Desc	A lion, lying down, with the face of a man, with a long, curved beard and coif, with the sun, with a cobra (Naja haje), standing up, with expanded hood (uraeus) at either side (N6B), on its head.
+U+13B18	kEH_Func	Logogram (king of Upper Egypt and Lower Egypt, lord)
 U+13B18	kEH_FVal	n(.y)-sw.t-bꞽ.ty-nb
 U+13B18	kEH_UniK	HJ E156
 U+13B18	kEH_JSesh	E156
@@ -21133,7 +21134,7 @@ U+13B19	kEH_HG	E154
 U+13B19	kEH_IFAO	141,11
 U+13B1A	kEH_Cat	E-22-012
 U+13B1A	kEH_Core	C
-U+13B1A	kEH_Desc	 A lion, lying down, with the face of a man, with a long, curved beard and coif (E151A), with a tie or strap, used with sandals (ankh-sign, S34) on its front paw.
+U+13B1A	kEH_Desc	 A lion, lying down, with the face of a man, with a long, curved beard and coif (E151A), with a tie or strap, used with sandals (ankh sign, S34) on its front paw.
 U+13B1A	kEH_Func	Logogram (living image)
 U+13B1A	kEH_FVal	šsp-ꜥnḫ
 U+13B1A	kEH_UniK	HJ E157A
@@ -21142,7 +21143,7 @@ U+13B1A	kEH_HG	E157A
 U+13B1A	kEH_IFAO	141,13
 U+13B1B	kEH_Cat	E-22-013
 U+13B1B	kEH_Core	C
-U+13B1B	kEH_Desc	 A lion, lying down, with the face of a man, with a long, curved beard and coif, with an uraeus on its forehead (E151), with a tie or strap, used with sandals (ankh-sign, S34) on its front paw.
+U+13B1B	kEH_Desc	 A lion, lying down, with the face of a man, with a long, curved beard and coif, with an uraeus on its forehead (E151), with a tie or strap, used with sandals (ankh sign, S34) on its front paw.
 U+13B1B	kEH_Func	Logogram (living image)
 U+13B1B	kEH_FVal	šsp-ꜥnḫ
 U+13B1B	kEH_UniK	HJ E157
@@ -21227,7 +21228,7 @@ U+13B26	kEH_UniK	E259B
 U+13B27	kEH_Cat	E-22-041
 U+13B27	kEH_Core	C
 U+13B27	kEH_Desc	The forepart of a sphinx.
-U+13B27	kEH_Func	Classifier Divinity Aker
+U+13B27	kEH_Func	Classifier divinity Aker
 U+13B27	kEH_FVal	ꜣkr
 U+13B27	kEH_UniK	HJ C274A
 U+13B27	kEH_JSesh	C274A
@@ -21235,7 +21236,7 @@ U+13B27	kEH_HG	C274A
 U+13B28	kEH_Cat	E-22-042
 U+13B28	kEH_Core	C
 U+13B28	kEH_Desc	Two foreparts of sphinxes, connected back-to-back.
-U+13B28	kEH_Func	Classifier Divinity Aker
+U+13B28	kEH_Func	Classifier divinity Aker
 U+13B28	kEH_FVal	ꜣkr
 U+13B28	kEH_UniK	HJ C274B
 U+13B28	kEH_JSesh	C274B
@@ -21286,7 +21287,7 @@ U+13B2E	kEH_HG	E169
 U+13B2E	kEH_IFAO	143,5
 U+13B2F	kEH_Cat	E-23-018
 U+13B2F	kEH_Core	C
-U+13B2F	kEH_Desc	A bovid (bull), standing, with a folded piece of cloth around its neck (V60), with a headdress consisting of a sun-disk with two feathers (S76) between its horns.
+U+13B2F	kEH_Desc	A bovid (bull), standing, with a folded piece of cloth around its neck (V60), with a headdress consisting of a sun disk with two feathers (S76) between its horns.
 U+13B2F	kEH_Func	Classifier bull (specifically in kꜣ-ḥḏ (the (sacred) white bull)
 U+13B2F	kEH_FVal	kꜣ
 U+13B2F	kEH_UniK	HJ E171
@@ -21384,7 +21385,7 @@ U+13B3B	kEH_FVal	sꞽd-tꜣ
 U+13B3B	kEH_UniK	E315
 U+13B3C	kEH_Cat	E-23-036
 U+13B3C	kEH_Core	C
-U+13B3C	kEH_Desc	A bull, standing, head lowered, tail down, left front leg bend, with a line running from the left front leg hoof over the head of the bull.
+U+13B3C	kEH_Desc	A bull, standing, head lowered, tail down, left front leg bent, with a line running from the left front leg hoof over the head of the bull.
 U+13B3C	kEH_Func	Classifier prepare to attack
 U+13B3C	kEH_FVal	ṯwn
 U+13B3C	kEH_UniK	HJ E165
@@ -21397,7 +21398,7 @@ U+13B3D	kEH_HG	E199A
 U+13B3E	kEH_Cat	E-23-040
 U+13B3E	kEH_Core	C
 U+13B3E	kEH_Desc	A pustule or gland, or a packet of mummy bandages (Aa2), in front of a bovid (bull), standing (E1); on top of a standard used for the carrying of religious symbols (R12).
-U+13B3E	kEH_Func	Logogram (11th nome of LE)
+U+13B3E	kEH_Func	Logogram (11th nome of Lower Egypt)
 U+13B3E	kEH_FVal	ḥsbw
 U+13B3E	kEH_UniK	HJ E201
 U+13B3E	kEH_JSesh	E201
@@ -21405,13 +21406,13 @@ U+13B3E	kEH_HG	E201
 U+13B3F	kEH_Cat	E-23-042
 U+13B3F	kEH_Core	C
 U+13B3F	kEH_Desc	The hill country over the edge of the cultivated areas (N25) in front of a bovid (bull), standing (E1), on top of a standard used for the carrying of religious symbols (R12).
-U+13B3F	kEH_Func	Logogram (6th nome of LE)
+U+13B3F	kEH_Func	Logogram (6th nome of Lower Egypt)
 U+13B3F	kEH_FVal	ḫꜣsw.w
 U+13B3F	kEH_UniK	E207A
 U+13B40	kEH_Cat	E-23-043
 U+13B40	kEH_Core	C
 U+13B40	kEH_Desc	The hill country over the edge of the cultivated areas (N25) in front of a bovid (bull), standing (E1), on top of a standard used for the carrying of religious symbols (R12) on top of a parcel of land with irrigation ditches (N24).
-U+13B40	kEH_Func	Logogram (6th nome of LE)
+U+13B40	kEH_Func	Logogram (6th nome of Lower Egypt)
 U+13B40	kEH_FVal	ḫꜣsw.w
 U+13B40	kEH_UniK	HJ E207
 U+13B40	kEH_JSesh	E207
@@ -21427,7 +21428,7 @@ U+13B41	kEH_HG	E209
 U+13B42	kEH_Cat	E-23-045
 U+13B42	kEH_Core	C
 U+13B42	kEH_Desc	The head of a human man, seen in profile, with a short straight beard, in front of a bovid (bull), standing (E1), on top of a standard used for the carrying of religious symbols (R12).
-U+13B42	kEH_Func	Logogram (12th nome of LE)
+U+13B42	kEH_Func	Logogram (12th nome of Lower Egypt)
 U+13B42	kEH_FVal	ṯb-nṯr
 U+13B42	kEH_UniK	HJ E210
 U+13B42	kEH_JSesh	E210
@@ -21494,7 +21495,7 @@ U+13B49	kEH_JSesh	E95
 U+13B49	kEH_HG	E95
 U+13B4A	kEH_Cat	E-23-076
 U+13B4A	kEH_Core	C
-U+13B4A	kEH_Desc	A bovid, standing, tail down, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)), between the horns, with the uraeus occurring in front of the horns. 
+U+13B4A	kEH_Desc	A bovid, standing, tail down, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)), between the horns, with the uraeus occurring in front of the horns. 
 U+13B4A	kEH_Func	Logogram (Re and lord (in sꜣ-rꜥ nb ḫꜥ.w))
 U+13B4A	kEH_FVal	rꜥ nb
 U+13B4A	kEH_UniK	E095C
@@ -21514,7 +21515,7 @@ U+13B4C	kEH_HG	E255
 U+13B4D	kEH_Cat	E-23-083
 U+13B4D	kEH_Core	C
 U+13B4D	kEH_Desc	A bovid, standing, tail down, with the double crown (S5) between the horns.
-U+13B4D	kEH_Func	Logogram (King of UE and LE, lord)
+U+13B4D	kEH_Func	Logogram (king of Upper Egypt and Lower Egypt, lord)
 U+13B4D	kEH_FVal	n(.y)-sw.t bꞽ.ty nb
 U+13B4D	kEH_UniK	E280A
 U+13B4E	kEH_Cat	E-23-084
@@ -21527,7 +21528,7 @@ U+13B4E	kEH_JSesh	E100A
 U+13B4E	kEH_HG	E100A
 U+13B4F	kEH_Cat	E-23-087
 U+13B4F	kEH_Core	C
-U+13B4F	kEH_Desc	A bovid, lying down, legs folded beneath the body, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus)), between the horns, with the uraeus occurring in front of the horns. 
+U+13B4F	kEH_Desc	A bovid, lying down, legs folded beneath the body, with N6 (The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus)), between the horns, with the uraeus occurring in front of the horns. 
 U+13B4F	kEH_Func	Logogram (Re and lord (in sꜣ-rꜥ nb ḫꜥ.w))
 U+13B4F	kEH_FVal	rꜥ nb
 U+13B4F	kEH_UniK	E102D
@@ -21541,7 +21542,7 @@ U+13B50	kEH_JSesh	E101A
 U+13B50	kEH_HG	E101A
 U+13B51	kEH_Cat	E-23-090
 U+13B51	kEH_Core	C
-U+13B51	kEH_Desc	A cult image of a bovid (cow), lying down, with a sun-disk (N5) between the horns, with a flagellum (S45) on its back.
+U+13B51	kEH_Desc	A cult image of a bovid (cow), lying down, with a sun disk (N5) between the horns, with a flagellum (S45) on its back.
 U+13B51	kEH_Func	Classifier cow divinity
 U+13B51	kEH_FVal	ḥs(ꜣ).t
 U+13B51	kEH_UniK	HJ E102A
@@ -21560,7 +21561,7 @@ U+13B53	kEH_UniK	E099A
 U+13B54	kEH_Cat	E-23-095
 U+13B54	kEH_Core	C
 U+13B54	kEH_Desc	A piece of crocodile skin with horizontal spines, or tail of a crocodile (I6), in front of a bovid (bull), standing (E1); on top of a standard used for the carrying of religious symbols (R12).
-U+13B54	kEH_Func	Logogram (10th nome of LE)
+U+13B54	kEH_Func	Logogram (10th nome of Lower Egypt)
 U+13B54	kEH_FVal	km-wr
 U+13B54	kEH_UniK	HJ E290
 U+13B54	kEH_JSesh	E290
@@ -21572,7 +21573,7 @@ U+13B55	kEH_HG	E291
 U+13B56	kEH_Cat	E-23-097
 U+13B56	kEH_Core	C
 U+13B56	kEH_Desc	A newborn bubalis antelope, lying down, legs folded beneath the body, long tail downwards (E9), in front of a bovid (bull), standing (E1); on top of a standard used for the carrying of religious symbols (R12).
-U+13B56	kEH_Func	Logogram (12th nome of LE)
+U+13B56	kEH_Func	Logogram (12th nome of Lower Egypt)
 U+13B56	kEH_FVal	ṯb-nṯr
 U+13B56	kEH_UniK	HJ E254
 U+13B56	kEH_JSesh	E254
@@ -21637,7 +21638,7 @@ U+13B5E	kEH_HG	F55
 U+13B5E	kEH_IFAO	146,5
 U+13B5F	kEH_Cat	F-01-007
 U+13B5F	kEH_Core	C
-U+13B5F	kEH_Desc	The forepart of a donkey, ears in a V-shape, lower leg bend backwards.
+U+13B5F	kEH_Desc	The forepart of a donkey, ears in a V-shape, lower leg bent backwards.
 U+13B5F	kEH_Func	Phonemogram
 U+13B5F	kEH_FVal	hrw
 U+13B5F	kEH_UniK	HJ F054
@@ -21669,7 +21670,7 @@ U+13B62	kEH_HG	F7C
 U+13B62	kEH_IFAO	146,6
 U+13B63	kEH_Cat	F-02-006
 U+13B63	kEH_Core	C
-U+13B63	kEH_Desc	The head of a ram (Ovis longipes palaeo-aegyptiacus), with beard, with a sun-disk (N5) on top of the horns.
+U+13B63	kEH_Desc	The head of a ram (Ovis longipes palaeo-aegyptiacus), with beard, with a sun disk (N5) on top of the horns.
 U+13B63	kEH_Func	Classifier worth, dignity, renown
 U+13B63	kEH_FVal	šf.y
 U+13B63	kEH_UniK	HJ F007A
@@ -21686,7 +21687,7 @@ U+13B64	kEH_HG	F164
 U+13B65	kEH_Cat	F-02-008
 U+13B65	kEH_Core	C
 U+13B65	kEH_Desc	The head of a ram (Ovis longipes palaeo-aegyptiacus), with beard, with the Atef crown (S8A) on top of the horns.
-U+13B65	kEH_Func	Classifier (atef crown)
+U+13B65	kEH_Func	Classifier (Atef crown)
 U+13B65	kEH_FVal	ꜣtf
 U+13B65	kEH_UniK	F164A
 U+13B66	kEH_Cat	F-02-010
@@ -21739,7 +21740,7 @@ U+13B6B	kEH_JSesh	F1A
 U+13B6B	kEH_HG	F1A
 U+13B6C	kEH_Cat	F-03-006
 U+13B6C	kEH_Core	C
-U+13B6C	kEH_Desc	The head of a bovid (bull), angled forward as if to attack with a cobra (Naja haje), standing up, with expanded hood (Uraeus), between its horns.
+U+13B6C	kEH_Desc	The head of a bovid (bull), angled forward as if to attack with a cobra (Naja haje), standing up, with expanded hood (uraeus), between its horns.
 U+13B6C	kEH_Func	Classifier rage/aggression
 U+13B6C	kEH_FVal	ḏnd
 U+13B6C	kEH_UniK	HJ F002A
@@ -22024,7 +22025,7 @@ U+13B90	kEH_JSesh	F154
 U+13B90	kEH_HG	F154
 U+13B91	kEH_Cat	F-08-010
 U+13B91	kEH_Core	C
-U+13B91	kEH_Desc	The forepart of a lion, lying down (F4), wearing a headdress consisting of two feathers on top of the horns of a ram, with a cobra (Naja haje), standing up, with expanded hood (Uraeus), with sun disks its head on either side of the feathers, orientated outwards (S74).
+U+13B91	kEH_Desc	The forepart of a lion, lying down (F4), wearing a headdress consisting of two feathers on top of the horns of a ram, with a cobra (Naja haje), standing up, with expanded hood (uraeus), with sun disks its head on either side of the feathers, orientated outwards (S74).
 U+13B91	kEH_Func	Logogram (to distinguish) and (beginning, front)
 U+13B91	kEH_FVal	ṯnꞽ ḥꜣ.t
 U+13B91	kEH_UniK	HJ F092
@@ -22051,7 +22052,7 @@ U+13B93	kEH_HG	E128
 U+13B93	kEH_IFAO	153,8
 U+13B94	kEH_Cat	F-08-015
 U+13B94	kEH_Core	C
-U+13B94	kEH_Desc	Two foreparts of lions, lying down, connected back-to-back, with a sun-disk (N5) on their back.
+U+13B94	kEH_Desc	Two foreparts of lions, lying down, connected back-to-back, with a sun disk (N5) on their back.
 U+13B94	kEH_Func	Logogram (Khonsu)
 U+13B94	kEH_FVal	ḫnsw
 U+13B94	kEH_UniK	HJ E129
@@ -22111,7 +22112,7 @@ U+13B9B	kEH_HG	F98D
 U+13B9B	kEH_IFAO	153,14
 U+13B9C	kEH_Cat	F-09-006
 U+13B9C	kEH_Core	C
-U+13B9C	kEH_Desc	A sledge with the forepart of a donkey/ass, with two legs, one raised, one bend backwards.
+U+13B9C	kEH_Desc	A sledge with the forepart of a donkey/ass, with two legs, one raised, one bent backwards.
 U+13B9C	kEH_Func	Phonemogram
 U+13B9C	kEH_FVal	ḫntš
 U+13B9C	kEH_UniK	HJ F097B
@@ -22172,7 +22173,7 @@ U+13BA3	kEH_IFAO	148,13
 U+13BA4	kEH_Cat	F-11-007
 U+13BA4	kEH_Core	C
 U+13BA4	kEH_Desc	A palm branch, stripped of leaves and notched with a round notch (M4), written within the horns of a bovid (F13), on top of an alabaster basin with a diamond shaped inner marking (W3).
-U+13BA4	kEH_Func	Logogram (new years day)
+U+13BA4	kEH_Func	Logogram (New Year's Day)
 U+13BA4	kEH_FVal	wp-rnp.t
 U+13BA4	kEH_UniK	HJ F173
 U+13BA4	kEH_JSesh	F173
@@ -22180,7 +22181,7 @@ U+13BA4	kEH_HG	F173
 U+13BA5	kEH_Cat	F-11-009
 U+13BA5	kEH_Core	C
 U+13BA5	kEH_Desc	A palm branch, stripped of leaves, with multiple sharp notches (M4A), written within the horns of a bovid (F13). 
-U+13BA5	kEH_Func	Logogram (new years day)
+U+13BA5	kEH_Func	Logogram (New Year's Day)
 U+13BA5	kEH_FVal	wp-rnp.t
 U+13BA5	kEH_UniK	HJ F014A
 U+13BA5	kEH_JSesh	F14A
@@ -22188,7 +22189,7 @@ U+13BA5	kEH_HG	F14A
 U+13BA5	kEH_IFAO	155,1
 U+13BA6	kEH_Cat	F-11-011
 U+13BA6	kEH_Core	C
-U+13BA6	kEH_Desc	A large sun-disk (N5), written within the horns of a bovid (F13). 
+U+13BA6	kEH_Desc	A large sun disk (N5), written within the horns of a bovid (F13). 
 U+13BA6	kEH_Func	Phonemogram (commonly in wp-rnp.t)
 U+13BA6	kEH_FVal	wp
 U+13BA6	kEH_UniK	HJ F102
@@ -22308,7 +22309,7 @@ U+13BB7	kEH_JSesh	F178
 U+13BB7	kEH_HG	F178
 U+13BB8	kEH_Cat	F-19-001
 U+13BB8	kEH_Core	C
-U+13BB8	kEH_Desc	The leg and hoof of a bovid (ox), bend at the top.
+U+13BB8	kEH_Desc	The leg and hoof of a bovid (ox), bent at the top.
 U+13BB8	kEH_Func	Phonemogram
 U+13BB8	kEH_FVal	sḳr
 U+13BB8	kEH_UniK	HJ F025A
@@ -22335,7 +22336,7 @@ U+13BBB	kEH_HG	F119
 U+13BBB	kEH_IFAO	159,14
 U+13BBC	kEH_Cat	F-19-017
 U+13BBC	kEH_Core	C
-U+13BBC	kEH_Desc	The leg and hoof of a bovid (ox), bend at the ankle.
+U+13BBC	kEH_Desc	The leg and hoof of a bovid (ox), bent at the ankle.
 U+13BBC	kEH_Func	Phonemogram
 U+13BBC	kEH_FVal	sḳr
 U+13BBC	kEH_UniK	HJ F114
@@ -22781,7 +22782,7 @@ U+13BF3	kEH_HG	F42B
 U+13BF3	kEH_IFAO	168,12
 U+13BF4	kEH_Cat	F-26-011
 U+13BF4	kEH_Core	C
-U+13BF4	kEH_Desc	A vertebrae.
+U+13BF4	kEH_Desc	A vertebra.
 U+13BF4	kEH_UniK	F043A
 U+13BF5	kEH_Cat	F-26-015
 U+13BF5	kEH_Core	C
@@ -22819,7 +22820,7 @@ U+13BF8	kEH_JSesh	F161
 U+13BF8	kEH_HG	F161
 U+13BF9	kEH_Cat	F-27-009
 U+13BF9	kEH_Core	C
-U+13BF9	kEH_Desc	A leg bone with heat, angled with the bone forward, with a piece of meat missing at the front.
+U+13BF9	kEH_Desc	A leg bone with meat, angled with the bone forward, with a piece of meat missing at the front.
 U+13BF9	kEH_UniK	HJ F141
 U+13BF9	kEH_JSesh	F141
 U+13BF9	kEH_HG	F141
@@ -22984,7 +22985,7 @@ U+13C0D	kEH_IFAO	171,6
 U+13C0E	kEH_Cat	G-04-002
 U+13C0E	kEH_Core	C
 U+13C0E	kEH_Desc	A pintail duck (Anas acuta), with a dotted circle around its head.
-U+13C0E	kEH_Func	Logogram (to tremble
+U+13C0E	kEH_Func	Logogram (to tremble)
 U+13C0E	kEH_FVal	sdꜣ
 U+13C0E	kEH_UniK	HJ G068
 U+13C0E	kEH_JSesh	G68
@@ -23110,7 +23111,7 @@ U+13C1E	kEH_HG	G76
 U+13C1E	kEH_IFAO	175,4
 U+13C1F	kEH_Cat	G-05-021
 U+13C1F	kEH_Core	C
-U+13C1F	kEH_Desc	Three ducks or geese, without wings, standing, overlapping each other vertically, rotated 90° degree.
+U+13C1F	kEH_Desc	Three ducks or geese, without wings, standing, overlapping each other vertically, rotated 90 degree.
 U+13C1F	kEH_Func	Phonemogram
 U+13C1F	kEH_FVal	ḥtr
 U+13C1F	kEH_UniK	HJ G076A
@@ -23119,7 +23120,7 @@ U+13C1F	kEH_HG	G76A
 U+13C1F	kEH_IFAO	175,5
 U+13C20	kEH_Cat	G-05-023
 U+13C20	kEH_Core	C
-U+13C20	kEH_Desc	Three ducks or geese, both wings above the body, standing, overlapping each other vertically, rotated 90° degree.
+U+13C20	kEH_Desc	Three ducks or geese, both wings above the body, standing, overlapping each other vertically, rotated 90 degree.
 U+13C20	kEH_Func	Phonemogram
 U+13C20	kEH_FVal	ḥtr
 U+13C20	kEH_UniK	HJ G078
@@ -23552,7 +23553,7 @@ U+13C5A	kEH_FVal	tꜣ
 U+13C5A	kEH_UniK	G321
 U+13C5B	kEH_Cat	G-11-082
 U+13C5B	kEH_Core	C
-U+13C5B	kEH_Desc	A crested ibis (Ibis comata), with a spiral, winding counterclockwise away from its central point, ending at the right lower corner after about one and a half turns(Z7) on its claws.
+U+13C5B	kEH_Desc	A crested ibis (Ibis comata), with a spiral, winding counterclockwise away from its central point, ending at the right lower corner after about one and a half turns (Z7) on its claws.
 U+13C5B	kEH_Func	Phonemogram
 U+13C5B	kEH_FVal	ꜣḫw
 U+13C5B	kEH_UniK	HJ G190
@@ -23690,7 +23691,7 @@ U+13C6B	kEH_JSesh	G287
 U+13C6B	kEH_HG	G287
 U+13C6C	kEH_Cat	G-12-009
 U+13C6C	kEH_Core	C
-U+13C6C	kEH_Desc	A falcon (G5), with a cobra (Naja haje), standing up, with expanded hood (Uraeus), wearing the white crown (I55) at its toe.
+U+13C6C	kEH_Desc	A falcon (G5), with a cobra (Naja haje), standing up, with expanded hood (uraeus), wearing the white crown (I55) at its toe.
 U+13C6C	kEH_Func	Logogram (Horus)
 U+13C6C	kEH_FVal	ḥr
 U+13C6C	kEH_UniK	HJ G285
@@ -23698,7 +23699,7 @@ U+13C6C	kEH_JSesh	G285
 U+13C6C	kEH_HG	G285
 U+13C6D	kEH_Cat	G-12-017
 U+13C6D	kEH_Core	C
-U+13C6D	kEH_Desc	A falcon (G5) with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus) (N6) on its head.
+U+13C6D	kEH_Desc	A falcon (G5) with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus) (N6) on its head.
 U+13C6D	kEH_Func	Logogram (Re-Hor (usually in rꜥ-ḥr-ꜣḫ.ty)
 U+13C6D	kEH_FVal	rꜥ-ḥr
 U+13C6D	kEH_UniK	HJ G009A
@@ -23707,7 +23708,7 @@ U+13C6D	kEH_HG	G9A
 U+13C6D	kEH_IFAO	185,16
 U+13C6E	kEH_Cat	G-12-018
 U+13C6E	kEH_Core	C
-U+13C6E	kEH_Desc	A falcon (G5) with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus) (N6) on its head, with a flagellum (S45) on its shoulder.
+U+13C6E	kEH_Desc	A falcon (G5) with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus) (N6) on its head, with a flagellum (S45) on its shoulder.
 U+13C6E	kEH_Func	Logogram (Re-Hor (usually in rꜥ-ḥr-ꜣḫ.ty)
 U+13C6E	kEH_FVal	rꜥ-ḥr
 U+13C6E	kEH_UniK	HJ G286
@@ -23715,7 +23716,7 @@ U+13C6E	kEH_JSesh	G286
 U+13C6E	kEH_HG	G286
 U+13C6F	kEH_Cat	G-12-022
 U+13C6F	kEH_Core	C
-U+13C6F	kEH_Desc	A falcon (G5) with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus) (N6) on its head, with a tie or strap, used with sandals (ankh-sign, S34) angled forwards, on its toe.
+U+13C6F	kEH_Desc	A falcon (G5) with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus) (N6) on its head, with a tie or strap, used with sandals (ankh sign, S34) angled forwards, on its toe.
 U+13C6F	kEH_Func	Logogram (Re-Hor (usually in rꜥ-ḥr-ꜣḫ.ty)
 U+13C6F	kEH_FVal	rꜥ-ḥr
 U+13C6F	kEH_UniK	HJ G105
@@ -23780,7 +23781,7 @@ U+13C77	kEH_FVal	spd.w
 U+13C77	kEH_UniK	G322
 U+13C78	kEH_Cat	G-12-038
 U+13C78	kEH_Core	C
-U+13C78	kEH_Desc	A falcon (G5), wearing a headdress consisting of a sun-disk between the horns of a bovid, with two plumes on top of the sun-disk (S65/S65A).
+U+13C78	kEH_Desc	A falcon (G5), wearing a headdress consisting of a sun disk between the horns of a bovid, with two plumes on top of the sun disk (S65/S65A).
 U+13C78	kEH_Func	Logogram (the female Horus)
 U+13C78	kEH_FVal	ḥr.t
 U+13C78	kEH_UniK	HJ G108
@@ -23798,7 +23799,7 @@ U+13C79	kEH_HG	G109
 U+13C79	kEH_IFAO	187,3
 U+13C7A	kEH_Cat	G-12-045
 U+13C7A	kEH_Core	C
-U+13C7A	kEH_Desc	A falcon (G5), wearing a headdress consisting of a sun-disk between the horns of a bovid (F102).
+U+13C7A	kEH_Desc	A falcon (G5), wearing a headdress consisting of a sun disk between the horns of a bovid (F102).
 U+13C7A	kEH_Func	Logogram (the female falcon)
 U+13C7A	kEH_FVal	bꞽk.t
 U+13C7A	kEH_UniK	HJ G112
@@ -23806,7 +23807,7 @@ U+13C7A	kEH_JSesh	G112
 U+13C7A	kEH_HG	G112
 U+13C7B	kEH_Cat	G-12-046
 U+13C7B	kEH_Core	C
-U+13C7B	kEH_Desc	A falcon (G5), wearing a headdress consisting of a sun-disk between the horns of a bovid (F102), with a flagellum (S45) on its shoulder.
+U+13C7B	kEH_Desc	A falcon (G5), wearing a headdress consisting of a sun disk between the horns of a bovid (F102), with a flagellum (S45) on its shoulder.
 U+13C7B	kEH_Func	Logogram (goddess)
 U+13C7B	kEH_FVal	nṯr.t
 U+13C7B	kEH_UniK	G112A
@@ -23840,7 +23841,7 @@ U+13C7F	kEH_UniK	G264C
 U+13C80	kEH_Cat	G-12-055
 U+13C80	kEH_Core	C
 U+13C80	kEH_Desc	A feather (H6), in front of a falcon (G5), on top of a standard used for carrying religious symbols, with a loop under the horizontal beam, running over the vertical pole (R12A).
-U+13C80	kEH_Func	Logogram (West, 3rd nome of LE)
+U+13C80	kEH_Func	Logogram (West, 3rd nome of Lower Egypt)
 U+13C80	kEH_FVal	ꞽmn.tt
 U+13C80	kEH_UniK	HJ G264A
 U+13C80	kEH_JSesh	G264A
@@ -23864,7 +23865,7 @@ U+13C82	kEH_HG	G7D
 U+13C82	kEH_IFAO	188,1
 U+13C83	kEH_Cat	G-12-064
 U+13C83	kEH_Core	C
-U+13C83	kEH_Desc	A falcon (G5), wearing a headdress consisting of a sun-disk between the horns of a bovid (F102); on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A). 
+U+13C83	kEH_Desc	A falcon (G5), wearing a headdress consisting of a sun disk between the horns of a bovid (F102); on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A). 
 U+13C83	kEH_Func	Logogram (goddess)
 U+13C83	kEH_FVal	nṯr.t
 U+13C83	kEH_UniK	HJ G114
@@ -23873,7 +23874,7 @@ U+13C83	kEH_HG	G114
 U+13C83	kEH_IFAO	188,4
 U+13C84	kEH_Cat	G-12-065
 U+13C84	kEH_Core	C
-U+13C84	kEH_Desc	A falcon (G5), wearing a headdress consisting of a sun-disk between the horns of a bovid (F102), with a flagellum (S45) on the shoulder, on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A). 
+U+13C84	kEH_Desc	A falcon (G5), wearing a headdress consisting of a sun disk between the horns of a bovid (F102), with a flagellum (S45) on the shoulder, on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A). 
 U+13C84	kEH_Func	Logogram (goddess)
 U+13C84	kEH_FVal	nṯr.t
 U+13C84	kEH_UniK	G114A
@@ -23887,8 +23888,8 @@ U+13C85	kEH_JSesh	G115A
 U+13C85	kEH_HG	G115A
 U+13C86	kEH_Cat	G-12-074
 U+13C86	kEH_Core	C
-U+13C86	kEH_Desc	A tie or strap, used with sandals (ankh-sign, S34), written vertically, in front of a falcon (G5); on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A). 
-U+13C86	kEH_Func	Logogram (May he live, the god)
+U+13C86	kEH_Desc	A tie or strap, used with sandals (ankh sign, S34), written vertically, in front of a falcon (G5); on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A). 
+U+13C86	kEH_Func	Logogram (may he live, the god)
 U+13C86	kEH_FVal	ꜥnḫ-nṯr
 U+13C86	kEH_UniK	HJ G120
 U+13C86	kEH_JSesh	G120
@@ -23937,7 +23938,7 @@ U+13C8B	kEH_IFAO	188,16
 U+13C8C	kEH_Cat	G-12-088
 U+13C8C	kEH_Core	C
 U+13C8C	kEH_Desc	Two falcons (G5), arranged horizontally, on top of a standard used for carrying religious symbols, with a loop under the horizontal beam, running over the vertical pole (R12A).
-U+13C8C	kEH_Func	Logogram (The two gods, 5th nome of UE)
+U+13C8C	kEH_Func	Logogram (The two gods, 5th nome of Upper Egypt)
 U+13C8C	kEH_FVal	nṯr.wy
 U+13C8C	kEH_UniK	G266A
 U+13C8D	kEH_Cat	G-12-090
@@ -23965,7 +23966,7 @@ U+13C8F	kEH_HG	G127F
 U+13C90	kEH_Cat	G-12-104
 U+13C90	kEH_Core	C
 U+13C90	kEH_Desc	A pole of a balance, with the pole resembling a seat (U39A), in front of a falcon (G5), on top of a standard used for carrying religious symbols, with a loop under the horizontal beam, running over the vertical pole (R12A), on top of a parcel of land with irrigation ditches (N24).
-U+13C90	kEH_Func	Logogram (Throne of Horus (Edfu, 2nd nome of UE))
+U+13C90	kEH_Func	Logogram (Throne of Horus (Edfu, 2nd nome of Upper Egypt))
 U+13C90	kEH_FVal	wṯs-ḥr
 U+13C90	kEH_UniK	HJ G127C
 U+13C90	kEH_JSesh	G127C
@@ -23996,8 +23997,8 @@ U+13C93	kEH_UniK	G129E
 U+13C93	kEH_IFAO	190,1
 U+13C94	kEH_Cat	G-12-111
 U+13C94	kEH_Core	C
-U+13C94	kEH_Desc	A falcon (G5) with a flagellum (S45) on its back (G6), with a tie or strap, used with sandals (ankh-sign) in front of it, vertically; on top of a façade of a palace or tomb, with a doorway, without internal detail (O129).
-U+13C94	kEH_Func	Logogram (The living falcon who is on the palace façade)
+U+13C94	kEH_Desc	A falcon (G5) with a flagellum (S45) on its back (G6), with a tie or strap, used with sandals (ankh sign) in front of it, vertically; on top of a façade of a palace or tomb, with a doorway, without internal detail (O129).
+U+13C94	kEH_Func	Logogram (the living falcon who is on the palace façade)
 U+13C94	kEH_FVal	bꞽk ꜥnḫ ḥr.y srḫ
 U+13C94	kEH_UniK	G129F
 U+13C95	kEH_Cat	G-12-114
@@ -24179,7 +24180,7 @@ U+13CAC	kEH_JSesh	G291
 U+13CAC	kEH_HG	G291
 U+13CAD	kEH_Cat	G-13-001
 U+13CAD	kEH_Core	C
-U+13CAD	kEH_Desc	A falcon, standing, with extended wings at either side of the body, at a 45° angle.
+U+13CAD	kEH_Desc	A falcon, standing, with extended wings at either side of the body, at 45 degree.
 U+13CAD	kEH_Func	Logogram (the one who spreads out his wings ((Dewen-anwy) divinity))
 U+13CAD	kEH_FVal	dwn-ꜥn.wy
 U+13CAD	kEH_UniK	HJ G144
@@ -24202,7 +24203,7 @@ U+13CAF	kEH_HG	G145
 U+13CAF	kEH_IFAO	192,2
 U+13CB0	kEH_Cat	G-13-009
 U+13CB0	kEH_Core	C
-U+13CB0	kEH_Desc	A falcon, standing, with extended wings at either side of the body, at a 45° angle, A block-throne with a rectangle in the far bottom corner, on top of a base (Q12).
+U+13CB0	kEH_Desc	A falcon, standing, with extended wings at either side of the body, at 45 degree, A block-throne with a rectangle in the far bottom corner, on top of a base (Q12).
 U+13CB0	kEH_Func	Phonemogram and classifier throne (in ṯnṯꜣ.t)
 U+13CB0	kEH_FVal	ṯꜣ
 U+13CB0	kEH_UniK	HJ G147
@@ -24231,7 +24232,7 @@ U+13CB3	kEH_FVal	sꜣb-šw.t
 U+13CB3	kEH_UniK	G151A
 U+13CB4	kEH_Cat	G-13-017
 U+13CB4	kEH_Core	C
-U+13CB4	kEH_Desc	A falcon, with spread wings that angle downwards and spread legs, head looking towards the reading direction, with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus) (N6) on its head; claws on top of cartouches in a round form (V9), with one handed fans (S37) going from the claw over the wing, at an outwards angle, the head of the fan above the wing, fan curving outwards.
+U+13CB4	kEH_Desc	A falcon, with spread wings that angle downwards and spread legs, head looking towards the reading direction, with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus) (N6) on its head; claws on top of cartouches in a round form (V9), with one handed fans (S37) going from the claw over the wing, at an outwards angle, the head of the fan above the wing, fan curving outwards.
 U+13CB4	kEH_Func	Logogram (many-coloured of plumage)
 U+13CB4	kEH_FVal	sꜣb-šw.t
 U+13CB4	kEH_UniK	HJ G152A
@@ -24249,7 +24250,7 @@ U+13CB5	kEH_HG	G152
 U+13CB5	kEH_IFAO	192,9
 U+13CB6	kEH_Cat	G-13-019
 U+13CB6	kEH_Core	C
-U+13CB6	kEH_Desc	A falcon, with horizontally spread wings and spread legs, head looking towards the reading direction, with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus) (N6) on its head; claws on top of cartouches in a round form (V9), with one handed fans (S37) going from the claw over the wing, at an outwards angle, the head of the fan above the wing, fan curving outwards; on top of a sand covered mountain over the edge of the cultivated areas (N26).
+U+13CB6	kEH_Desc	A falcon, with horizontally spread wings and spread legs, head looking towards the reading direction, with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus) (N6) on its head; claws on top of cartouches in a round form (V9), with one handed fans (S37) going from the claw over the wing, at an outwards angle, the head of the fan above the wing, fan curving outwards; on top of a sand covered mountain over the edge of the cultivated areas (N26).
 U+13CB6	kEH_Func	Logogram (many-coloured of plumage, who goes forth in/from the horizon)
 U+13CB6	kEH_FVal	sꜣb-šw.t-pr-m-ꜣḫ.t
 U+13CB6	kEH_UniK	HJ G153
@@ -24258,7 +24259,7 @@ U+13CB6	kEH_HG	G153
 U+13CB6	kEH_IFAO	192,10
 U+13CB7	kEH_Cat	G-13-020
 U+13CB7	kEH_Core	C
-U+13CB7	kEH_Desc	A falcon, with spread wings that angle downwards and spread legs, head looking towards the reading direction, with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus) (N6) on its head; claws on top of cartouches in a round form (V9), with one handed fans (S37) going from the claw over the wing, at an outwards angle, the head of the fan above the wing, fan curving outwards; written inside the sun-disk of the sun rising over a sand covered mountain over the edge of the cultivated areas (N27). 
+U+13CB7	kEH_Desc	A falcon, with spread wings that angle downwards and spread legs, head looking towards the reading direction, with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus) (N6) on its head; claws on top of cartouches in a round form (V9), with one handed fans (S37) going from the claw over the wing, at an outwards angle, the head of the fan above the wing, fan curving outwards; written inside the sun disk of the sun rising over a sand covered mountain over the edge of the cultivated areas (N27). 
 U+13CB7	kEH_Func	Logogram (many-coloured of plumage, who goes forth in/from the horizon)
 U+13CB7	kEH_FVal	sꜣb-šw.t-pr-m-ꜣḫ.t
 U+13CB7	kEH_UniK	HJ G153A
@@ -24267,7 +24268,7 @@ U+13CB7	kEH_HG	G153A
 U+13CB7	kEH_IFAO	192,11
 U+13CB8	kEH_Cat	G-13-021
 U+13CB8	kEH_Core	C
-U+13CB8	kEH_Desc	A falcon, with spread wings that angle downwards and spread legs, head looking towards the reading direction, written inside the sun-disk of the sun rising over a sand covered mountain over the edge of the cultivated areas (N27). 
+U+13CB8	kEH_Desc	A falcon, with spread wings that angle downwards and spread legs, head looking towards the reading direction, written inside the sun disk of the sun rising over a sand covered mountain over the edge of the cultivated areas (N27). 
 U+13CB8	kEH_Func	Logogram (many-coloured of plumage, who goes forth in/from the horizon)
 U+13CB8	kEH_FVal	sꜣb-šw.t-pr-m-ꜣḫ.t
 U+13CB8	kEH_UniK	G153B
@@ -24289,7 +24290,7 @@ U+13CBB	kEH_HG	G154
 U+13CBB	kEH_IFAO	192,14
 U+13CBC	kEH_Cat	G-13-026
 U+13CBC	kEH_Core	C
-U+13CBC	kEH_Desc	A falcon, standing, with extended wings at either side of the body, at a 45° angle; on top of a standard used for carrying religious symbols (R12).
+U+13CBC	kEH_Desc	A falcon, standing, with extended wings at either side of the body, at 45 degree; on top of a standard used for carrying religious symbols (R12).
 U+13CBC	kEH_Func	Logogram (the one who spreads out his wings ((Dewen-anwy) divinity))
 U+13CBC	kEH_FVal	dwn-ꜥn.wy
 U+13CBC	kEH_UniK	HJ G148
@@ -24301,7 +24302,7 @@ U+13CBD	kEH_JSesh	G260
 U+13CBD	kEH_HG	G260
 U+13CBE	kEH_Cat	G-13-031
 U+13CBE	kEH_Core	C
-U+13CBE	kEH_Desc	A falcon, seen from the side, one wing forwards, horizontal, other wing forwards, at a 45° downward angle, one claw visible below the lower wing.
+U+13CBE	kEH_Desc	A falcon, seen from the side, one wing forwards, horizontal, other wing forwards, at 45 degree downward angle, one claw visible below the lower wing.
 U+13CBE	kEH_Func	Logogram (to protect)
 U+13CBE	kEH_FVal	mkꞽ/ḫwꞽ
 U+13CBE	kEH_UniK	HJ G293
@@ -24513,7 +24514,7 @@ U+13CDB	kEH_HG	G204
 U+13CDB	kEH_IFAO	197,9
 U+13CDC	kEH_Cat	G-18-013
 U+13CDC	kEH_Core	C
-U+13CDC	kEH_Desc	A human headed bird (G53A), wearing a headdress consisting of a sun-disk between the horns of a bovid (F102), with a flagellum (S45) on its shoulder.
+U+13CDC	kEH_Desc	A human headed bird (G53A), wearing a headdress consisting of a sun disk between the horns of a bovid (F102), with a flagellum (S45) on its shoulder.
 U+13CDC	kEH_Func	Logogram (the female falcon)
 U+13CDC	kEH_FVal	bꞽk.t
 U+13CDC	kEH_UniK	HJ G204A
@@ -24522,7 +24523,7 @@ U+13CDC	kEH_HG	G204A
 U+13CDC	kEH_IFAO	197,11
 U+13CDD	kEH_Cat	G-18-014
 U+13CDD	kEH_Core	C
-U+13CDD	kEH_Desc	A human headed bird (G53A), wearing a headdress consisting of a sun-disk between the horns of a bovid (F102), with a flagellum (S45) on its shoulder.
+U+13CDD	kEH_Desc	A human headed bird (G53A), wearing a headdress consisting of a sun disk between the horns of a bovid (F102), with a flagellum (S45) on its shoulder.
 U+13CDD	kEH_Func	Logogram (goddess)
 U+13CDD	kEH_FVal	nṯr.t
 U+13CDD	kEH_UniK	G204B
@@ -24911,7 +24912,7 @@ U+13D0F	kEH_FVal	mw.t-nṯr-nb
 U+13D0F	kEH_UniK	G332
 U+13D10	kEH_Cat	H-01-005
 U+13D10	kEH_Core	C
-U+13D10	kEH_Desc	A staff, with a straight shaft, topped with the head of a falcon, with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus) (N6) on top of the head.
+U+13D10	kEH_Desc	A staff, with a straight shaft, topped with the head of a falcon, with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus) (N6) on top of the head.
 U+13D10	kEH_Func	Logogram (staff)
 U+13D10	kEH_FVal	mdw
 U+13D10	kEH_UniK	HJ H013
@@ -24920,7 +24921,7 @@ U+13D10	kEH_HG	H13
 U+13D10	kEH_IFAO	206,5
 U+13D11	kEH_Cat	H-01-007
 U+13D11	kEH_Core	C
-U+13D11	kEH_Desc	A staff, with a straight shaft and forked end, topped with the head of a falcon, with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus) (N6) on top of the head.
+U+13D11	kEH_Desc	A staff, with a straight shaft and forked end, topped with the head of a falcon, with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus) (N6) on top of the head.
 U+13D11	kEH_Func	Classifier staff
 U+13D11	kEH_FVal	mdw
 U+13D11	kEH_UniK	H014B
@@ -24938,7 +24939,7 @@ U+13D13	kEH_FVal	mdw
 U+13D13	kEH_UniK	H014D
 U+13D14	kEH_Cat	H-01-010
 U+13D14	kEH_Core	C
-U+13D14	kEH_Desc	A spear, with a straight shaft and forked end, topped with the head of a falcon, with a cobra (Naja haje), standing up, with expanded hood (Uraeus) on top of the head, tail descending behind the head; with a triangular spearhead above the snake.
+U+13D14	kEH_Desc	A spear, with a straight shaft and forked end, topped with the head of a falcon, with a cobra (Naja haje), standing up, with expanded hood (uraeus) on top of the head, tail descending behind the head; with a triangular spearhead above the snake.
 U+13D14	kEH_Func	Phonemogram
 U+13D14	kEH_FVal	mdw
 U+13D14	kEH_UniK	HJ H014
@@ -25186,7 +25187,7 @@ U+13D33	kEH_UniK	I005C
 U+13D34	kEH_Cat	I-03-009
 U+13D34	kEH_Core	C
 U+13D34	kEH_Desc	A Nile crocodile (Crocodylus niloticus), with a feather (H6), angled forwards, on its head.
-U+13D34	kEH_Func	Logogram (Iqer, 6th nome of UE)
+U+13D34	kEH_Func	Logogram (Iqer, 6th nome of Upper Egypt)
 U+13D34	kEH_FVal	ꞽḳr
 U+13D34	kEH_UniK	HJ I003A
 U+13D34	kEH_JSesh	I3A
@@ -25201,7 +25202,7 @@ U+13D35	kEH_UniK	I018D
 U+13D36	kEH_Cat	I-03-012
 U+13D36	kEH_Core	C
 U+13D36	kEH_Desc	A Nile crocodile (Crocodylus niloticus), with a feather (H6), angled forwards, on its head, with a spear, arrow without fletching or a harpoon without handle, written vertically, tip downwards on its back; on top of a standard used for carrying religious symbols, with a short vertical pole, with a loop under the horizontal beam, running over the vertical pole (R56).
-U+13D36	kEH_Func	Logogram (Iqer, 6th nome of UE)
+U+13D36	kEH_Func	Logogram (Iqer, 6th nome of Upper Egypt)
 U+13D36	kEH_FVal	ꞽḳr
 U+13D36	kEH_UniK	I106B
 U+13D37	kEH_Cat	I-03-014
@@ -25213,7 +25214,7 @@ U+13D37	kEH_UniK	I106D
 U+13D38	kEH_Cat	I-03-015
 U+13D38	kEH_Core	C
 U+13D38	kEH_Desc	A Nile crocodile (Crocodylus niloticus), with a feather (H6), angled backwards, on its head, and a knife with triangular blade and straight handle (T30A) vertically on its back, blade towards the front; on top of a standard used for carrying religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
-U+13D38	kEH_Func	Logogram (Iqer, 6th nome of UE)
+U+13D38	kEH_Func	Logogram (Iqer, 6th nome of Upper Egypt)
 U+13D38	kEH_FVal	ꞽḳr
 U+13D38	kEH_UniK	HJ I106
 U+13D38	kEH_JSesh	I106
@@ -25300,7 +25301,7 @@ U+13D42	kEH_FVal	sbk
 U+13D42	kEH_UniK	I004B
 U+13D43	kEH_Cat	I-03-045
 U+13D43	kEH_Core	C
-U+13D43	kEH_Desc	A Nile crocodile (Crocodylus niloticus) on top of a shrine (I4), with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus) (N6) on top of its head. 
+U+13D43	kEH_Desc	A Nile crocodile (Crocodylus niloticus) on top of a shrine (I4), with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus) (N6) on top of its head. 
 U+13D43	kEH_Func	Logogram (Sobek-Re (divinity))
 U+13D43	kEH_FVal	sbk-rꜥ
 U+13D43	kEH_UniK	I004C
@@ -25312,7 +25313,7 @@ U+13D44	kEH_FVal	ꞽty
 U+13D44	kEH_UniK	I018E
 U+13D45	kEH_Cat	I-03-047
 U+13D45	kEH_Core	C
-U+13D45	kEH_Desc	A Nile crocodile (Crocodylus niloticus), wearing a headdress consisting of two feathers on top of the horns of a ram, with a cobra (Naja haje), standing up, with expanded hood (Uraeus), with sun disks its head on either side of the feathers, orientated outwards.
+U+13D45	kEH_Desc	A Nile crocodile (Crocodylus niloticus), wearing a headdress consisting of two feathers on top of the horns of a ram, with a cobra (Naja haje), standing up, with expanded hood (uraeus), with sun disks its head on either side of the feathers, orientated outwards.
 U+13D45	kEH_Func	Logogram (Sobek (divinity))
 U+13D45	kEH_FVal	sbk
 U+13D45	kEH_UniK	HJ I018C
@@ -25331,7 +25332,7 @@ U+13D47	kEH_Func	?
 U+13D47	kEH_UniK	I018G
 U+13D48	kEH_Cat	I-03-053
 U+13D48	kEH_Core	C
-U+13D48	kEH_Desc	 Nile crocodile (Crocodylus niloticus), on a base, with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus) (N6) on top of its head.
+U+13D48	kEH_Desc	 Nile crocodile (Crocodylus niloticus), on a base, with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus) (N6) on top of its head.
 U+13D48	kEH_Func	Logogram (Sobek-Re (divinity))
 U+13D48	kEH_FVal	sbk-rꜥ
 U+13D48	kEH_UniK	I018H
@@ -25721,7 +25722,7 @@ U+13D78	kEH_HG	I41
 U+13D78	kEH_IFAO	218,2
 U+13D79	kEH_Cat	I-11-001
 U+13D79	kEH_Core	C
-U+13D79	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus).
+U+13D79	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus).
 U+13D79	kEH_Func	Classifier female divinity
 U+13D79	kEH_UniK	HJ I064
 U+13D79	kEH_JSesh	I64
@@ -25729,7 +25730,7 @@ U+13D79	kEH_HG	I64
 U+13D79	kEH_IFAO	218,3
 U+13D7A	kEH_Cat	I-11-003
 U+13D7A	kEH_Core	C
-U+13D7A	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), on top of a wickerwork basket (V30).
+U+13D7A	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), on top of a wickerwork basket (V30).
 U+13D7A	kEH_Func	Logogram (lady (in nb.ty))
 U+13D7A	kEH_FVal	nb.t
 U+13D7A	kEH_UniK	HJ I013A
@@ -25737,7 +25738,7 @@ U+13D7A	kEH_JSesh	I13A
 U+13D7A	kEH_HG	I13A
 U+13D7B	kEH_Cat	I-11-006
 U+13D7B	kEH_Core	C
-U+13D7B	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), with a forward, downward dotted line coming from the mouth.
+U+13D7B	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), with a forward, downward dotted line coming from the mouth.
 U+13D7B	kEH_Func	Logogram (fire, flame)
 U+13D7B	kEH_FVal	nsr.t
 U+13D7B	kEH_UniK	HJ I043
@@ -25746,14 +25747,14 @@ U+13D7B	kEH_HG	I43
 U+13D7B	kEH_IFAO	218,7
 U+13D7C	kEH_Cat	I-11-007
 U+13D7C	kEH_Core	C
-U+13D7C	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), with three forward, downward lines coming from the mouth.
+U+13D7C	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), with three forward, downward lines coming from the mouth.
 U+13D7C	kEH_Func	Logogram (fire, flame)
 U+13D7C	kEH_FVal	nsr.t
 U+13D7C	kEH_UniK	I043A
 U+13D7D	kEH_Cat	I-11-008
 U+13D7D	kEH_Core	C
-U+13D7D	kEH_Desc	Two cobras (Naja haje), standing up, with expanded hood (Uraeus) (I64), overlapping each other.
-U+13D7D	kEH_Func	Classifier the two Udjat eyes
+U+13D7D	kEH_Desc	Two cobras (Naja haje), standing up, with expanded hood (uraeus) (I64), overlapping each other.
+U+13D7D	kEH_Func	Classifier the two udjat eyes
 U+13D7D	kEH_FVal	wḏꜣ.ty
 U+13D7D	kEH_UniK	HJ I044
 U+13D7D	kEH_JSesh	I44
@@ -25761,7 +25762,7 @@ U+13D7D	kEH_HG	I44
 U+13D7D	kEH_IFAO	218,8
 U+13D7E	kEH_Cat	I-11-009
 U+13D7E	kEH_Core	C
-U+13D7E	kEH_Desc	Three cobras (Naja haje), standing up, with expanded hood (Uraeus) (I64), overlapping each other.
+U+13D7E	kEH_Desc	Three cobras (Naja haje), standing up, with expanded hood (uraeus) (I64), overlapping each other.
 U+13D7E	kEH_Func	Logogram (goddesses)
 U+13D7E	kEH_FVal	nṯr.wt
 U+13D7E	kEH_UniK	HJ I045
@@ -25770,7 +25771,7 @@ U+13D7E	kEH_HG	I45
 U+13D7E	kEH_IFAO	218,9
 U+13D7F	kEH_Cat	I-11-011
 U+13D7F	kEH_Core	C
-U+13D7F	kEH_Desc	Nine cobras (Naja haje), standing up, with expanded hood (Uraeus), in a row, with overlapping bodies.
+U+13D7F	kEH_Desc	Nine cobras (Naja haje), standing up, with expanded hood (uraeus), in a row, with overlapping bodies.
 U+13D7F	kEH_Func	Classifier Ennead
 U+13D7F	kEH_FVal	psḏ.t
 U+13D7F	kEH_UniK	HJ I046
@@ -25788,7 +25789,7 @@ U+13D81	kEH_JSesh	I47A
 U+13D81	kEH_HG	I47A
 U+13D82	kEH_Cat	I-11-016
 U+13D82	kEH_Core	C
-U+13D82	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A). 
+U+13D82	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A). 
 U+13D82	kEH_Func	Logogram (goddess)
 U+13D82	kEH_FVal	nṯr.t
 U+13D82	kEH_UniK	HJ I050
@@ -25797,7 +25798,7 @@ U+13D82	kEH_HG	I50
 U+13D82	kEH_IFAO	218,14
 U+13D83	kEH_Cat	I-11-017
 U+13D83	kEH_Core	C
-U+13D83	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), in front of a half round loaf of bread (X1) above an egg (H8); on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A). 
+U+13D83	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), in front of a half round loaf of bread (X1) above an egg (H8); on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A). 
 U+13D83	kEH_Func	Logogram (goddess)
 U+13D83	kEH_FVal	nṯr.t
 U+13D83	kEH_UniK	HJ I105
@@ -25805,7 +25806,7 @@ U+13D83	kEH_JSesh	I105
 U+13D83	kEH_HG	I105
 U+13D84	kEH_Cat	I-11-018
 U+13D84	kEH_Core	C
-U+13D84	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), on top of standard used for carrying religious symbols, with a loop under the horizontal beam, running over the vertical pole (R12A).
+U+13D84	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), on top of standard used for carrying religious symbols, with a loop under the horizontal beam, running over the vertical pole (R12A).
 U+13D84	kEH_Func	Logogram (goddess)
 U+13D84	kEH_FVal	nṯr.t
 U+13D84	kEH_UniK	HJ I050A
@@ -25822,13 +25823,13 @@ U+13D86	kEH_JSesh	I54
 U+13D86	kEH_HG	I54
 U+13D87	kEH_Cat	I-11-027
 U+13D87	kEH_Core	C
-U+13D87	kEH_Desc	Three cobras (Naja haje), standing up, with expanded hood (Uraeus) (I64), overlapping each other, on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A). 
+U+13D87	kEH_Desc	Three cobras (Naja haje), standing up, with expanded hood (uraeus) (I64), overlapping each other, on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A). 
 U+13D87	kEH_Func	Logogram (goddesses)
 U+13D87	kEH_FVal	nṯr.wt
 U+13D87	kEH_UniK	I053B
 U+13D88	kEH_Cat	I-11-029
 U+13D88	kEH_Core	C
-U+13D88	kEH_Desc	 A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), wearing the white crown (S1).
+U+13D88	kEH_Desc	 A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), wearing the white crown (S1).
 U+13D88	kEH_Func	Classifier uraeus snake
 U+13D88	kEH_FVal	wꜣḏ.t
 U+13D88	kEH_UniK	HJ I055
@@ -25837,7 +25838,7 @@ U+13D88	kEH_HG	I55
 U+13D88	kEH_IFAO	219,6
 U+13D89	kEH_Cat	I-11-030
 U+13D89	kEH_Core	C
-U+13D89	kEH_Desc	 A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), wearing the white crown (S1), on top of a wickerwork basket (V30).
+U+13D89	kEH_Desc	 A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), wearing the white crown (S1), on top of a wickerwork basket (V30).
 U+13D89	kEH_Func	Logogram (lady (in nb.ty))
 U+13D89	kEH_FVal	nb.t
 U+13D89	kEH_UniK	HJ I056
@@ -25846,7 +25847,7 @@ U+13D89	kEH_HG	I56
 U+13D89	kEH_IFAO	219,7
 U+13D8A	kEH_Cat	I-11-033
 U+13D8A	kEH_Core	C
-U+13D8A	kEH_Desc	 A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), wearing the red crown (S3).
+U+13D8A	kEH_Desc	 A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), wearing the red crown (S3).
 U+13D8A	kEH_Func	Phonemogram
 U+13D8A	kEH_FVal	n
 U+13D8A	kEH_UniK	HJ I058
@@ -25855,7 +25856,7 @@ U+13D8A	kEH_HG	I58
 U+13D8A	kEH_IFAO	219,9
 U+13D8B	kEH_Cat	I-11-034
 U+13D8B	kEH_Core	C
-U+13D8B	kEH_Desc	 A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), wearing the red crown (S3), on top of a wickerwork basket (V30).
+U+13D8B	kEH_Desc	 A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), wearing the red crown (S3), on top of a wickerwork basket (V30).
 U+13D8B	kEH_Func	Logogram (lady (in nb.ty))
 U+13D8B	kEH_FVal	nb.t
 U+13D8B	kEH_UniK	HJ I059
@@ -25864,7 +25865,7 @@ U+13D8B	kEH_HG	I59
 U+13D8B	kEH_IFAO	219,10
 U+13D8C	kEH_Cat	I-11-035
 U+13D8C	kEH_Core	C
-U+13D8C	kEH_Desc	Two cobras (Naja haje), standing up, with expanded hood (Uraeus) (I64), overlapping each other, the first cobra wearing the white crown (S1), the second cobra wearing the red crown (S3).
+U+13D8C	kEH_Desc	Two cobras (Naja haje), standing up, with expanded hood (uraeus) (I64), overlapping each other, the first cobra wearing the white crown (S1), the second cobra wearing the red crown (S3).
 U+13D8C	kEH_Func	Classifier the two uraeus snakes
 U+13D8C	kEH_FVal	wꜣḏ.ty
 U+13D8C	kEH_UniK	HJ I060
@@ -25873,7 +25874,7 @@ U+13D8C	kEH_HG	I60
 U+13D8C	kEH_IFAO	219,11
 U+13D8D	kEH_Cat	I-11-042
 U+13D8D	kEH_Core	C
-U+13D8D	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), wearing a headdress consisting of a sun-disk between the horns of a bovid (F102).
+U+13D8D	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), wearing a headdress consisting of a sun disk between the horns of a bovid (F102).
 U+13D8D	kEH_Func	Logogram (Hathor)
 U+13D8D	kEH_FVal	ḥw.t-ḥr
 U+13D8D	kEH_UniK	HJ I062
@@ -25882,14 +25883,14 @@ U+13D8D	kEH_HG	I62
 U+13D8D	kEH_IFAO	219,15
 U+13D8E	kEH_Cat	I-11-043
 U+13D8E	kEH_Core	C
-U+13D8E	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), wearing a headdress consisting of a sun-disk between the horns of a bovid (F102), on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A). 
+U+13D8E	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), wearing a headdress consisting of a sun disk between the horns of a bovid (F102), on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A). 
 U+13D8E	kEH_Func	Logogram (goddess)
 U+13D8E	kEH_FVal	nṯr.t
 U+13D8E	kEH_UniK	I062A
 U+13D8F	kEH_Cat	I-11-045
 U+13D8F	kEH_Core	C
-U+13D8F	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), wearing a headdress consisting of two plumes (S9).
-U+13D8F	kEH_Func	Logogram (Renenoutet)
+U+13D8F	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), wearing a headdress consisting of two plumes (S9).
+U+13D8F	kEH_Func	Logogram (Renenutet)
 U+13D8F	kEH_FVal	rnn.wtt
 U+13D8F	kEH_UniK	HJ I063
 U+13D8F	kEH_JSesh	I63
@@ -25897,19 +25898,19 @@ U+13D8F	kEH_HG	I63
 U+13D8F	kEH_IFAO	220,1
 U+13D90	kEH_Cat	I-11-050
 U+13D90	kEH_Core	C
-U+13D90	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus), with a coiled tail, resembling a sideways number 8.
+U+13D90	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus), with a coiled tail, resembling a sideways number 8.
 U+13D90	kEH_Func	Phonemogram/logogram (to encircle with)
 U+13D90	kEH_FVal	mḥn
 U+13D90	kEH_UniK	I012B
 U+13D91	kEH_Cat	I-11-051
 U+13D91	kEH_Core	C
-U+13D91	kEH_Desc	Two cobras (Naja haje), standing up, with expanded hood (Uraeus), with a coiled tail (I12), overlapping each other.
+U+13D91	kEH_Desc	Two cobras (Naja haje), standing up, with expanded hood (uraeus), with a coiled tail (I12), overlapping each other.
 U+13D91	kEH_Func	Classifier snake, uraeus
 U+13D91	kEH_FVal	ꞽꜥr.ty
 U+13D91	kEH_UniK	I012A
 U+13D92	kEH_Cat	I-11-054
 U+13D92	kEH_Core	C
-U+13D92	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus), with a coiled tail (I12), written over a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (S40), angling forwards, with a cartouche in a round form (V9) with the loop around the staff.
+U+13D92	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus), with a coiled tail (I12), written over a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (S40), angling forwards, with a cartouche in a round form (V9) with the loop around the staff.
 U+13D92	kEH_Func	Logogram (Wadjet (divinity)
 U+13D92	kEH_FVal	wꜣḏ.t
 U+13D92	kEH_UniK	HJ I065
@@ -25918,7 +25919,7 @@ U+13D92	kEH_HG	I65
 U+13D92	kEH_IFAO	220,6
 U+13D93	kEH_Cat	I-11-057
 U+13D93	kEH_Core	C
-U+13D93	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus), with a coiled tail (I12), wearing the red crown (S3), upon a wickerwork basket (V30).
+U+13D93	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus), with a coiled tail (I12), wearing the red crown (S3), upon a wickerwork basket (V30).
 U+13D93	kEH_Func	Logogram (lady (in nb.ty))
 U+13D93	kEH_FVal	nb.t
 U+13D93	kEH_UniK	HJ I067
@@ -25927,13 +25928,13 @@ U+13D93	kEH_HG	I67
 U+13D93	kEH_IFAO	220,9
 U+13D94	kEH_Cat	I-11-058
 U+13D94	kEH_Core	C
-U+13D94	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus), with a coiled tail (I12), wearing the red crown (S3), with a flagellum (S45) on its back; upon a wickerwork basket (V30).
+U+13D94	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus), with a coiled tail (I12), wearing the red crown (S3), with a flagellum (S45) on its back; upon a wickerwork basket (V30).
 U+13D94	kEH_Func	Classifier uraeus
 U+13D94	kEH_FVal	wr.t
 U+13D94	kEH_UniK	I059A
 U+13D95	kEH_Cat	I-11-060
 U+13D95	kEH_Core	C
-U+13D95	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus), with a coiled tail (I12), wearing the white crown (S1), upon a wickerwork basket (V30).
+U+13D95	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus), with a coiled tail (I12), wearing the white crown (S1), upon a wickerwork basket (V30).
 U+13D95	kEH_Func	Logogram (lady (in nb.ty))
 U+13D95	kEH_FVal	nb.t
 U+13D95	kEH_UniK	HJ I068
@@ -25942,13 +25943,13 @@ U+13D95	kEH_HG	I68
 U+13D95	kEH_IFAO	220,11
 U+13D96	kEH_Cat	I-11-063
 U+13D96	kEH_Core	C
-U+13D96	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus), with a coiled tail (I12), wearing a headdress consisting of two plumes (S9).
-U+13D96	kEH_Func	Logogram (Renenoutet)
+U+13D96	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus), with a coiled tail (I12), wearing a headdress consisting of two plumes (S9).
+U+13D96	kEH_Func	Logogram (Renenutet)
 U+13D96	kEH_FVal	rnn.wtt
 U+13D96	kEH_UniK	I069A
 U+13D97	kEH_Cat	I-11-064
 U+13D97	kEH_Core	C
-U+13D97	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus), with its tail going forwards, over its head.
+U+13D97	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus), with its tail going forwards, over its head.
 U+13D97	kEH_Func	Logogram (uraeus)
 U+13D97	kEH_FVal	mḥn.t
 U+13D97	kEH_UniK	HJ I070
@@ -25957,13 +25958,13 @@ U+13D97	kEH_HG	I70
 U+13D97	kEH_IFAO	220,13
 U+13D98	kEH_Cat	I-11-067
 U+13D98	kEH_Core	C
-U+13D98	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus), with its tail coiled in an elaborate pattern.
+U+13D98	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus), with its tail coiled in an elaborate pattern.
 U+13D98	kEH_Func	Classifier coil (of a snake)
 U+13D98	kEH_FVal	mḥn
 U+13D98	kEH_UniK	I070E
 U+13D99	kEH_Cat	I-11-070
 U+13D99	kEH_Core	C
-U+13D99	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus), with its tail coiled, one coil horizontally, with the tail going forwards, over the head after this coil.
+U+13D99	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus), with its tail coiled, one coil horizontally, with the tail going forwards, over the head after this coil.
 U+13D99	kEH_Func	Logogram (uraeus)
 U+13D99	kEH_FVal	mḥn.t
 U+13D99	kEH_UniK	I070A
@@ -25971,7 +25972,7 @@ U+13D99	kEH_JSesh	I70A
 U+13D99	kEH_IFAO	220,16
 U+13D9A	kEH_Cat	I-11-071
 U+13D9A	kEH_Core	C
-U+13D9A	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus), with its tail coiled, with two coils, with the tail going forwards, over the head after the second coil.
+U+13D9A	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus), with its tail coiled, with two coils, with the tail going forwards, over the head after the second coil.
 U+13D9A	kEH_Func	Logogram (uraeus)
 U+13D9A	kEH_FVal	mḥn.t
 U+13D9A	kEH_UniK	I070B
@@ -25979,7 +25980,7 @@ U+13D9A	kEH_HG	I70B
 U+13D9A	kEH_IFAO	221,1
 U+13D9B	kEH_Cat	I-11-073
 U+13D9B	kEH_Core	C
-U+13D9B	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus), with its tail going backwards, over its head.
+U+13D9B	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus), with its tail going backwards, over its head.
 U+13D9B	kEH_Func	Logogram (uraeus)
 U+13D9B	kEH_FVal	mḥn.t
 U+13D9B	kEH_UniK	HJ I071
@@ -25993,7 +25994,7 @@ U+13D9C	kEH_HG	I73
 U+13D9C	kEH_IFAO	221,7
 U+13D9D	kEH_Cat	I-11-081
 U+13D9D	kEH_Core	C
-U+13D9D	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus), with a coiled tail, consisting of three horizontal coils, arranged vertically.
+U+13D9D	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus), with a coiled tail, consisting of three horizontal coils, arranged vertically.
 U+13D9D	kEH_Func	Logogram (uraeus)
 U+13D9D	kEH_FVal	mḥn.t
 U+13D9D	kEH_UniK	HJ I074
@@ -26071,7 +26072,7 @@ U+13DA6	kEH_IFAO	222,6
 U+13DA7	kEH_Cat	I-11-095
 U+13DA7	kEH_Core	C
 U+13DA7	kEH_Desc	A cobra with the head of a female, with a coiled tail, wearing a headdress consisting of two plumes (S9).
-U+13DA7	kEH_Func	Logogram (Renenoutet)
+U+13DA7	kEH_Func	Logogram (Renenutet)
 U+13DA7	kEH_FVal	rnn.wtt
 U+13DA7	kEH_UniK	I139
 U+13DA8	kEH_Cat	I-11-097
@@ -26090,7 +26091,7 @@ U+13DA9	kEH_JSesh	I130
 U+13DA9	kEH_HG	I130
 U+13DAA	kEH_Cat	I-11-101
 U+13DAA	kEH_Core	C
-U+13DAA	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), with a forward, downward dotted line coming from the mouth (I43), on top of the corner of a wall (O38); facing its mirror.
+U+13DAA	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), with a forward, downward dotted line coming from the mouth (I43), on top of the corner of a wall (O38); facing its mirror.
 U+13DAA	kEH_Func	Logogram (the two caverns)
 U+13DAA	kEH_FVal	ḳr.ty
 U+13DAA	kEH_UniK	I152
@@ -26171,7 +26172,7 @@ U+13DB6	kEH_JSesh	I127
 U+13DB6	kEH_HG	I127
 U+13DB7	kEH_Cat	I-13-014
 U+13DB7	kEH_Core	C
-U+13DB7	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus), with a coiled tail, consisting of three coils.
+U+13DB7	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus), with a coiled tail, consisting of three coils.
 U+13DB7	kEH_Func	Logogram (Shai (divinity))
 U+13DB7	kEH_FVal	šꜣw
 U+13DB7	kEH_UniK	HJ I015B
@@ -26304,7 +26305,7 @@ U+13DC9	kEH_HG	I93
 U+13DC9	kEH_IFAO	225,5
 U+13DCA	kEH_Cat	I-15-001
 U+13DCA	kEH_Core	C
-U+13DCA	kEH_Desc	Two cobras (Naja haje), standing up, with expanded hood (Uraeus), facing outwards, tails coiled together, with a child, seated on nothing, forelegs separated, right arm raised with hand to mouth, left arm hanging beside the body (A17) written between the two heads.
+U+13DCA	kEH_Desc	Two cobras (Naja haje), standing up, with expanded hood (uraeus), facing outwards, tails coiled together, with a child, seated on nothing, forelegs separated, right arm raised with hand to mouth, left arm hanging beside the body (A17) written between the two heads.
 U+13DCA	kEH_Func	Logogram (the north wind)
 U+13DCA	kEH_FVal	mḥy.t
 U+13DCA	kEH_UniK	HJ I109
@@ -26326,7 +26327,7 @@ U+13DCC	kEH_FVal	rm
 U+13DCC	kEH_UniK	K040
 U+13DCD	kEH_Cat	K-01-014
 U+13DCD	kEH_Core	C
-U+13DCD	kEH_Desc	A fish, at a 45° angle, with a V shaped tail, and a long and short fin on either side of the body.
+U+13DCD	kEH_Desc	A fish, at 45 degree, with a V shaped tail, and a long and short fin on either side of the body.
 U+13DCD	kEH_Func	Phonemogram
 U+13DCD	kEH_FVal	ẖꜣ
 U+13DCD	kEH_UniK	K031
@@ -26334,7 +26335,7 @@ U+13DCD	kEH_IFAO	226,12
 U+13DCE	kEH_Cat	K-01-016
 U+13DCE	kEH_Core	C
 U+13DCE	kEH_Desc	Two mullets (Mugil cephalus), arranged vertically, on top of a standard used for carrying religious symbols (R12).
-U+13DCE	kEH_Func	Logogram (canal of the two fishes (in the second nome of UE))
+U+13DCE	kEH_Func	Logogram (canal of the Two Fishes (in the second nome of Upper Egypt))
 U+13DCE	kEH_FVal	ꜥꜣḏ.wy
 U+13DCE	kEH_UniK	K003A
 U+13DCF	kEH_Cat	K-01-020
@@ -26346,9 +26347,9 @@ U+13DCF	kEH_UniK	K004C
 U+13DCF	kEH_IFAO	227,3
 U+13DD0	kEH_Cat	K-01-024
 U+13DD0	kEH_Core	C
-U+13DD0	kEH_Desc	A fish, at a 45° angle, written in an oval, at a 45° angle.
+U+13DD0	kEH_Desc	A fish, at 45 degree, written in an oval, rotated at 45 degree.
 U+13DD0	kEH_Func	Phonemogram/logogram (Shenes (geographical location))
-U+13DD0	kEH_FVal	šns
+U+13DD0	kEH_FVal	Šns
 U+13DD0	kEH_UniK	K028C
 U+13DD0	kEH_IFAO	227,7
 U+13DD1	kEH_Cat	K-01-027
@@ -26377,7 +26378,7 @@ U+13DD3	kEH_IFAO	227,12
 U+13DD4	kEH_Cat	K-01-033
 U+13DD4	kEH_Core	C
 U+13DD4	kEH_Desc	A fish, with its tail orientated downwards (K4A), on top of standard used for carrying religious symbols, with a loop under the horizontal beam, running over the vertical pole (R12A).
-U+13DD4	kEH_Func	Logogram (First-of-fishes nome (16th nome of LE))
+U+13DD4	kEH_Func	Logogram (First-of-fishes nome (16th nome of Lower Egypt))
 U+13DD4	kEH_FVal	ḥꜣ.t-mḥ.yt
 U+13DD4	kEH_UniK	HJ K017
 U+13DD4	kEH_JSesh	K17
@@ -26625,13 +26626,13 @@ U+13DF4	kEH_IFAO	231,11
 U+13DF5	kEH_Cat	L-06-017
 U+13DF5	kEH_Core	C
 U+13DF5	kEH_Desc	A scorpion (L19), on top of a standard used for carrying religious symbols (R12).
-U+13DF5	kEH_Func	Logogram (Serket/Selkis (divinity)
+U+13DF5	kEH_Func	Logogram (Serket/Selkis (divinity))
 U+13DF5	kEH_FVal	srḳ.t
 U+13DF5	kEH_UniK	L036
 U+13DF6	kEH_Cat	L-06-018
 U+13DF6	kEH_Core	C
 U+13DF6	kEH_Desc	A covered or winged scorpion, holding a seal, attached to a neck string (S20).
-U+13DF6	kEH_Func	Logogram (Serket/Selkis (divinity)
+U+13DF6	kEH_Func	Logogram (Serket/Selkis (divinity))
 U+13DF6	kEH_FVal	srḳ.t
 U+13DF6	kEH_UniK	L038
 U+13DF7	kEH_Cat	L-07-001
@@ -26687,13 +26688,13 @@ U+13DFD	kEH_IFAO	487,4
 U+13DFE	kEH_Cat	M-01-018
 U+13DFE	kEH_Core	C
 U+13DFE	kEH_Desc	A shield with a round top, with a line coming from either side, angled upwards, on top of a standard used for carrying religious symbols, with a loop under the horizontal beam, running over the vertical pole (R56/R12A).
-U+13DFE	kEH_Func	Logogram (Neith, 4-5th nome of LE)
+U+13DFE	kEH_Func	Logogram (Neith, 4th and 5th nomes of Lower Egypt)
 U+13DFE	kEH_FVal	n.t
 U+13DFE	kEH_UniK	M260
 U+13DFF	kEH_Cat	M-01-019
 U+13DFF	kEH_Core	C
 U+13DFF	kEH_Desc	A tree (M1), written over a horned desert viper (Cerastes cerastes) (I9), in front of the hindquarters of a seated lion or leopard (F22); on top of a standard used for carrying religious symbols (R12).
-U+13DFF	kEH_Func	Logogram (14th nome of UE)
+U+13DFF	kEH_Func	Logogram (14th nome of Upper Egypt)
 U+13DFF	kEH_FVal	nḏf.t-pḥ.t
 U+13DFF	kEH_UniK	HJ N113A
 U+13DFF	kEH_JSesh	N113A
@@ -26701,13 +26702,13 @@ U+13DFF	kEH_HG	N113A
 U+13E00	kEH_Cat	M-01-020
 U+13E00	kEH_Core	C
 U+13E00	kEH_Desc	A branch, horizontally written (M3), written over a tree (M1); on top of a standard used for carrying religious symbols (R12).
-U+13E00	kEH_Func	Logogram (20-21st nome of UE)
+U+13E00	kEH_Func	Logogram (20th and 21st nomes of Upper Egypt)
 U+13E00	kEH_FVal	nꜥr.t
 U+13E00	kEH_UniK	M001J
 U+13E01	kEH_Cat	M-01-021
 U+13E01	kEH_Core	C
 U+13E01	kEH_Desc	A tree (M1), on top of a standard used for carrying religious symbols (R12).
-U+13E01	kEH_Func	Logogram (20-21st nome of UE)
+U+13E01	kEH_Func	Logogram (20th and 21st nomes of Upper Egypt)
 U+13E01	kEH_FVal	nꜥr.t
 U+13E01	kEH_UniK	HJ M001D
 U+13E01	kEH_JSesh	M1D
@@ -26715,7 +26716,7 @@ U+13E01	kEH_HG	M1D
 U+13E02	kEH_Cat	M-01-023
 U+13E02	kEH_Core	C
 U+13E02	kEH_Desc	A tree (M1), written over a horned desert viper (Cerastes cerastes) (I9), in front of a schematic representation of three sealed water pots in a rack (W17A); on top of a standard used for carrying religious symbols (R12).
-U+13E02	kEH_Func	Logogram (13th nome of UE)
+U+13E02	kEH_Func	Logogram (13th nome of Upper Egypt)
 U+13E02	kEH_FVal	nḏf.t-ḫnt.t
 U+13E02	kEH_UniK	N112A
 U+13E03	kEH_Cat	M-01-024
@@ -26764,14 +26765,14 @@ U+13E08	kEH_HG	M54
 U+13E08	kEH_IFAO	233,2
 U+13E09	kEH_Cat	M-02-003
 U+13E09	kEH_Core	C
-U+13E09	kEH_Desc	A dom palm tree (Hyphaene thebaica) with sprouts a the bottom, with dom palm dates hanging from the top. 
-U+13E09	kEH_Func	Classifier dom-palm
+U+13E09	kEH_Desc	A doum palm tree (Hyphaene thebaica) with sprouts a the bottom, with doum palm dates hanging from the top. 
+U+13E09	kEH_Func	Classifier doum palm
 U+13E09	kEH_FVal	mꜣmꜣ
 U+13E09	kEH_UniK	M055A
 U+13E0A	kEH_Cat	M-02-007
 U+13E0A	kEH_Core	C
-U+13E0A	kEH_Desc	A dom palm tree (Hyphaene thebaica) with sprouts a the bottom, with two trunks.
-U+13E0A	kEH_Func	Classifier dom-palm
+U+13E0A	kEH_Desc	A doum palm tree (Hyphaene thebaica) with sprouts a the bottom, with two trunks.
+U+13E0A	kEH_Func	Classifier doum palm
 U+13E0A	kEH_FVal	mꜣmꜣ
 U+13E0A	kEH_UniK	HJ M054A
 U+13E0A	kEH_JSesh	M54A
@@ -27355,7 +27356,7 @@ U+13E5B	kEH_HG	M11D
 U+13E5B	kEH_IFAO	242,12
 U+13E5C	kEH_Cat	M-11-001
 U+13E5C	kEH_Core	C
-U+13E5C	kEH_Desc	A leaf, stem and root of a lotus plant, with the stem before the leaf bend forwards.
+U+13E5C	kEH_Desc	A leaf, stem and root of a lotus plant, with the stem before the leaf bent forwards.
 U+13E5C	kEH_Func	Phonemogram
 U+13E5C	kEH_FVal	ḫꜣ
 U+13E5C	kEH_UniK	M012K
@@ -27372,7 +27373,7 @@ U+13E5D	kEH_JSesh	M102
 U+13E5D	kEH_HG	M102
 U+13E5E	kEH_Cat	M-11-021
 U+13E5E	kEH_Core	C
-U+13E5E	kEH_Desc	A leaf, stem and root of a lotus plant, with the stem before the leaf bend forwards, with the root resembling a cartouche in a round form (V9), with two angled strokes on either side of the stem.
+U+13E5E	kEH_Desc	A leaf, stem and root of a lotus plant, with the stem before the leaf bent forwards, with the root resembling a cartouche in a round form (V9), with two angled strokes on either side of the stem.
 U+13E5E	kEH_Func	Phonemogram
 U+13E5E	kEH_FVal	ḫ
 U+13E5E	kEH_UniK	HJ M106
@@ -27468,7 +27469,7 @@ U+13E69	kEH_HG	M131
 U+13E6A	kEH_Cat	M-12-009
 U+13E6A	kEH_Core	C
 U+13E6A	kEH_Desc	A stem of papyrus with a bud (M13), on top of a plan of a crossroads in a village (O49).
-U+13E6A	kEH_Func	Logogram (lower Egypt)
+U+13E6A	kEH_Func	Logogram (Lower Egypt)
 U+13E6A	kEH_FVal	mḥ.w
 U+13E6A	kEH_UniK	HJ M113
 U+13E6A	kEH_JSesh	M113
@@ -27485,7 +27486,7 @@ U+13E6B	kEH_HG	M116
 U+13E6B	kEH_IFAO	245,11
 U+13E6C	kEH_Cat	M-12-014
 U+13E6C	kEH_Core	C
-U+13E6C	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), on top of a stem of papyrus with a bud (M13), with the tail curling around the stem.
+U+13E6C	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), on top of a stem of papyrus with a bud (M13), with the tail curling around the stem.
 U+13E6C	kEH_Func	Logogram (uraeus)
 U+13E6C	kEH_FVal	wꜣḏ.t
 U+13E6C	kEH_UniK	HJ M117
@@ -27494,7 +27495,7 @@ U+13E6C	kEH_HG	M117
 U+13E6C	kEH_IFAO	245,13
 U+13E6D	kEH_Cat	M-12-015
 U+13E6D	kEH_Core	C
-U+13E6D	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), wearing the white crown (S1), on top of a stem of papyrus with a bud (M13), with the tail curling around the stem.
+U+13E6D	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), wearing the white crown (S1), on top of a stem of papyrus with a bud (M13), with the tail curling around the stem.
 U+13E6D	kEH_Func	Logogram (uraeus)
 U+13E6D	kEH_FVal	wꜣḏ.t
 U+13E6D	kEH_UniK	HJ M118
@@ -27503,7 +27504,7 @@ U+13E6D	kEH_HG	M118
 U+13E6D	kEH_IFAO	245,14
 U+13E6E	kEH_Cat	M-12-017
 U+13E6E	kEH_Core	C
-U+13E6E	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), wearing the red crown (S3), on top of a stem of papyrus with a bud (M13), with the tail curling around the stem.
+U+13E6E	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), wearing the red crown (S3), on top of a stem of papyrus with a bud (M13), with the tail curling around the stem.
 U+13E6E	kEH_Func	Logogram (uraeus)
 U+13E6E	kEH_FVal	wꜣḏ.t
 U+13E6E	kEH_UniK	HJ M119
@@ -27557,7 +27558,7 @@ U+13E74	kEH_HG	M15A
 U+13E74	kEH_IFAO	247,10
 U+13E75	kEH_Cat	M-13-012
 U+13E75	kEH_Core	C
-U+13E75	kEH_Desc	A stem of papyrus with a bud (M13), with a bud bend down on either side of the stem, on top of a plan of a crossroads in a village (O49).
+U+13E75	kEH_Desc	A stem of papyrus with a bud (M13), with a bud bent down on either side of the stem, on top of a plan of a crossroads in a village (O49).
 U+13E75	kEH_Func	Logogram (Lower Egypt)
 U+13E75	kEH_FVal	mḥ.w
 U+13E75	kEH_UniK	HJ M139A
@@ -27581,7 +27582,7 @@ U+13E77	kEH_FVal	tꜣ-mḥ.w
 U+13E77	kEH_UniK	M261
 U+13E78	kEH_Cat	M-13-015
 U+13E78	kEH_Core	C
-U+13E78	kEH_Desc	A stem of papyrus with a flowering bud (M129), with a bud bend down on either side of the stem, on top of a plan of a crossroads in a village (O49).
+U+13E78	kEH_Desc	A stem of papyrus with a flowering bud (M129), with a bud bent down on either side of the stem, on top of a plan of a crossroads in a village (O49).
 U+13E78	kEH_Func	Logogram (Upper Egypt)
 U+13E78	kEH_FVal	šmꜥ.w
 U+13E78	kEH_UniK	HJ M140A
@@ -27599,7 +27600,7 @@ U+13E79	kEH_HG	M138A
 U+13E7A	kEH_Cat	M-13-017
 U+13E7A	kEH_Core	C
 U+13E7A	kEH_Desc	A rounded clump of three papyrus flowers, with two buds bent down.
-U+13E7A	kEH_Func	Radicogram (grain of LE)
+U+13E7A	kEH_Func	Radicogram (grain of Lower Egypt)
 U+13E7A	kEH_FVal	mḥ.w
 U+13E7A	kEH_UniK	HJ M135
 U+13E7A	kEH_JSesh	M135
@@ -27616,7 +27617,7 @@ U+13E7B	kEH_HG	M137
 U+13E7B	kEH_IFAO	247,15
 U+13E7C	kEH_Cat	M-13-026
 U+13E7C	kEH_Core	C
-U+13E7C	kEH_Desc	Three thin stems of papyrus with a flowering bud, with two buds bend down; on top of a plan of a crossroads in a village (O49).
+U+13E7C	kEH_Desc	Three thin stems of papyrus with a flowering bud, with two buds bent down; on top of a plan of a crossroads in a village (O49).
 U+13E7C	kEH_Func	Logogram (Upper Egypt)
 U+13E7C	kEH_FVal	šmꜥ.w
 U+13E7C	kEH_UniK	HJ M140
@@ -27683,7 +27684,7 @@ U+13E84	kEH_JSesh	M17A
 U+13E84	kEH_HG	M17A
 U+13E85	kEH_Cat	M-14-013
 U+13E85	kEH_Core	C
-U+13E85	kEH_Desc	A flowering reed, with two shoots at the bottom, at a 45° angle forwards.
+U+13E85	kEH_Desc	A flowering reed, with two shoots at the bottom, at 45 degree forwards.
 U+13E85	kEH_Func	Phonemogram
 U+13E85	kEH_FVal	ꞽ
 U+13E85	kEH_UniK	HJ M233
@@ -27849,7 +27850,7 @@ U+13E99	kEH_UniK	M026B
 U+13E9A	kEH_Cat	M-16-047
 U+13E9A	kEH_Core	C
 U+13E9A	kEH_Desc	A flowering sedge (M23A), on top of a half round loaf of bread (X1).
-U+13E9A	kEH_Func	Logogram (King of UE)
+U+13E9A	kEH_Func	Logogram (king of Upper Egypt)
 U+13E9A	kEH_FVal	n(.y)-sw.t
 U+13E9A	kEH_UniK	HJ M165
 U+13E9A	kEH_JSesh	M165
@@ -28244,7 +28245,7 @@ U+13ECD	kEH_FVal	ḥr.y
 U+13ECD	kEH_UniK	N046C
 U+13ECE	kEH_Cat	N-01-025
 U+13ECE	kEH_Core	C
-U+13ECE	kEH_Desc	The sun-disk (N5) on top of the sky.
+U+13ECE	kEH_Desc	The sun disk (N5) on top of the sky.
 U+13ECE	kEH_Func	Classifier dawn
 U+13ECE	kEH_FVal	ꜥnḏ
 U+13ECE	kEH_UniK	HJ N049
@@ -28277,7 +28278,7 @@ U+13ED1	kEH_UniK	HJ N004E
 U+13ED1	kEH_JSesh	N4E
 U+13ED1	kEH_HG	N4E
 U+13ED2	kEH_Cat	N-02-011
-U+13ED2	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (Uraeus), written inside it, with a tie or strap, used with sandals (ankh-sign) (S34) written below the sun.
+U+13ED2	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (uraeus), written inside it, with a tie or strap, used with sandals (ankh sign) (S34) written below the sun.
 U+13ED2	kEH_Func	Classifier time
 U+13ED2	kEH_FVal	nḥḥ
 U+13ED2	kEH_UniK	HJ N122
@@ -28285,7 +28286,7 @@ U+13ED2	kEH_JSesh	N122
 U+13ED2	kEH_HG	N122
 U+13ED3	kEH_Cat	N-03-004
 U+13ED3	kEH_Core	C
-U+13ED3	kEH_Desc	The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus), head below the sun-disk, with a tie or strap, used with sandals (ankh-sign, S34) with the loop around the body of the cobra, in front of the sun-disk.
+U+13ED3	kEH_Desc	The sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus), head below the sun disk, with a tie or strap, used with sandals (ankh sign, S34) with the loop around the body of the cobra, in front of the sun disk.
 U+13ED3	kEH_Func	Classifier divinity
 U+13ED3	kEH_FVal	ḥr
 U+13ED3	kEH_UniK	HJ N006A
@@ -28294,8 +28295,8 @@ U+13ED3	kEH_HG	N6A
 U+13ED3	kEH_IFAO	263,4
 U+13ED4	kEH_Cat	N-03-008
 U+13ED4	kEH_Core	C
-U+13ED4	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (Uraeus) at either side.
-U+13ED4	kEH_Func	Logogram (King of UE and LE)
+U+13ED4	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (uraeus) at either side.
+U+13ED4	kEH_Func	Logogram (king of Upper Egypt and Lower Egypt)
 U+13ED4	kEH_FVal	n(.y)-sw.t-bꞽ.ty
 U+13ED4	kEH_UniK	HJ N006B
 U+13ED4	kEH_JSesh	N6B
@@ -28303,8 +28304,8 @@ U+13ED4	kEH_HG	N6B
 U+13ED4	kEH_IFAO	263,9
 U+13ED5	kEH_Cat	N-03-010
 U+13ED5	kEH_Core	C
-U+13ED5	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (Uraeus) at either side, with the left cobra wearing the red crown (S3) and the right cobra wearing the white crown (S1).
-U+13ED5	kEH_Func	Logogram (King of UE and LE)
+U+13ED5	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (uraeus) at either side, with the left cobra wearing the red crown (S3) and the right cobra wearing the white crown (S1).
+U+13ED5	kEH_Func	Logogram (king of Upper Egypt and Lower Egypt)
 U+13ED5	kEH_FVal	n(.y)-sw.t-bꞽ.ty
 U+13ED5	kEH_UniK	HJ N051
 U+13ED5	kEH_JSesh	N51
@@ -28312,8 +28313,8 @@ U+13ED5	kEH_HG	N51
 U+13ED5	kEH_IFAO	263,11
 U+13ED6	kEH_Cat	N-03-011
 U+13ED6	kEH_Core	C
-U+13ED6	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (Uraeus) at either side, with a tie or strap, used with sandals (ankh-sign, S34) with the loop around the body of the cobras.
-U+13ED6	kEH_Func	Logogram (King of UE and LE)
+U+13ED6	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (uraeus) at either side, with a tie or strap, used with sandals (ankh sign, S34) with the loop around the body of the cobras.
+U+13ED6	kEH_Func	Logogram (king of Upper Egypt and Lower Egypt)
 U+13ED6	kEH_FVal	n(.y)-sw.t-bꞽ.ty
 U+13ED6	kEH_UniK	HJ N006C
 U+13ED6	kEH_JSesh	N6C
@@ -28321,8 +28322,8 @@ U+13ED6	kEH_HG	N6C
 U+13ED6	kEH_IFAO	263,12
 U+13ED7	kEH_Cat	N-03-012
 U+13ED7	kEH_Core	C
-U+13ED7	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (Uraeus) at either side, with a tie or strap, used with sandals (ankh-sign, S34) with the loop around the body of the cobras, with the left cobra wearing the white crown (S1), and the right cobra wearing the red crown (S3).
-U+13ED7	kEH_Func	Logogram (King of UE and LE)
+U+13ED7	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (uraeus) at either side, with a tie or strap, used with sandals (ankh sign, S34) with the loop around the body of the cobras, with the left cobra wearing the white crown (S1), and the right cobra wearing the red crown (S3).
+U+13ED7	kEH_Func	Logogram (king of Upper Egypt and Lower Egypt)
 U+13ED7	kEH_FVal	n(.y)-sw.t-bꞽ.ty
 U+13ED7	kEH_UniK	HJ N051A
 U+13ED7	kEH_JSesh	N51A
@@ -28330,8 +28331,8 @@ U+13ED7	kEH_HG	N51A
 U+13ED7	kEH_IFAO	263,13
 U+13ED8	kEH_Cat	N-03-013
 U+13ED8	kEH_Core	C
-U+13ED8	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (Uraeus) at either side, heads below the sun-disk.
-U+13ED8	kEH_Func	Logogram (King of UE and LE)
+U+13ED8	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (uraeus) at either side, heads below the sun disk.
+U+13ED8	kEH_Func	Logogram (king of Upper Egypt and Lower Egypt)
 U+13ED8	kEH_FVal	n(.y)-sw.t-bꞽ.ty
 U+13ED8	kEH_UniK	HJ N006D
 U+13ED8	kEH_JSesh	N6D
@@ -28339,8 +28340,8 @@ U+13ED8	kEH_HG	N6D
 U+13ED8	kEH_IFAO	263,14
 U+13ED9	kEH_Cat	N-03-016
 U+13ED9	kEH_Core	C
-U+13ED9	kEH_Desc	The sun with three straight lines of sunlight coming from it (N8), with a cobra (Naja haje), standing up, with expanded hood (Uraeus) at either side, heads below the sun-disk, with the left cobra wearing the red crown (S3) and the right cobra wearing the white crown (S1).
-U+13ED9	kEH_Func	Logogram (King of UE and LE)
+U+13ED9	kEH_Desc	The sun with three straight lines of sunlight coming from it (N8), with a cobra (Naja haje), standing up, with expanded hood (uraeus) at either side, heads below the sun disk, with the left cobra wearing the red crown (S3) and the right cobra wearing the white crown (S1).
+U+13ED9	kEH_Func	Logogram (king of Upper Egypt and Lower Egypt)
 U+13ED9	kEH_FVal	n(.y)-sw.t-bꞽ.ty
 U+13ED9	kEH_UniK	HJ N052
 U+13ED9	kEH_JSesh	N52
@@ -28348,8 +28349,8 @@ U+13ED9	kEH_HG	N52
 U+13ED9	kEH_IFAO	264,1
 U+13EDA	kEH_Cat	N-03-017
 U+13EDA	kEH_Core	C
-U+13EDA	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (Uraeus) at either side, heads below the sun-disk, with the left cobra wearing the red crown (S3) and the right cobra wearing the white crown (S1).
-U+13EDA	kEH_Func	Logogram (King of UE and LE)
+U+13EDA	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (uraeus) at either side, heads below the sun disk, with the left cobra wearing the red crown (S3) and the right cobra wearing the white crown (S1).
+U+13EDA	kEH_Func	Logogram (king of Upper Egypt and Lower Egypt)
 U+13EDA	kEH_FVal	n(.y)-sw.t-bꞽ.ty
 U+13EDA	kEH_UniK	HJ N142
 U+13EDA	kEH_JSesh	N142
@@ -28370,7 +28371,7 @@ U+13EDC	kEH_JSesh	N108
 U+13EDC	kEH_HG	N108
 U+13EDD	kEH_Cat	N-04-008
 U+13EDD	kEH_Core	C
-U+13EDD	kEH_Desc	A small circle (sun-disk) within a larger circle of dots.
+U+13EDD	kEH_Desc	A small circle (sun disk) within a larger circle of dots.
 U+13EDD	kEH_Func	Classifier to scatter light, to illuminate
 U+13EDD	kEH_FVal	wpš
 U+13EDD	kEH_UniK	N055C
@@ -28427,7 +28428,7 @@ U+13EE3	kEH_JSesh	N55A
 U+13EE3	kEH_HG	N55A
 U+13EE4	kEH_Cat	N-04-024
 U+13EE4	kEH_Core	C
-U+13EE4	kEH_Desc	The sun, with two short horizontal strokes on either side of the sun-disk, on top of an irrigation canal (N23).
+U+13EE4	kEH_Desc	The sun, with two short horizontal strokes on either side of the sun disk, on top of an irrigation canal (N23).
 U+13EE4	kEH_Func	Classifier solar period
 U+13EE4	kEH_FVal	rnp.t
 U+13EE4	kEH_UniK	N116A
@@ -28452,8 +28453,8 @@ U+13EE7	kEH_HG	N58
 U+13EE7	kEH_IFAO	265,3
 U+13EE8	kEH_Cat	N-05-004
 U+13EE8	kEH_Core	C
-U+13EE8	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (Uraeus) at either side (N6B), with the fully extended wing of a bird (H5) on either side, arranged horizontally.
-U+13EE8	kEH_Func	Logogram (the winged scarab/sundisk)
+U+13EE8	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (uraeus) at either side (N6B), with the fully extended wing of a bird (H5) on either side, arranged horizontally.
+U+13EE8	kEH_Func	Logogram (the winged scarab or sun disk)
 U+13EE8	kEH_FVal	ꜥpy
 U+13EE8	kEH_UniK	HJ N058A
 U+13EE8	kEH_JSesh	N58A
@@ -28461,7 +28462,7 @@ U+13EE8	kEH_HG	N58A
 U+13EE8	kEH_IFAO	265,5
 U+13EE9	kEH_Cat	N-05-007
 U+13EE9	kEH_Core	C
-U+13EE9	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (Uraeus) at either side (N6B), with the fully extended wing of a bird (H5) on either side, arranged horizontally; with the horns of a ram on top of the sun disk, with the white crown (S1), facing left to right, overlapping the red crown (S3), facing right to left, on top of the horns.
+U+13EE9	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (uraeus) at either side (N6B), with the fully extended wing of a bird (H5) on either side, arranged horizontally; with the horns of a ram on top of the sun disk, with the white crown (S1), facing left to right, overlapping the red crown (S3), facing right to left, on top of the horns.
 U+13EE9	kEH_Func	Classifier Horus of Edfu
 U+13EE9	kEH_FVal	bḥd.ty
 U+13EE9	kEH_UniK	N133C
@@ -28477,7 +28478,7 @@ U+13EEA	kEH_HG	N59
 U+13EEA	kEH_IFAO	265,9
 U+13EEB	kEH_Cat	N-05-015
 U+13EEB	kEH_Core	C
-U+13EEB	kEH_Desc	A sun-disk with wings at a 90° angle.
+U+13EEB	kEH_Desc	A sun disk with wings at 90 degree.
 U+13EEB	kEH_Func	Classifier divinity
 U+13EEB	kEH_FVal	ḏḥwty
 U+13EEB	kEH_UniK	HJ N060
@@ -28486,7 +28487,7 @@ U+13EEB	kEH_HG	N60
 U+13EEB	kEH_IFAO	265,13
 U+13EEC	kEH_Cat	N-05-018
 U+13EEC	kEH_Core	C
-U+13EEC	kEH_Desc	A sun-disk with wings at a 90° angle, with an uraeus coming from the sun-disk, filling the space between the two wings.
+U+13EEC	kEH_Desc	A sun disk with wings at 90 degree, with an uraeus coming from the sun disk, filling the space between the two wings.
 U+13EEC	kEH_Func	Classifier divinity
 U+13EEC	kEH_FVal	ḏḥwty
 U+13EEC	kEH_UniK	HJ N060A
@@ -28495,16 +28496,16 @@ U+13EEC	kEH_HG	N60A
 U+13EEC	kEH_IFAO	266,1
 U+13EED	kEH_Cat	N-05-019
 U+13EED	kEH_Core	C
-U+13EED	kEH_Desc	A sun-disk with wings, angled downwards.
-U+13EED	kEH_Func	Logogram (King of UE and LE)
+U+13EED	kEH_Desc	A sun disk with wings, angled downwards.
+U+13EED	kEH_Func	Logogram (king of Upper Egypt and Lower Egypt)
 U+13EED	kEH_FVal	n(.y)-sw.t-bꞽ.ty
 U+13EED	kEH_UniK	HJ N132
 U+13EED	kEH_JSesh	N132
 U+13EED	kEH_HG	N132
 U+13EEE	kEH_Cat	N-05-020
 U+13EEE	kEH_Core	C
-U+13EEE	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (Uraeus) at either side, heads below the sun-disk (N6D), with wings, angled downwards.
-U+13EEE	kEH_Func	Logogram (King of UE and LE)
+U+13EEE	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (uraeus) at either side, heads below the sun disk (N6D), with wings, angled downwards.
+U+13EEE	kEH_Func	Logogram (king of Upper Egypt and Lower Egypt)
 U+13EEE	kEH_FVal	n(.y)-sw.t-bꞽ.ty
 U+13EEE	kEH_UniK	HJ N133
 U+13EEE	kEH_JSesh	N133
@@ -28522,7 +28523,7 @@ U+13EEF	kEH_IFAO	266,5
 U+13EF0	kEH_Cat	N-05-023
 U+13EF0	kEH_Core	C
 U+13EF0	kEH_Desc	The sun, with a broad beam of light coming from below (N8B), with wings, angled downwards.
-U+13EF0	kEH_Func	Classifier winged sun-disk
+U+13EF0	kEH_Func	Classifier winged sun disk
 U+13EF0	kEH_FVal	ꜥpy
 U+13EF0	kEH_UniK	HJ N132A
 U+13EF0	kEH_JSesh	N132A
@@ -28530,7 +28531,7 @@ U+13EF0	kEH_HG	N132A
 U+13EF0	kEH_IFAO	266,6
 U+13EF1	kEH_Cat	N-05-024
 U+13EF1	kEH_Core	C
-U+13EF1	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (Uraeus) at either side, heads below the sun-disk (N6D), with a broad beam of light coming from below, between the cobras; with wings, angled downwards.
+U+13EF1	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (uraeus) at either side, heads below the sun disk (N6D), with a broad beam of light coming from below, between the cobras; with wings, angled downwards.
 U+13EF1	kEH_Func	Logogram (to rise, to shine)
 U+13EF1	kEH_FVal	wbn
 U+13EF1	kEH_UniK	HJ N133B
@@ -28538,7 +28539,7 @@ U+13EF1	kEH_JSesh	N133B
 U+13EF1	kEH_HG	N133B
 U+13EF2	kEH_Cat	N-05-027
 U+13EF2	kEH_Core	C
-U+13EF2	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (Uraeus) at either side (N6B), with wings, angled downwards.
+U+13EF2	kEH_Desc	The sun, with a cobra (Naja haje), standing up, with expanded hood (uraeus) at either side (N6B), with wings, angled downwards.
 U+13EF2	kEH_Func	Logogram (to rise, to shine)
 U+13EF2	kEH_FVal	wbn
 U+13EF2	kEH_UniK	N132D
@@ -28701,7 +28702,7 @@ U+13F07	kEH_IFAO	271,10
 U+13F08	kEH_Cat	N-11-017
 U+13F08	kEH_Core	C
 U+13F08	kEH_Desc	A standard used for carrying religious symbols, with a short vertical pole, with a loop under the horizontal beam, running over the vertical pole (R56), written on top of a parcel of land with irrigation ditches (N24).
-U+13F08	kEH_Func	Logogram (9th nome of LE)
+U+13F08	kEH_Func	Logogram (9th nome of Lower Egypt)
 U+13F08	kEH_FVal	wꜥ-m-ḥww
 U+13F08	kEH_UniK	HJ N071
 U+13F08	kEH_JSesh	N71
@@ -28738,7 +28739,7 @@ U+13F0C	kEH_IFAO	272,5
 U+13F0D	kEH_Cat	N-11-026
 U+13F0D	kEH_Core	C
 U+13F0D	kEH_Desc	The head of a man on a stick, wearing a double feather headdress (S78), with a band of string around its head, with the ties at the back, with arms coming from the head, right arm forwards, holding a crook (S38) vertically, left arm hanging beside the stick, holding a flagellum (S45) horizontally; on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
-U+13F0D	kEH_Func	Logogram (9th nome of UE)
+U+13F0D	kEH_Func	Logogram (9th nome of Lower Egypt)
 U+13F0D	kEH_FVal	ꜥnḏ.ty
 U+13F0D	kEH_UniK	HJ N074
 U+13F0D	kEH_JSesh	N74
@@ -28747,7 +28748,7 @@ U+13F0D	kEH_IFAO	272,6
 U+13F0E	kEH_Cat	N-11-028
 U+13F0E	kEH_Core	C
 U+13F0E	kEH_Desc	A forearm, with the palm of the hand facing upwards (D36), holding a loop of cord with the ends downwards (V7); written over a tree (M1); on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
-U+13F0E	kEH_Func	Logogram (20-21st nome of UE)
+U+13F0E	kEH_Func	Logogram (20th and 21st nomes of Upper Egypt)
 U+13F0E	kEH_FVal	nꜥr.t
 U+13F0E	kEH_UniK	HJ N111
 U+13F0E	kEH_JSesh	N111
@@ -28755,7 +28756,7 @@ U+13F0E	kEH_HG	N111
 U+13F0F	kEH_Cat	N-11-030
 U+13F0F	kEH_Core	C
 U+13F0F	kEH_Desc	A tree (M1), in front of a piece of flesh, point down, curving forwards (F51), in front of hindquarters of a seated lion or leopard (F22); arranged horizontally; on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
-U+13F0F	kEH_Func	Logogram (14th Upper Egyptian nome)
+U+13F0F	kEH_Func	Logogram (14th nome of Upper Egypt)
 U+13F0F	kEH_FVal	nḏf.t-pḥ.t
 U+13F0F	kEH_UniK	HJ N113
 U+13F0F	kEH_JSesh	N113
@@ -28763,7 +28764,7 @@ U+13F0F	kEH_HG	N113
 U+13F10	kEH_Cat	N-11-031
 U+13F10	kEH_Core	C
 U+13F10	kEH_Desc	A tree (M1), in front of hindquarters of a seated lion or leopard (F22); arranged horizontally; on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
-U+13F10	kEH_Func	Logogram (21th Upper Egyptian nome)
+U+13F10	kEH_Func	Logogram (21th nome of Upper Egypt)
 U+13F10	kEH_FVal	nꜥr.t-pḥ.t
 U+13F10	kEH_UniK	HJ N113B
 U+13F10	kEH_JSesh	N113B
@@ -28771,7 +28772,7 @@ U+13F10	kEH_HG	N113B
 U+13F11	kEH_Cat	N-11-032
 U+13F11	kEH_Core	C
 U+13F11	kEH_Desc	A horned desert viper (Cerastes cerastes) (I9), written over a tree (M1), in front of hindquarters of a seated lion or leopard (F22); on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
-U+13F11	kEH_Func	Logogram (14th Upper Egyptian nome)
+U+13F11	kEH_Func	Logogram (14th nome of Upper Egypt)
 U+13F11	kEH_FVal	nḏf.t-pḥ.t
 U+13F11	kEH_UniK	HJ N113C
 U+13F11	kEH_JSesh	N113C
@@ -28779,7 +28780,7 @@ U+13F11	kEH_HG	N113C
 U+13F12	kEH_Cat	N-11-035
 U+13F12	kEH_Core	C
 U+13F12	kEH_Desc	A schematic representation of three sealed water pots in a rack (W17A), in front of a spear made into a standard, resembling a fire-drill in a piece of wood (R15A); on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
-U+13F12	kEH_Func	Logogram (14th upper Egyptian nome)
+U+13F12	kEH_Func	Logogram (14th nome of Upper Egypt)
 U+13F12	kEH_FVal	ḫnt.y-ꞽꜣb.ty
 U+13F12	kEH_UniK	HJ N119
 U+13F12	kEH_JSesh	N119
@@ -28787,7 +28788,7 @@ U+13F12	kEH_HG	N119
 U+13F13	kEH_Cat	N-11-037
 U+13F13	kEH_Core	C
 U+13F13	kEH_Desc	Child, wearing the white crown (S1), seated on nothing, forelegs spread, right arm raised in front with hand to mouth, left arm hanging beside the body (A274); in front of the head of a bovid (cow), without horns, with an ear (F63), on top of a half round loaf of bread (X1); on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
-U+13F13	kEH_Func	Logogram (18th Lower Egyptian nome (Pelusium))
+U+13F13	kEH_Func	Logogram (18th nome of Lower Egypt)
 U+13F13	kEH_FVal	ꞽm.ty-ḫnt.y
 U+13F13	kEH_UniK	HJ A337
 U+13F13	kEH_JSesh	A337
@@ -28795,7 +28796,7 @@ U+13F13	kEH_HG	A337
 U+13F14	kEH_Cat	N-13-005
 U+13F14	kEH_Core	C
 U+13F14	kEH_Desc	The hill country over the edge of the cultivated areas (N25), on top of a standard used for carrying religious symbols, with a loop under the horizontal beam, running over the vertical pole (R12A).
-U+13F14	kEH_Func	Logogram (12th Upper Egyptian nome)
+U+13F14	kEH_Func	Logogram (12th nome of Upper Egypt)
 U+13F14	kEH_FVal	ꜣtf.t
 U+13F14	kEH_UniK	HJ N076
 U+13F14	kEH_JSesh	N76
@@ -28828,7 +28829,7 @@ U+13F17	kEH_JSesh	N82
 U+13F17	kEH_HG	N82
 U+13F18	kEH_Cat	N-13-013
 U+13F18	kEH_Core	C
-U+13F18	kEH_Desc	A tie or strap, used with sandals (ankh-sign) (S34), written on top of the middle hill of the hill country over the edge of the cultivated areas (N25).
+U+13F18	kEH_Desc	A tie or strap, used with sandals (ankh sign) (S34), written on top of the middle hill of the hill country over the edge of the cultivated areas (N25).
 U+13F18	kEH_Func	Logogram (place of life (i.e., the west))
 U+13F18	kEH_FVal	ꜥnḫ.t
 U+13F18	kEH_UniK	HJ N117
@@ -28836,7 +28837,7 @@ U+13F18	kEH_JSesh	N117
 U+13F18	kEH_HG	N117
 U+13F19	kEH_Cat	N-13-018
 U+13F19	kEH_Core	C
-U+13F19	kEH_Desc	A tie or strap, used with sandals (ankh-sign) (S34), written on top of a sand covered mountain over the edge of the cultivated areas (N26).
+U+13F19	kEH_Desc	A tie or strap, used with sandals (ankh sign) (S34), written on top of a sand covered mountain over the edge of the cultivated areas (N26).
 U+13F19	kEH_Func	Logogram (place of life (i.e., the west))
 U+13F19	kEH_FVal	ꜥnḫ.t
 U+13F19	kEH_UniK	N149
@@ -28861,7 +28862,7 @@ U+13F1B	kEH_IFAO	273,10
 U+13F1C	kEH_Cat	N-13-026
 U+13F1C	kEH_Core	C
 U+13F1C	kEH_Desc	A horned desert viper (Cerastes cerastes) (I9), above a sand covered mountain over the edge of the cultivated areas (N26); on top of a standard used for carrying religious symbols (R12), written on top of a parcel of land with irrigation ditches (N24).
-U+13F1C	kEH_Func	Logogram (12th Upper Egyptian nome)
+U+13F1C	kEH_Func	Logogram (12th nome of Upper Egypt)
 U+13F1C	kEH_FVal	ꜣtf.t
 U+13F1C	kEH_UniK	HJ N118
 U+13F1C	kEH_JSesh	N118
@@ -28869,7 +28870,7 @@ U+13F1C	kEH_HG	N118
 U+13F1D	kEH_Cat	N-13-028
 U+13F1D	kEH_Core	C
 U+13F1D	kEH_Desc	A sand covered mountain over the edge of the cultivated areas (N26), on top of a standard used for carrying religious symbols, with a loop under the horizontal beam, running over the vertical pole (R12A).
-U+13F1D	kEH_Func	Logogram (12th Upper Egyptian nome)
+U+13F1D	kEH_Func	Logogram (12th nome of Upper Egypt)
 U+13F1D	kEH_FVal	ꜣtf.t
 U+13F1D	kEH_UniK	HJ N115
 U+13F1D	kEH_JSesh	N115
@@ -28890,7 +28891,7 @@ U+13F1F	kEH_FVal	snṯr
 U+13F1F	kEH_UniK	N033C
 U+13F20	kEH_Cat	N-15-006
 U+13F20	kEH_Core	C
-U+13F20	kEH_Desc	A falcon (G5), written inside the sun-disk of the sun rising over a sand covered mountain over the edge of the cultivated areas (N27).
+U+13F20	kEH_Desc	A falcon (G5), written inside the sun disk of the sun rising over a sand covered mountain over the edge of the cultivated areas (N27).
 U+13F20	kEH_Func	Logogram (eternity)
 U+13F20	kEH_FVal	nḥḥ
 U+13F20	kEH_UniK	HJ N092
@@ -29025,7 +29026,7 @@ U+13F31	kEH_IFAO	277,8
 U+13F32	kEH_Cat	N-19-012
 U+13F32	kEH_Core	C
 U+13F32	kEH_Desc	A horizontal line written within an oval.
-U+13F32	kEH_Func	Logogram (island (in ꞽw-ḏsḏs (el-Bahriya oasis))
+U+13F32	kEH_Func	Logogram (island (in ꞽw-ḏsḏs (El-Bahriya oasis)))
 U+13F32	kEH_FVal	ꞽw
 U+13F32	kEH_UniK	HJ N140
 U+13F32	kEH_JSesh	N140
@@ -29062,8 +29063,8 @@ U+13F36	kEH_IFAO	278,5
 U+13F37	kEH_Cat	N-20-012
 U+13F37	kEH_Core	C
 U+13F37	kEH_Desc	A canal, with multiple rectangles resembling battlements written on top of the sign.
-U+13F37	kEH_Func	Classifier bank (river, fortress
-U+13F37	kEH_FVal	ꞽḫm.t)
+U+13F37	kEH_Func	Classifier bank (river, fortress)
+U+13F37	kEH_FVal	ꞽḫm.t
 U+13F37	kEH_UniK	HJ N099
 U+13F37	kEH_JSesh	N99
 U+13F37	kEH_HG	N99
@@ -29241,7 +29242,7 @@ U+13F4F	kEH_IFAO	282,3
 U+13F50	kEH_Cat	O-01-063
 U+13F50	kEH_Core	C
 U+13F50	kEH_Desc	Three feathers (H6), written angled forwards, on top of three houses or enclosures, connected together, horizontally (O262).
-U+13F50	kEH_Func	Logogram temple)
+U+13F50	kEH_Func	Logogram (temple)
 U+13F50	kEH_FVal	gs.w-pr.w 
 U+13F50	kEH_UniK	O072B
 U+13F50	kEH_IFAO	282,4
@@ -30305,7 +30306,7 @@ U+13FDF	kEH_HG	O28
 U+13FDF	kEH_IFAO	314,14
 U+13FE0	kEH_Cat	O-16-006
 U+13FE0	kEH_Core	C
-U+13FE0	kEH_Desc	A column with a base, with a tenon at the top, with a spiral, winding counterclockwise away from its central point, ending at the right lower corner after about one and a half turns(Z7) attached to the top, towards the front.
+U+13FE0	kEH_Desc	A column with a base, with a tenon at the top, with a spiral, winding counterclockwise away from its central point, ending at the right lower corner after about one and a half turns (Z7) attached to the top, towards the front.
 U+13FE0	kEH_Func	Phonemogram
 U+13FE0	kEH_FVal	wṯs
 U+13FE0	kEH_UniK	O028E
@@ -30385,7 +30386,7 @@ U+13FEA	kEH_IFAO	317,3
 U+13FEB	kEH_Cat	O-16-048
 U+13FEB	kEH_Core	C
 U+13FEB	kEH_Desc	A column resembling a stem of papyrus with a bud (M13), on a base, with a 
-U+13FEB	kEH_Func	Classifier Pillar
+U+13FEB	kEH_Func	Classifier pillar
 U+13FEB	kEH_FVal	ꞽwn
 U+13FEB	kEH_UniK	O357
 U+13FEC	kEH_Cat	O-16-049
@@ -30403,7 +30404,7 @@ U+13FED	kEH_HG	O212
 U+13FEE	kEH_Cat	O-18-002
 U+13FEE	kEH_Core	C
 U+13FEE	kEH_Desc	A rectangular door bolt, resembling the forepart of a lion, with a rope used for locking attached to the paw of the lion, with a plummet attached to the rope.
-U+13FEE	kEH_Func	Classifier door-bolt
+U+13FEE	kEH_Func	Classifier door bolt
 U+13FEE	kEH_FVal	ḥkn
 U+13FEE	kEH_UniK	HJ O217
 U+13FEE	kEH_JSesh	O217
@@ -30412,7 +30413,7 @@ U+13FEE	kEH_IFAO	317,7
 U+13FEF	kEH_Cat	O-18-004
 U+13FEF	kEH_Core	C
 U+13FEF	kEH_Desc	A lion, lying down, tail curled over the body towards the back (E23), on top of a shrine, facing its mirror, connected with a rope running from paw to paw.
-U+13FEF	kEH_Func	Classifier door-bolt
+U+13FEF	kEH_Func	Classifier door bolt
 U+13FEF	kEH_FVal	kfꜣ/pḥ-ꜥḥꜥ
 U+13FEF	kEH_UniK	HJ O218
 U+13FEF	kEH_JSesh	O218
@@ -30428,13 +30429,13 @@ U+13FF0	kEH_JSesh	O219
 U+13FF0	kEH_HG	O219
 U+13FF1	kEH_Cat	O-18-013
 U+13FF1	kEH_Core	C
-U+13FF1	kEH_Desc	A door-bolt (O34), written over a circle of dots.
+U+13FF1	kEH_Desc	A door bolt (O034), written over a circle of dots.
 U+13FF1	kEH_Func	Phonemogram
 U+13FF1	kEH_FVal	sn
 U+13FF1	kEH_UniK	O034C
 U+13FF2	kEH_Cat	O-18-021
 U+13FF2	kEH_Core	C
-U+13FF2	kEH_Desc	A door-bolt (O34), written over two human feet and lower legs (D58), arranged horizontally.
+U+13FF2	kEH_Desc	A door bolt (O034), written over two human feet and lower legs (D58), arranged horizontally.
 U+13FF2	kEH_Func	Phonemogram
 U+13FF2	kEH_FVal	sbb
 U+13FF2	kEH_UniK	HJ O222
@@ -30638,7 +30639,7 @@ U+1400C	kEH_HG	R131
 U+1400D	kEH_Cat	O-24-025
 U+1400D	kEH_Core	C
 U+1400D	kEH_Desc	A domed building, in the form of a quarter of a circle, with a smaller quarter circle inside the corner away from the reading direction, with an extended pole at the back, with multiple perpendicular lines on top of the curved line. 
-U+1400D	kEH_Func	Classifier Harim, inner chamber
+U+1400D	kEH_Func	Classifier harim, inner chamber
 U+1400D	kEH_FVal	ꞽp.t
 U+1400D	kEH_UniK	O045A
 U+1400E	kEH_Cat	O-24-026
@@ -31025,7 +31026,7 @@ U+14041	kEH_HG	P2B
 U+14041	kEH_IFAO	327,11
 U+14042	kEH_Cat	P-02-017
 U+14042	kEH_Core	C
-U+14042	kEH_Desc	A boat/ship, resembling a crescent moon, on top of a rectangle of water, with a sail on top of a rectangle, with an oar/rudder at the back.
+U+14042	kEH_Desc	A boat/ship, a prow and stern curved inwards, ending with a flower-like shape, on top of a rectangle of water, with a sail on top of a rectangle, with an oar/rudder at the back.
 U+14042	kEH_Func	Classifier sailing upstream/going south
 U+14042	kEH_FVal	ḫnt(ꞽ)
 U+14042	kEH_UniK	HJ P002I
@@ -31071,7 +31072,7 @@ U+14047	kEH_HG	P36A
 U+14047	kEH_IFAO	328,8
 U+14048	kEH_Cat	P-03-014
 U+14048	kEH_Core	C
-U+14048	kEH_Desc	A boat/ship, resembling a crescent moon, with the head of a falcon, with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus) (N6) on top of the head, on top of the prow and stern, on top of a rectangle of water, with a shrine, seen from the side, with a downward sloping roof, with an uraeus at the front of the roof (O18A) inside the boat/ship, with an oar/rudder at the back.
+U+14048	kEH_Desc	A boat/ship, resembling a crescent moon, with the head of a falcon, with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus) (N6) on top of the head, on top of the prow and stern, on top of a rectangle of water, with a shrine, seen from the side, with a downward sloping roof, with an uraeus at the front of the roof (O18A) inside the boat/ship, with an oar/rudder at the back.
 U+14048	kEH_Func	Classifier boat/ship
 U+14048	kEH_FVal	wṯs-nfr.w
 U+14048	kEH_UniK	HJ P039
@@ -31080,7 +31081,7 @@ U+14048	kEH_HG	P39
 U+14048	kEH_IFAO	328,10
 U+14049	kEH_Cat	P-03-015
 U+14049	kEH_Core	C
-U+14049	kEH_Desc	A boat/ship, resembling a crescent moon, with the head of a falcon, with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus) (N6) on top of the head, on top of the prow and stern, prow lower than the stern, on top of a rectangle of water, with a shrine, seen from the side, with a downward sloping roof, with an uraeus at the front of the roof (O18A) inside the boat/ship, with an animal (leonid?) standing, wearing headgear resembling two feathers on top of goat horns, on top of a standard used for carrying religious symbols (R12) in front of the shrine, with a god with the head of a falcon, standing in front of the rudders, controlling the rudders with a horizontal rope with an uraeus at the front.
+U+14049	kEH_Desc	A boat/ship, resembling a crescent moon, with the head of a falcon, with the sun, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus) (N6) on top of the head, on top of the prow and stern, prow lower than the stern, on top of a rectangle of water, with a shrine, seen from the side, with a downward sloping roof, with an uraeus at the front of the roof (O18A) inside the boat/ship, with an animal (leonid?) standing, wearing headgear resembling two feathers on top of goat horns, on top of a standard used for carrying religious symbols (R12) in front of the shrine, with a god with the head of a falcon, standing in front of the rudders, controlling the rudders with a horizontal rope with an uraeus at the front.
 U+14049	kEH_Func	Classifier boat/ship
 U+14049	kEH_FVal	wṯs-nfr(.w)
 U+14049	kEH_UniK	HJ P040
@@ -31171,7 +31172,7 @@ U+14055	kEH_IFAO	329,14
 U+14056	kEH_Cat	P-03-048
 U+14056	kEH_Core	C
 U+14056	kEH_Desc	A boat/ship with a prow and stern resembling the handle of a sickle (U1), on top of a rectangle resembling water, with two falcons (G5), arranged horizontally, on top of a standard used for carrying religious symbols, with a loop under the horizontal beam, running over the vertical pole (R12A) inside the boat/ship.
-U+14056	kEH_Func	Logogram (Bark of the two divine falcons)
+U+14056	kEH_Func	Logogram (bark of the two divine falcons)
 U+14056	kEH_FVal	nṯr.wy
 U+14056	kEH_UniK	HJ P098
 U+14056	kEH_JSesh	P98
@@ -31209,7 +31210,7 @@ U+1405B	kEH_JSesh	P110
 U+1405B	kEH_HG	P110
 U+1405C	kEH_Cat	P-03-060
 U+1405C	kEH_Core	C
-U+1405C	kEH_Desc	God, standing, with the head of a falcon, with a sun-disk (N5) on his head, facing towards the back, both arms raised in front, hands held vertically, hand palms outwards, in front of a goddess, standing, with a headdress of bovine horns with a sun disk (F102), right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the woman, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh-sign, S34), at the loop (C228); inside a boat/ship with a prow and stern resembling the handle of a sickle (U1), on top of a canal (N36).
+U+1405C	kEH_Desc	God, standing, with the head of a falcon, with a sun disk (N5) on his head, facing towards the back, both arms raised in front, hands held vertically, hand palms outwards, in front of a goddess, standing, with a headdress of bovine horns with a sun disk (F102), right arm forward, hand at the height of the waist, holding a sceptre with a straight shaft, forked bottom and head of the Seth animal (S40) of the same size as the woman, left arm hanging beside the body, holding a tie or strap, used with sandals (ankh sign, S34), at the loop (C228); inside a boat/ship with a prow and stern resembling the handle of a sickle (U1), on top of a canal (N36).
 U+1405C	kEH_Func	Classifier bark
 U+1405C	kEH_FVal	wꞽꜣ
 U+1405C	kEH_UniK	HJ P054
@@ -31297,7 +31298,7 @@ U+14067	kEH_UniK	P059D
 U+14067	kEH_IFAO	330,12
 U+14068	kEH_Cat	P-03-083
 U+14068	kEH_Core	C
-U+14068	kEH_Desc	A moon-sickle shaped boat with a higher prow than stern, with the head of an antelope (F81) on top of the prow, on top of a sledge with two vertical internal strokes, with a falcon (G5) standing on top of a rectangular shrine, inside the boat/ship, with an oar/rudder at the back.
+U+14068	kEH_Desc	A moon-sickle shaped boat with a higher prow than stern, with the head of an antelope (F081) on top of the prow, on top of a sledge with two vertical internal strokes, with a falcon (G005) standing on top of a rectangular shrine, inside the boat/ship, with an oar/rudder at the back.
 U+14068	kEH_Func	Classifier bark of Sokar
 U+14068	kEH_FVal	ḥny
 U+14068	kEH_UniK	HJ P115
@@ -31306,7 +31307,7 @@ U+14068	kEH_HG	P115
 U+14068	kEH_IFAO	330,16
 U+14069	kEH_Cat	P-03-085
 U+14069	kEH_Core	C
-U+14069	kEH_Desc	A moon-sickle shaped boat with a higher prow than stern, with the head of an antelope (F81) on top of the prow, on top of a sledge with two vertical internal strokes, with a falcon (G5) standing on top of a low cone shape, inside the boat/ship, with an oar/rudder at the back.
+U+14069	kEH_Desc	A moon-sickle shaped boat with a higher prow than stern, with the head of an antelope (F081) on top of the prow, on top of a sledge with two vertical internal strokes, with a falcon (G005) standing on top of a low cone shape, inside the boat/ship, with an oar/rudder at the back.
 U+14069	kEH_Func	Classifier bark of Sokar
 U+14069	kEH_FVal	ḥnw
 U+14069	kEH_UniK	HJ P060A
@@ -31315,7 +31316,7 @@ U+14069	kEH_HG	P60A
 U+14069	kEH_IFAO	331,2
 U+1406A	kEH_Cat	P-03-086
 U+1406A	kEH_Core	C
-U+1406A	kEH_Desc	A moon-sickle shaped boat with a higher prow than stern, with a rudder, with the head of an antelope (F81) on top of the prow, facing inwards, with a downward line with multiple horizontal lines written over it coming from the head, on top of a sledge.
+U+1406A	kEH_Desc	A moon-sickle shaped boat with a higher prow than stern, with a rudder, with the head of an antelope (F081) on top of the prow, facing inwards, with a downward line with multiple horizontal lines written over it coming from the head, on top of a sledge.
 U+1406A	kEH_Func	Classifier bark of Sokar
 U+1406A	kEH_FVal	ḥnw
 U+1406A	kEH_UniK	HJ P060B
@@ -31324,7 +31325,7 @@ U+1406A	kEH_HG	P60B
 U+1406A	kEH_IFAO	331,3
 U+1406B	kEH_Cat	P-03-089
 U+1406B	kEH_Core	C
-U+1406B	kEH_Desc	A moon-sickle shaped boat with a higher stern than prow, with the head of an antelope (F81) on top of the stern, on top of a rectangle representing water, with a tall shrine with a round roof, with two vertical lines enclosing the top, on a base, without internal decoration (GID O20D), written inside the boat/ship.
+U+1406B	kEH_Desc	A moon-sickle shaped boat with a higher stern than prow, with the head of an antelope (F081) on top of the stern, on top of a rectangle representing water, with a tall shrine with a round roof, with two vertical lines enclosing the top, on a base, without internal decoration (O020D), written inside the boat/ship, with an oar/rudder at the front.
 U+1406B	kEH_Func	Logogram (Henu-bark of Sokar)
 U+1406B	kEH_FVal	ḥnw
 U+1406B	kEH_UniK	P063
@@ -31332,7 +31333,7 @@ U+1406B	kEH_HG	P63
 U+1406B	kEH_IFAO	331,6
 U+1406C	kEH_Cat	P-03-092
 U+1406C	kEH_Core	C
-U+1406C	kEH_Desc	A moon-sickle shaped boat with a higher stern than prow, with the head of an antelope (F81) on top of the stern, with lines crossing the prow, on top of a sledge with two vertical internal strokes, with a tall shrine with a round roof, with two vertical lines enclosing the top, on a base, without internal decoration (GID O20D), written inside the boat/ship.
+U+1406C	kEH_Desc	A moon-sickle shaped boat with a higher stern than prow, with the head of an antelope (F081) on top of the stern, on top of a sledge with two vertical internal strokes, with a tall shrine with a round roof, with two vertical lines enclosing the top, on a base, without internal decoration (O020D), written inside the boat/ship, with an oar/rudder at the front.
 U+1406C	kEH_Func	Classifier bark of Sokar
 U+1406C	kEH_FVal	ḥnw
 U+1406C	kEH_UniK	HJ P068
@@ -31366,7 +31367,7 @@ U+1406F	kEH_HG	P66
 U+1406F	kEH_IFAO	331,12
 U+14070	kEH_Cat	P-03-103
 U+14070	kEH_Core	C
-U+14070	kEH_Desc	A moon-sickle shaped boat with a higher prow than stern, with a rudder, with the head of an antelope (F81) on top of the prow, facing inwards, with a downward line with multiple horizontal lines written over it coming from the head, on top of a sledge, with a falcon (G5), standing on top of a rectangular shrine, with vertical lines as internal detail, written inside the boat/ship.
+U+14070	kEH_Desc	A moon-sickle shaped boat with a higher prow than stern, with a rudder, with the head of an antelope (F081) on top of the prow, facing inwards, with a downward line with multiple horizontal lines written over it coming from the head, on top of a sledge, with a falcon (G005), standing on top of a rectangular shrine, with vertical lines as internal detail, written inside the boat/ship.
 U+14070	kEH_Func	Logogram (Sokar)
 U+14070	kEH_FVal	skr
 U+14070	kEH_UniK	HJ P116
@@ -31375,7 +31376,7 @@ U+14070	kEH_HG	P116
 U+14070	kEH_IFAO	331,14
 U+14071	kEH_Cat	P-03-107
 U+14071	kEH_Core	C
-U+14071	kEH_Desc	A moon-sickle shaped boat with a higher stern than prow, with the head of an antelope (F81) on top of the stern, on top of a block shaped shrine or table, with a falcon (G5) standing on top of a low cone shape inside the boat/ship, with an oar/rudder at the front.
+U+14071	kEH_Desc	A moon-sickle shaped boat with a higher stern than prow, with the head of an antelope (F081) on top of the stern, on top of a block shaped shrine or table, with a falcon (G005) standing on top of a low cone shape inside the boat/ship, with an oar/rudder at the front.
 U+14071	kEH_Func	Logogram (Sokar)
 U+14071	kEH_FVal	skr
 U+14071	kEH_UniK	P069A
@@ -31386,7 +31387,7 @@ U+14072	kEH_HG	P61B
 U+14072	kEH_IFAO	332,4
 U+14073	kEH_Cat	P-03-112
 U+14073	kEH_Core	C
-U+14073	kEH_Desc	A moon-sickle shaped boat with a higher prow than stern, with the head of an antelope (F81) on top of the prow, on top of a rectangle representing water, with a falcon with spread wings, on top of a low cone shape inside the boat/ship, embracing the cone with its wings, with an oar/rudder at the back.
+U+14073	kEH_Desc	A moon-sickle shaped boat with a higher prow than stern, with the head of an antelope (F081) on top of the prow, on top of a rectangle representing water, with a falcon with spread wings, on top of a low cone shape inside the boat/ship, embracing the cone with its wings, with an oar/rudder at the back.
 U+14073	kEH_Func	Logogram (Henu-bark of Sokar)
 U+14073	kEH_FVal	ḥnw
 U+14073	kEH_UniK	HJ P066B
@@ -31394,7 +31395,7 @@ U+14073	kEH_JSesh	P66B
 U+14073	kEH_HG	P66B
 U+14074	kEH_Cat	P-03-113
 U+14074	kEH_Core	C
-U+14074	kEH_Desc	A moon-sickle shaped boat with a higher prow than stern, with the head of an antelope (F81) on top of the prow, on top of a sledge represented by four vertical lines between two horizontal lines, with a falcon with spread wings, on top of a low cone shape inside the boat/ship, embracing the cone with its wings, with an oar/rudder at the back.
+U+14074	kEH_Desc	A moon-sickle shaped boat with a higher prow than stern, with the head of an antelope (F081) on top of the prow, on top of a sledge represented by four vertical lines between two horizontal lines, with a falcon with spread wings, on top of a low cone shape inside the boat/ship, embracing the cone with its wings, with an oar/rudder at the back.
 U+14074	kEH_Func	Logogram (Henu-bark of Sokar)
 U+14074	kEH_FVal	ḥnw
 U+14074	kEH_UniK	HJ P097A
@@ -31402,7 +31403,7 @@ U+14074	kEH_JSesh	P97A
 U+14074	kEH_HG	P97A
 U+14075	kEH_Cat	P-03-114
 U+14075	kEH_Core	C
-U+14075	kEH_Desc	A moon-sickle shaped boat with a higher prow than stern, with the head of an antelope (F81) on top of the prow, with a downward line with multiple horizontal lines written over it coming from the head, on top of a sledge represented by four vertical lines between two horizontal lines, with a falcon with spread wings, on top of a low cone shape inside the boat/ship, embracing the cone with its wings, with an oar/rudder at the back.
+U+14075	kEH_Desc	A moon-sickle shaped boat with a higher prow than stern, with the head of an antelope (F081) on top of the prow, with a downward line with multiple horizontal lines written over it coming from the head, on top of a sledge represented by four vertical lines between two horizontal lines, with a falcon with spread wings, on top of a low cone shape inside the boat/ship, embracing the cone with its wings, with an oar/rudder at the back.
 U+14075	kEH_Func	Logogram (Sokar)
 U+14075	kEH_FVal	skr
 U+14075	kEH_UniK	HJ P097C
@@ -31441,7 +31442,7 @@ U+14079	kEH_FVal	mnš
 U+14079	kEH_UniK	P004G
 U+1407A	kEH_Cat	P-05-002
 U+1407A	kEH_Core	C
-U+1407A	kEH_Desc	A boat/ship, on top of a rectangle representing water, with a horizontal rectangle inside the ship with vertical lines as internal decoration, with three vertical poles on top of the rectangle, with a line running from the top of the middle pole to the front and stern, forming a triangular shape, with an oar/rudder at the back.
+U+1407A	kEH_Desc	A boat/ship, on top of a rectangle representing water, with a flat shape between prow and stern  with vertical lines as internal decoration, with three vertical poles on top of the rectangle, with a line running from the top of the middle pole to the front and stern, forming a triangular shape, with two oar/rudders at the back.
 U+1407A	kEH_Func	Classifier boat/ship
 U+1407A	kEH_FVal	mnš
 U+1407A	kEH_UniK	HJ P074
@@ -31515,7 +31516,7 @@ U+14083	kEH_HG	P5D
 U+14083	kEH_IFAO	334,5
 U+14084	kEH_Cat	P-06-033
 U+14084	kEH_Core	C
-U+14084	kEH_Desc	A sail, with a point at the bottom, angling backwards, with a distinct beam at the top, with a mast in front of the sail.
+U+14084	kEH_Desc	A sail, with a corner at the bottom, angling backwards, with a distinct beam at the top, with a mast in front of the sail.
 U+14084	kEH_Func	Classifier wind, breath, air
 U+14084	kEH_FVal	ꞽwn
 U+14084	kEH_UniK	HJ P005I
@@ -31523,7 +31524,7 @@ U+14084	kEH_JSesh	P5I
 U+14084	kEH_HG	P5I
 U+14085	kEH_Cat	P-06-034
 U+14085	kEH_Core	C
-U+14085	kEH_Desc	A sail, with a point at the bottom, angling backwards, with a mast in front of the sail.
+U+14085	kEH_Desc	A sail, with a corner at the bottom, angling backwards, with a mast in front of the sail.
 U+14085	kEH_Func	Classifier wind, breath, air
 U+14085	kEH_FVal	nfw/y
 U+14085	kEH_UniK	HJ P005J
@@ -31545,14 +31546,14 @@ U+14087	kEH_HG	P5K
 U+14087	kEH_IFAO	334,15
 U+14088	kEH_Cat	P-06-045
 U+14088	kEH_Core	C
-U+14088	kEH_Desc	A sail, with a point at the bottom, angling backwards, with a distinct beam at the top, with a mast in front of the sail, with a crossbeam over the mast, with rigging coming from the top of the sail to the mast.
+U+14088	kEH_Desc	A sail, with a corner at the bottom, angling backwards, with a distinct beam at the top, with a mast in front of the sail, with a crossbeam over the mast, with rigging coming from the top of the sail to the mast.
 U+14088	kEH_Func	Logogram (wind, breath, air)
 U+14088	kEH_FVal	ṯꜣw
 U+14088	kEH_UniK	P005Y
 U+14088	kEH_IFAO	335,3
 U+14089	kEH_Cat	P-06-046
 U+14089	kEH_Core	C
-U+14089	kEH_Desc	A sail, with a point at the bottom, angling forwards, with a distinct beam at the top, with a mast in front of the sail, with a crossbeam over the mast.
+U+14089	kEH_Desc	A sail, with a corner at the bottom, angling forwards, with a distinct beam at the top, with a mast in front of the sail, with a crossbeam over the mast.
 U+14089	kEH_Func	Classifier wind, breath, air
 U+14089	kEH_FVal	mḥy.t
 U+14089	kEH_UniK	HJ P005L
@@ -31569,7 +31570,7 @@ U+1408A	kEH_JSesh	P5G
 U+1408A	kEH_HG	P5G
 U+1408B	kEH_Cat	P-07-001
 U+1408B	kEH_Core	C
-U+1408B	kEH_Desc	A mast of a ship, with two prongs, with filling between the prongs.
+U+1408B	kEH_Desc	A mast of a ship, with two prongs, with white filling between the prongs.
 U+1408B	kEH_Func	Phonemogram
 U+1408B	kEH_FVal	ꜥḥꜥ
 U+1408B	kEH_UniK	HJ P118
@@ -31604,7 +31605,7 @@ U+1408F	kEH_HG	AA23A
 U+1408F	kEH_IFAO	478,8
 U+14090	kEH_Cat	P-07-028
 U+14090	kEH_Core	C
-U+14090	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), written over a mast of a ship with two prongs, connected by vertical lines (P6).
+U+14090	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), written over a mast of a ship with two prongs, connected by vertical lines (P6).
 U+14090	kEH_Func	Logogram (snake divinity)
 U+14090	kEH_FVal	ꜥḥꜥ.w
 U+14090	kEH_UniK	HJ P083
@@ -31954,8 +31955,8 @@ U+140BE	kEH_IFAO	343,15
 U+140BF	kEH_Cat	Q-05-037
 U+140BF	kEH_Core	C
 U+140BF	kEH_Desc	A box or shrine, with a rounded lid and upstanding edges, with the head of a bubalis antelope on top of the lid.
-U+140BF	kEH_Func	Logogram (crocodopolis)
-U+140BF	kEH_FVal	šd.t
+U+140BF	kEH_Func	Logogram (Crocodilopolis)
+U+140BF	kEH_FVal	Šd.t
 U+140BF	kEH_UniK	HJ Q047
 U+140BF	kEH_JSesh	Q47
 U+140BF	kEH_HG	Q47
@@ -32331,7 +32332,7 @@ U+140F3	kEH_UniK	R006B
 U+140F3	kEH_IFAO	352,1
 U+140F4	kEH_Cat	R-05-005
 U+140F4	kEH_Core	C
-U+140F4	kEH_Desc	A censer for fumigation, written vertically, with a triangular shape at the top and the bottom.
+U+140F4	kEH_Desc	A censer for fumigation, written vertically, with a trapezoidal shape at the top and the bottom.
 U+140F4	kEH_Func	Classifier incense fire
 U+140F4	kEH_FVal	snṯr-sḏ.t
 U+140F4	kEH_UniK	R006A
@@ -32399,7 +32400,7 @@ U+140FE	kEH_FVal	psḏ.t
 U+140FE	kEH_UniK	R008B
 U+140FF	kEH_Cat	R-07-009
 U+140FF	kEH_Core	C
-U+140FF	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), connected at the base of a cloth wound on a pole, an emblem of divinity (R8).
+U+140FF	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), connected at the base of a cloth wound on a pole, an emblem of divinity (R8).
 U+140FF	kEH_Func	Logogram (god and goddess)
 U+140FF	kEH_FVal	nṯr-nṯr.t
 U+140FF	kEH_UniK	HJ R045
@@ -32408,7 +32409,7 @@ U+140FF	kEH_HG	R45
 U+140FF	kEH_IFAO	353,11
 U+14100	kEH_Cat	R-07-010
 U+14100	kEH_Core	C
-U+14100	kEH_Desc	Three times a cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), connected at the base of a cloth wound on a pole, an emblem of divinity (R8), on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A).
+U+14100	kEH_Desc	Three times a cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), connected at the base of a cloth wound on a pole, an emblem of divinity (R8), on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A).
 U+14100	kEH_Func	Logogram (gods and goddesses)
 U+14100	kEH_FVal	nṯr.w-nṯr.wt
 U+14100	kEH_UniK	HJ R046
@@ -32417,7 +32418,7 @@ U+14100	kEH_HG	R46
 U+14100	kEH_IFAO	353,12
 U+14101	kEH_Cat	R-07-011
 U+14101	kEH_Core	C
-U+14101	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), connected at the base of a cloth wound on a pole, an emblem of divinity (R8), in front of three vertical strokes in a triangular orientation with one stroke a the top (Z2A); on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A).
+U+14101	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), connected at the base of a cloth wound on a pole, an emblem of divinity (R8), in front of three vertical strokes in a triangular orientation with one stroke a the top (Z2A); on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A).
 U+14101	kEH_Func	Logogram (gods and goddesses)
 U+14101	kEH_FVal	nṯr.w-nṯr.wt
 U+14101	kEH_UniK	HJ R107
@@ -32425,7 +32426,7 @@ U+14101	kEH_JSesh	R107
 U+14101	kEH_HG	R107
 U+14102	kEH_Cat	R-07-012
 U+14102	kEH_Core	C
-U+14102	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (Uraeus) (I64), connected at the base of a cloth wound on a pole, an emblem of divinity (R8), on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A).
+U+14102	kEH_Desc	A cobra (Naja haje), standing up, with expanded hood (uraeus) (I64), connected at the base of a cloth wound on a pole, an emblem of divinity (R8), on top of a standard used for the carrying of religious symbols with the vertical stick at the far side (R92A).
 U+14102	kEH_Func	Logogram (god and goddess)
 U+14102	kEH_FVal	nṯr-nṯr.t
 U+14102	kEH_UniK	HJ R107A
@@ -32439,7 +32440,7 @@ U+14103	kEH_IFAO	354,1
 U+14104	kEH_Cat	R-07-018
 U+14104	kEH_Core	C
 U+14104	kEH_Desc	A cloth wound on a pole, an emblem of divinity (R8), on top of a circle.
-U+14104	kEH_Func	Logogram (Natron)
+U+14104	kEH_Func	Logogram (natron)
 U+14104	kEH_FVal	ḥsmn
 U+14104	kEH_UniK	R009A
 U+14105	kEH_Cat	R-07-028
@@ -32473,7 +32474,7 @@ U+14108	kEH_HG	R10H
 U+14108	kEH_IFAO	355,2
 U+14109	kEH_Cat	R-07-040
 U+14109	kEH_Core	C
-U+14109	kEH_Desc	A cloth wound on a pole, an emblem of divinity (R8), written over top of a butcher's block, with the pole at the bottom of the block, at the back of a rectangular base, with a feather (H6), angled forwards on the tip of the base.
+U+14109	kEH_Desc	A cloth wound on a pole, an emblem of divinity (R8), written over top of a butcher's block, with the pole at the bottom of the block, at the back of a base, with a feather (H6), angled forwards on the tip of the base.
 U+14109	kEH_Func	Logogram (necropolis)
 U+14109	kEH_FVal	ẖr.t-nṯr
 U+14109	kEH_UniK	HJ R010D
@@ -32482,7 +32483,7 @@ U+14109	kEH_HG	R10D
 U+14109	kEH_IFAO	355,3
 U+1410A	kEH_Cat	R-07-044
 U+1410A	kEH_Core	C
-U+1410A	kEH_Desc	A cloth wound on a pole, an emblem of divinity (R8), written over top of a butcher's block, with the pole at the bottom of the block, on top of a rectangular base, with a feather (H6), angled forwards on the tip of the base and a sandy hill slope (N29) behind the butcher's block.
+U+1410A	kEH_Desc	A cloth wound on a pole, an emblem of divinity (R8), written over top of a butcher's block, with the pole at the bottom of the block, on top of a base, with a feather (H6), angled forwards on the tip of the base and a sandy hill slope (N29) behind the butcher's block.
 U+1410A	kEH_Func	Logogram (necropolis)
 U+1410A	kEH_FVal	ẖr.t-nṯr
 U+1410A	kEH_UniK	HJ R010G
@@ -32527,7 +32528,7 @@ U+14110	kEH_UniK	R010E
 U+14111	kEH_Cat	R-07-057
 U+14111	kEH_Core	C
 U+14111	kEH_Desc	Two times a cloth wound on a pole, an emblem of divinity (R8), arranged horizontally, on top of a standard used for carrying religious symbols, with a loop under the horizontal beam, running over the vertical pole (R12A).
-U+14111	kEH_Func	Logogram (18th UE nome)
+U+14111	kEH_Func	Logogram (18th nome of Upper Egypt)
 U+14111	kEH_FVal	nmt.y
 U+14111	kEH_UniK	HJ R108
 U+14111	kEH_JSesh	R108
@@ -32814,7 +32815,7 @@ U+14137	kEH_HG	R83
 U+14137	kEH_IFAO	363,4
 U+14138	kEH_Cat	R-14-009
 U+14138	kEH_Core	C
-U+14138	kEH_Desc	A wig without a fillet, with a headdress consisting of two plumes (S9), with a cobra (Naja haje), standing up, with expanded hood (Uraeus) written behind the wig, upon a pole.
+U+14138	kEH_Desc	A wig without a fillet, with a headdress consisting of two plumes (S9), with a cobra (Naja haje), standing up, with expanded hood (uraeus) written behind the wig, upon a pole.
 U+14138	kEH_Func	Logogram (Abydos)
 U+14138	kEH_FVal	ꜣbḏw
 U+14138	kEH_UniK	HJ R018A
@@ -32828,7 +32829,7 @@ U+14139	kEH_HG	R18F
 U+14139	kEH_IFAO	363,8
 U+1413A	kEH_Cat	R-14-012
 U+1413A	kEH_Core	C
-U+1413A	kEH_Desc	A wig without a fillet, with a headdress consisting of two plumes (S9), with a cobra (Naja haje), standing up, with expanded hood (Uraeus) written behind the wig, upon a pole (R18A), on top of a sand covered mountain over the edge of the cultivated areas (N26).
+U+1413A	kEH_Desc	A wig without a fillet, with a headdress consisting of two plumes (S9), with a cobra (Naja haje), standing up, with expanded hood (uraeus) written behind the wig, upon a pole (R18A), on top of a sand covered mountain over the edge of the cultivated areas (N26).
 U+1413A	kEH_Func	Logogram (Abydos)
 U+1413A	kEH_FVal	ꜣbḏw
 U+1413A	kEH_UniK	HJ R018B
@@ -32837,7 +32838,7 @@ U+1413A	kEH_HG	R18B
 U+1413A	kEH_IFAO	363,9
 U+1413B	kEH_Cat	R-14-014
 U+1413B	kEH_Core	C
-U+1413B	kEH_Desc	A wig without a fillet, with a headdress consisting of two plumes (S9), with a cobra (Naja haje), standing up, with expanded hood (Uraeus) written behind the wig, upon a pole (R18A), on top of the hill country over the edge of the cultivated areas (N25).
+U+1413B	kEH_Desc	A wig without a fillet, with a headdress consisting of two plumes (S9), with a cobra (Naja haje), standing up, with expanded hood (uraeus) written behind the wig, upon a pole (R18A), on top of the hill country over the edge of the cultivated areas (N25).
 U+1413B	kEH_Func	Logogram (Abydos)
 U+1413B	kEH_FVal	ꜣbḏw
 U+1413B	kEH_UniK	HJ R018D
@@ -32845,7 +32846,7 @@ U+1413B	kEH_JSesh	R18D
 U+1413B	kEH_HG	R18D
 U+1413C	kEH_Cat	R-14-018
 U+1413C	kEH_Core	C
-U+1413C	kEH_Desc	A wig without a fillet, with a headdress consisting of two plumes (S9), with a cobra (Naja haje), standing up, with expanded hood (Uraeus) written behind the wig, upon a pole (R18A), on top of a standard used for carrying religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
+U+1413C	kEH_Desc	A wig without a fillet, with a headdress consisting of two plumes (S9), with a cobra (Naja haje), standing up, with expanded hood (uraeus) written behind the wig, upon a pole (R18A), on top of a standard used for carrying religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
 U+1413C	kEH_Func	Logogram (Abydos)
 U+1413C	kEH_FVal	ꜣbḏw
 U+1413C	kEH_UniK	R018H
@@ -32936,7 +32937,7 @@ U+14148	kEH_JSesh	R88
 U+14148	kEH_HG	R88
 U+14148	kEH_IFAO	365,5
 U+14149	kEH_Cat	R-22-001
-U+14149	kEH_Func	Logogram/Classifier (the one of Shedet (i.e., Sobek)
+U+14149	kEH_Func	Logogram/Classifier (the one of Shedet (i.e., Sobek))
 U+14149	kEH_FVal	šd.ty
 U+14149	kEH_UniK	HJ R085
 U+14149	kEH_JSesh	R85
@@ -33070,7 +33071,7 @@ U+1415A	kEH_FVal	dšr.t
 U+1415A	kEH_UniK	S173A
 U+1415B	kEH_Cat	S-03-002
 U+1415B	kEH_Core	C
-U+1415B	kEH_Desc	The union of the red crown of Lower Egypt and the white crown of Upper Egypt, with the white crown worn within the red crown. (i.e., the double crown), with an Uraeus at the front.
+U+1415B	kEH_Desc	The union of the red crown of Lower Egypt and the white crown of Upper Egypt, with the white crown worn within the red crown. (i.e., the double crown), with an uraeus at the front.
 U+1415B	kEH_Func	Classifier double crown
 U+1415B	kEH_FVal	sḫm.ty
 U+1415B	kEH_UniK	S005A
@@ -33170,14 +33171,14 @@ U+14167	kEH_IFAO	369,6
 U+14168	kEH_Cat	S-07-004
 U+14168	kEH_Core	C
 U+14168	kEH_Desc	The Atef crown with ram horns and a sun disk, with a circle on top of the split top of the Atef crown.
-U+14168	kEH_Func	Logogram (Atef-crown)
+U+14168	kEH_Func	Logogram (Atef crown)
 U+14168	kEH_FVal	ꜣtf
 U+14168	kEH_UniK	S008B
 U+14168	kEH_IFAO	369,7
 U+14169	kEH_Cat	S-07-006
 U+14169	kEH_Core	C
 U+14169	kEH_Desc	The Atef crown, on top of the horns of a ram, with an uraeus, with a sun disk on the head, facing outwards, at either side of the crown.
-U+14169	kEH_Func	Logogram (Atef-crown)
+U+14169	kEH_Func	Logogram (Atef crown)
 U+14169	kEH_FVal	ꜣtf
 U+14169	kEH_UniK	S060A
 U+14169	kEH_HG	S60A
@@ -33189,8 +33190,8 @@ U+1416A	kEH_HG	S60
 U+1416A	kEH_IFAO	369,9
 U+1416B	kEH_Cat	S-08-001
 U+1416B	kEH_Core	C
-U+1416B	kEH_Desc	A crown, consisting of three horizontally arranged Atef crowns with a round bulb at the top, and the sun-disk at the base, on top of the horns of a ram, with an uraeus, with a sun disk on the head, facing outwards, at either side of the crown, with two ureai hanging downwards from the horns at either side.
-U+1416B	kEH_Func	Logogram (Hemhem-crown)
+U+1416B	kEH_Desc	A crown, consisting of three horizontally arranged Atef crowns with a round bulb at the top, and the sun disk at the base, on top of the horns of a ram, with an uraeus, with a sun disk on the head, facing outwards, at either side of the crown, with two ureai hanging downwards from the horns at either side.
+U+1416B	kEH_Func	Logogram (Hemhem crown)
 U+1416B	kEH_FVal	hmhm
 U+1416B	kEH_UniK	HJ S061
 U+1416B	kEH_JSesh	S61
@@ -33198,8 +33199,8 @@ U+1416B	kEH_HG	S61
 U+1416B	kEH_IFAO	369,10
 U+1416C	kEH_Cat	S-08-002
 U+1416C	kEH_Core	C
-U+1416C	kEH_Desc	A crown, consisting of three horizontally arranged Atef crowns with a round bulb at the top, and the sun-disk at the base, on top of the horns of a ram, with an uraeus, with a sun disk on the head, facing outwards, at either side of the crown.
-U+1416C	kEH_Func	Logogram (Hemhem-crown)
+U+1416C	kEH_Desc	A crown, consisting of three horizontally arranged Atef crowns with a round bulb at the top, and the sun disk at the base, on top of the horns of a ram, with an uraeus, with a sun disk on the head, facing outwards, at either side of the crown.
+U+1416C	kEH_Func	Logogram (Hemhem crown)
 U+1416C	kEH_FVal	hmhm
 U+1416C	kEH_UniK	HJ S061A
 U+1416C	kEH_JSesh	S61A
@@ -33208,7 +33209,7 @@ U+1416C	kEH_IFAO	369,11
 U+1416D	kEH_Cat	S-08-005
 U+1416D	kEH_Core	C
 U+1416D	kEH_Desc	A crown, consisting of three horizontally arranged Atef crowns, on top of the horns of a ram, with an uraeus, facing outwards, at either side of the crown.
-U+1416D	kEH_Func	Logogram (Hemhem-crown)
+U+1416D	kEH_Func	Logogram (Hemhem crown)
 U+1416D	kEH_FVal	hmhm
 U+1416D	kEH_UniK	S061D
 U+1416E	kEH_Cat	S-09-002
@@ -33222,7 +33223,7 @@ U+1416E	kEH_HG	S62
 U+1416E	kEH_IFAO	369,13
 U+1416F	kEH_Cat	S-09-004
 U+1416F	kEH_Core	C
-U+1416F	kEH_Desc	A headdress consisting of two plumes, with a sun-disk between them, on top of a short vertical line.
+U+1416F	kEH_Desc	A headdress consisting of two plumes, with a sun disk between them, on top of a short vertical line.
 U+1416F	kEH_Func	Logogram (double plumes/two feather crown)
 U+1416F	kEH_FVal	šw.ty
 U+1416F	kEH_UniK	HJ S063
@@ -33231,7 +33232,7 @@ U+1416F	kEH_HG	S63
 U+1416F	kEH_IFAO	370,2
 U+14170	kEH_Cat	S-09-005
 U+14170	kEH_Core	C
-U+14170	kEH_Desc	A headdress consisting of two plumes, with a sun-disk between them.
+U+14170	kEH_Desc	A headdress consisting of two plumes, with a sun disk between them.
 U+14170	kEH_Func	Logogram (double plumes/two feather crown)
 U+14170	kEH_FVal	šw.ty
 U+14170	kEH_UniK	HJ S063A
@@ -33258,7 +33259,7 @@ U+14173	kEH_JSesh	S67
 U+14173	kEH_HG	S67
 U+14174	kEH_Cat	S-09-019
 U+14174	kEH_Core	C
-U+14174	kEH_Desc	A headdress consisting of the horns of a ram with two plumes on top of it, with a sun-disk between the plumes.
+U+14174	kEH_Desc	A headdress consisting of the horns of a ram with two plumes on top of it, with a sun disk between the plumes.
 U+14174	kEH_Func	Logogram (double plumes/two feather crown)
 U+14174	kEH_FVal	šw.ty
 U+14174	kEH_UniK	HJ S064
@@ -33267,7 +33268,7 @@ U+14174	kEH_HG	S64
 U+14174	kEH_IFAO	370,12
 U+14175	kEH_Cat	S-09-020
 U+14175	kEH_Core	C
-U+14175	kEH_Desc	A headdress consisting of the horns of a ram with two plumes on top of it, angled backwards, with a sun-disk between the plumes.
+U+14175	kEH_Desc	A headdress consisting of the horns of a ram with two plumes on top of it, angled backwards, with a sun disk between the plumes.
 U+14175	kEH_Func	Logogram (double plumes/two feather crown)
 U+14175	kEH_FVal	šw.ty
 U+14175	kEH_UniK	S064A
@@ -33282,7 +33283,7 @@ U+14176	kEH_HG	S72A
 U+14176	kEH_IFAO	370,13
 U+14177	kEH_Cat	S-09-022
 U+14177	kEH_Core	C
-U+14177	kEH_Desc	A headdress consisting of the base of a crown (S55), with two plumes on top of it, with a sun-disk between the plumes.
+U+14177	kEH_Desc	A headdress consisting of the base of a crown (S55), with two plumes on top of it, with a sun disk between the plumes.
 U+14177	kEH_Func	Logogram (double plumes/two feather crown)
 U+14177	kEH_FVal	šw.ty
 U+14177	kEH_UniK	HJ S072
@@ -33291,7 +33292,7 @@ U+14177	kEH_HG	S72
 U+14177	kEH_IFAO	370,14
 U+14178	kEH_Cat	S-09-025
 U+14178	kEH_Core	C
-U+14178	kEH_Desc	A headdress consisting of two feathers on top of the horns of a ram, with a sun-disk between the feathers, with a cobra (Naja haje), standing up, with expanded hood (Uraeus), with sun disks its head on either side of the feathers, orientated outwards.
+U+14178	kEH_Desc	A headdress consisting of two feathers on top of the horns of a ram, with a sun disk between the feathers, with a cobra (Naja haje), standing up, with expanded hood (uraeus), with sun disks its head on either side of the feathers, orientated outwards.
 U+14178	kEH_Func	Phonemogram
 U+14178	kEH_FVal	ṯn
 U+14178	kEH_UniK	HJ S075
@@ -33300,9 +33301,9 @@ U+14178	kEH_HG	S75
 U+14178	kEH_IFAO	371,1
 U+14179	kEH_Cat	S-09-026
 U+14179	kEH_Core	C
-U+14179	kEH_Desc	A headdress consisting of two feathers on top of the horns of a ram, with a cobra (Naja haje), standing up, with expanded hood (Uraeus), with sun disks its head on either side of the feathers, orientated outwards.
+U+14179	kEH_Desc	A headdress consisting of two feathers on top of the horns of a ram, with a cobra (Naja haje), standing up, with expanded hood (uraeus), with sun disks its head on either side of the feathers, orientated outwards.
 U+14179	kEH_Func	Logogram (Elkab)
-U+14179	kEH_FVal	nḫb
+U+14179	kEH_FVal	Nḫb
 U+14179	kEH_UniK	HJ S074
 U+14179	kEH_JSesh	S74
 U+14179	kEH_HG	S74
@@ -33351,7 +33352,7 @@ U+1417E	kEH_HG	S78A
 U+1417E	kEH_IFAO	371,10
 U+1417F	kEH_Cat	S-09-040
 U+1417F	kEH_Core	C
-U+1417F	kEH_Desc	A headdress consisting of two feathers on top of the horns of a ram, with a sun-disk between the feathers, with a cobra (Naja haje), standing up, with expanded hood (Uraeus), on either side of the feathers, orientated outwards; on top of a half-circle shaped base.
+U+1417F	kEH_Desc	A headdress consisting of two feathers on top of the horns of a ram, with a sun disk between the feathers, with a cobra (Naja haje), standing up, with expanded hood (uraeus), on either side of the feathers, orientated outwards; on top of a half-circle shaped base.
 U+1417F	kEH_Func	Phonemogram
 U+1417F	kEH_FVal	ṯn
 U+1417F	kEH_UniK	HJ S075A
@@ -33367,7 +33368,7 @@ U+14180	kEH_JSesh	S80A
 U+14180	kEH_HG	S80A
 U+14181	kEH_Cat	S-09-043
 U+14181	kEH_Core	C
-U+14181	kEH_Desc	A dung beetle, scarab (scarabaeus sacer) (L1), with the fully extended wing of a bird (H5) on either side of the body (L12A), on top of a sun-disk, on top of the horns of a ram, with a feather (H6), orientated outwards, at either side of the scarab, connected to the tip of the wings.
+U+14181	kEH_Desc	A dung beetle, scarab (scarabaeus sacer) (L1), with the fully extended wing of a bird (H5) on either side of the body (L12A), on top of a sun disk, on top of the horns of a ram, with a feather (H6), orientated outwards, at either side of the scarab, connected to the tip of the wings.
 U+14181	kEH_Func	Logogram (who goes forth from the horizon)
 U+14181	kEH_FVal	pr-m-ꜣḫ.t
 U+14181	kEH_UniK	S080B
@@ -33454,7 +33455,7 @@ U+1418B	kEH_HG	S11A
 U+1418B	kEH_IFAO	373,5
 U+1418C	kEH_Cat	S-11-011
 U+1418C	kEH_Core	C
-U+1418C	kEH_Desc	A collar of beads with ornamental terminals, resembling the head of a falcon with a sun-disk on its head, looking outwards, with two vertical strings with flower-like end-pieces, curving outwards and downwards, coming from the collar.
+U+1418C	kEH_Desc	A collar of beads with ornamental terminals, resembling the head of a falcon with a sun disk on its head, looking outwards, with two vertical strings with flower-like end-pieces, curving outwards and downwards, coming from the collar.
 U+1418C	kEH_Func	Logogram collar
 U+1418C	kEH_FVal	bb
 U+1418C	kEH_UniK	HJ S011D
@@ -33869,7 +33870,7 @@ U+141C4	kEH_JSesh	S106
 U+141C4	kEH_HG	S106
 U+141C5	kEH_Cat	S-17-005
 U+141C5	kEH_Core	C
-U+141C5	kEH_Desc	A tie or strap, used with sandals (ankh-sign, S34), with the sun, within a halo (N5) on top of the loop.
+U+141C5	kEH_Desc	A tie or strap, used with sandals (ankh sign, S34), with the sun, within a halo (N5) on top of the loop.
 U+141C5	kEH_Func	classifier time
 U+141C5	kEH_FVal	nḥḥ
 U+141C5	kEH_UniK	HJ S133
@@ -33878,15 +33879,15 @@ U+141C5	kEH_HG	S133
 U+141C5	kEH_IFAO	382,14
 U+141C6	kEH_Cat	S-17-007
 U+141C6	kEH_Core	C
-U+141C6	kEH_Desc	A vessel with a spout and broad rim, made to resemble a tie or strap, used with sandals (ankh-sign, S34).
-U+141C6	kEH_Func	Classifier Ankh vessel
+U+141C6	kEH_Desc	A vessel with a spout and broad rim, made to resemble a tie or strap, used with sandals (ankh sign, S34).
+U+141C6	kEH_Func	Classifier ankh vessel
 U+141C6	kEH_FVal	ꜥnḫ
 U+141C6	kEH_UniK	S134
 U+141C6	kEH_JSesh	S134
 U+141C6	kEH_HG	S134B
 U+141C7	kEH_Cat	S-17-009
 U+141C7	kEH_Core	C
-U+141C7	kEH_Desc	A tie or strap, used with sandals (ankh-sign, S34), with a column imitating a bundle of stalks tied together (R11) replacing the vertical strap.
+U+141C7	kEH_Desc	A tie or strap, used with sandals (ankh sign, S34), with a column imitating a bundle of stalks tied together (R11) replacing the vertical strap.
 U+141C7	kEH_Func	Logogram (stability and life)
 U+141C7	kEH_FVal	ḏd-ꜥnḫ
 U+141C7	kEH_UniK	HJ S135
@@ -33895,7 +33896,7 @@ U+141C7	kEH_HG	S135
 U+141C7	kEH_IFAO	383,3
 U+141C8	kEH_Cat	S-17-012
 U+141C8	kEH_Core	C
-U+141C8	kEH_Desc	A tie or strap, used with sandals (ankh-sign, S34), a column imitating a bundle of stalks tied together (R11) and a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (S40), arranged horizontally; on top of a wickerwork basket.
+U+141C8	kEH_Desc	A tie or strap, used with sandals (ankh sign, S34), a column imitating a bundle of stalks tied together (R11) and a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (S40), arranged horizontally; on top of a wickerwork basket.
 U+141C8	kEH_Func	Logogram (all life, stability and dominion)
 U+141C8	kEH_FVal	ꜥnḫ-ḏd-wꜣs-nb
 U+141C8	kEH_UniK	HJ S176
@@ -33903,7 +33904,7 @@ U+141C8	kEH_JSesh	S176
 U+141C8	kEH_HG	S176
 U+141C9	kEH_Cat	S-17-013
 U+141C9	kEH_Core	C
-U+141C9	kEH_Desc	A tie or strap, used with sandals (ankh-sign, S34) and a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (S40), arranged horizontally; on top of a wickerwork basket.
+U+141C9	kEH_Desc	A tie or strap, used with sandals (ankh sign, S34) and a sceptre with a straight shaft, a forked base, topped with the head of the Seth animal (S40), arranged horizontally; on top of a wickerwork basket.
 U+141C9	kEH_Func	Logogram (all life and dominion)
 U+141C9	kEH_FVal	ꜥnḫ-wꜣs-nb
 U+141C9	kEH_UniK	S176A
@@ -34420,8 +34421,8 @@ U+1420D	kEH_IFAO	416,9
 U+1420E	kEH_Cat	T-07-010
 U+1420E	kEH_Core	C
 U+1420E	kEH_Desc	An arrow with rectangular fletching, written vertically, on top of a plan of a crossroads in a village (O49).
-U+1420E	kEH_Func	Logogram (Synene (Aswan))
-U+1420E	kEH_FVal	swn.w
+U+1420E	kEH_Func	Logogram (Syene (Aswan))
+U+1420E	kEH_FVal	Swn.w
 U+1420E	kEH_UniK	HJ T125
 U+1420E	kEH_JSesh	T125
 U+1420E	kEH_HG	T125
@@ -34464,7 +34465,7 @@ U+14213	kEH_HG	T60A
 U+14214	kEH_Cat	T-07-026
 U+14214	kEH_Core	C
 U+14214	kEH_Desc	A shield with a rounded top, with two arrows crossed over it, fletching upwards (T62), on top of a standard used for carrying religious symbols, with a loop under the horizontal beam, running over the vertical pole (R12A).
-U+14214	kEH_Func	Logogram (Neith, 4-5th nome of LE)
+U+14214	kEH_Func	Logogram (Neith, 4th and 5th nomes of Lower Egypt)
 U+14214	kEH_FVal	n.t
 U+14214	kEH_UniK	HJ T063
 U+14214	kEH_JSesh	T63
@@ -34473,19 +34474,19 @@ U+14214	kEH_IFAO	417,8
 U+14215	kEH_Cat	T-07-027
 U+14215	kEH_Core	C
 U+14215	kEH_Desc	A shield with a rounded top, on top of a base, with an arrow with the fletching upwards sticking out at either side.
-U+14215	kEH_Func	Logogram (Neith, 4-5th nome of LE)
+U+14215	kEH_Func	Logogram (Neith, 4th and 5th nomes of Lower Egypt)
 U+14215	kEH_FVal	n.t
 U+14215	kEH_UniK	T063E
 U+14216	kEH_Cat	T-07-028
 U+14216	kEH_Core	C
 U+14216	kEH_Desc	A shield with a rounded top, with two arrows crossed over it, fletching upwards (T62), on top of a standard used for carrying religious symbols, with a short vertical pole, with a loop under the horizontal beam, running over the vertical pole (R56).
-U+14216	kEH_Func	Logogram (Neith, 4-5th nome of LE)
+U+14216	kEH_Func	Logogram (Neith, 4th and 5th nomes of Lower Egypt)
 U+14216	kEH_FVal	n.t
 U+14216	kEH_UniK	T063F
 U+14217	kEH_Cat	T-07-029
 U+14217	kEH_Core	C
 U+14217	kEH_Desc	A shield with a rounded top, with two arrows crossed over it, arrowheads at the top; on top of a standard used for carrying religious symbols, with a short vertical pole, with a loop under the horizontal beam, running over the vertical pole (R56).
-U+14217	kEH_Func	Logogram (Neith, 4-5th nome of LE)
+U+14217	kEH_Func	Logogram (Neith, 4th and 5th nomes of Lower Egypt)
 U+14217	kEH_FVal	n.t
 U+14217	kEH_UniK	HJ T063C
 U+14217	kEH_JSesh	T63C
@@ -34493,7 +34494,7 @@ U+14217	kEH_HG	T63C
 U+14218	kEH_Cat	T-07-030
 U+14218	kEH_Core	C
 U+14218	kEH_Desc	A shield with a rounded top, with two arrows crossed over it, fletching upwards (T62), in front of a clump of three papyrus flowers, with two buds bent down (M15); on top of a standard used for carrying religious symbols (R12).
-U+14218	kEH_Func	Logogram (Neith-north, 5th nome of LE)
+U+14218	kEH_Func	Logogram (Neith-North, 5th nome of Lower Egypt)
 U+14218	kEH_FVal	n.t-mḥ.yt
 U+14218	kEH_UniK	HJ T064
 U+14218	kEH_JSesh	T64
@@ -34501,7 +34502,7 @@ U+14218	kEH_HG	T64
 U+14219	kEH_Cat	T-07-031
 U+14219	kEH_Core	C
 U+14219	kEH_Desc	A shield with a rounded top, with two arrows crossed over it, fletching upwards (T62), in front of a sedge (M23); on top of a standard used for carrying religious symbols (R12).
-U+14219	kEH_Func	Logogram (Neith-south, 4th nome LE)
+U+14219	kEH_Func	Logogram (Neith-South, 4th nome of Lower Egypt)
 U+14219	kEH_FVal	n.t-rs.yt
 U+14219	kEH_UniK	HJ T116B
 U+14219	kEH_JSesh	T116B
@@ -34513,7 +34514,7 @@ U+1421A	kEH_HG	T64B
 U+1421B	kEH_Cat	T-07-038
 U+1421B	kEH_Core	C
 U+1421B	kEH_Desc	A shield with a rounded top, with two arrows crossed over it, fletching upwards (T62) in front of a mouth (D21) written over a sedge (M23); on top of a standard used for carrying religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
-U+1421B	kEH_Func	Logogram (Neith-south, 4th nome LE)
+U+1421B	kEH_Func	Logogram (Neith-South, 4th nome of Lower Egypt)
 U+1421B	kEH_FVal	n.t-rs.yt
 U+1421B	kEH_UniK	HJ T116
 U+1421B	kEH_JSesh	T116
@@ -34521,7 +34522,7 @@ U+1421B	kEH_HG	T116
 U+1421C	kEH_Cat	T-07-039
 U+1421C	kEH_Core	C
 U+1421C	kEH_Desc	A shield with a rounded top, with two arrows crossed over it, fletching upwards (T62) in front of a sedge (M23); on top of a standard used for carrying religious symbols (R12), on top of a parcel of land with irrigation ditches (N24).
-U+1421C	kEH_Func	Logogram (Neith-south, 4th nome LE)
+U+1421C	kEH_Func	Logogram (Neith-South, 4th nome of Lower Egypt)
 U+1421C	kEH_FVal	n.t-rs.yt
 U+1421C	kEH_UniK	HJ T116A
 U+1421C	kEH_JSesh	T116A
@@ -34648,8 +34649,8 @@ U+1422C	kEH_HG	T133
 U+1422D	kEH_Cat	T-09-020
 U+1422D	kEH_Core	C
 U+1422D	kEH_Desc	Two throwing-sticks, or clubs used by foreign people (T14), arranged horizontally, on top of a standard used for carrying religious symbols, with a loop under the horizontal beam, running over the vertical pole (R12A).
-U+1422D	kEH_Func	Logogram/phonemogram (meter canal)
-U+1422D	kEH_FVal	mtr
+U+1422D	kEH_Func	Logogram/phonemogram (Meter canal)
+U+1422D	kEH_FVal	Mtr
 U+1422D	kEH_UniK	T142
 U+1422E	kEH_Cat	T-09-024
 U+1422E	kEH_Core	C
@@ -34661,7 +34662,7 @@ U+1422E	kEH_JSesh	T124
 U+1422E	kEH_HG	T124
 U+1422F	kEH_Cat	T-10-005
 U+1422F	kEH_Core	C
-U+1422F	kEH_Desc	A scimitar (khopesh), written vertically, blade curving inwards, with the head of a falcon with a sun-disk (N5) on top of it.
+U+1422F	kEH_Desc	A scimitar (khopesh), written vertically, blade curving inwards, with the head of a falcon with a sun disk (N5) on top of it.
 U+1422F	kEH_Func	Logogram (to be strong, brave, capable)
 U+1422F	kEH_FVal	ḳnꞽ
 U+1422F	kEH_UniK	HJ T073
@@ -34670,14 +34671,14 @@ U+1422F	kEH_HG	T73
 U+1422F	kEH_IFAO	420,12
 U+14230	kEH_Cat	T-10-006
 U+14230	kEH_Core	C
-U+14230	kEH_Desc	A scimitar (khopesh), written vertically, blade curving forwards, with the head of a falcon with a sun-disk (N5) on top of it.
+U+14230	kEH_Desc	A scimitar (khopesh), written vertically, blade curving forwards, with the head of a falcon with a sun disk (N5) on top of it.
 U+14230	kEH_Func	Logogram (valour, strength)
 U+14230	kEH_FVal	ḳn.t
 U+14230	kEH_UniK	T073B
 U+14231	kEH_Cat	T-10-007
 U+14231	kEH_Core	C
-U+14231	kEH_Desc	A scimitar (khopesh), written vertically, blade curving inwards, with the head of a falcon with he sun within a halo, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus) (N6); on top of the head.
-U+14231	kEH_Func	Logogram (Khopesh sword/scimitar)
+U+14231	kEH_Desc	A scimitar (khopesh), written vertically, blade curving inwards, with the head of a falcon with he sun within a halo, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus) (N6); on top of the head.
+U+14231	kEH_Func	Logogram (khopesh sword/scimitar)
 U+14231	kEH_FVal	ḫpš
 U+14231	kEH_UniK	HJ T073A
 U+14231	kEH_JSesh	T73A
@@ -34685,14 +34686,14 @@ U+14231	kEH_HG	T73A
 U+14231	kEH_IFAO	420,13
 U+14232	kEH_Cat	T-10-008
 U+14232	kEH_Core	C
-U+14232	kEH_Desc	A scimitar (khopesh), written vertically, blade curving forwards, with the head of a falcon with he sun within a halo, encircled by a cobra (Naja haje), standing up, with expanded hood (Uraeus) (N6); on top of the head.
+U+14232	kEH_Desc	A scimitar (khopesh), written vertically, blade curving forwards, with the head of a falcon with he sun within a halo, encircled by a cobra (Naja haje), standing up, with expanded hood (uraeus) (N6); on top of the head.
 U+14232	kEH_Func	Classifier to be strong, brave, capable
 U+14232	kEH_FVal	ḳn
 U+14232	kEH_UniK	T073C
 U+14233	kEH_Cat	T-10-009
 U+14233	kEH_Core	C
 U+14233	kEH_Desc	A scimitar (khopesh), written vertically, blade curving inwards, with the head of a falcon, wearing the double crown (S5), on top of it.
-U+14233	kEH_Func	Logogram (Khopesh sword/scimitar)
+U+14233	kEH_Func	Logogram (khopesh sword/scimitar)
 U+14233	kEH_FVal	ḫpš
 U+14233	kEH_UniK	T073D
 U+14234	kEH_Cat	T-10-010
@@ -34919,14 +34920,14 @@ U+1424F	kEH_IFAO	424,9
 U+14250	kEH_Cat	T-13-064
 U+14250	kEH_Core	C
 U+14250	kEH_Desc	A spear, arrow without fletching or a harpoon without handle, written horizontally, on top of a boat/ship, resembling a crescent moon, with an oar/rudder at the back, connected by three lines; on a standard used for carrying religious symbols, with a loop under the horizontal beam, running over the vertical pole (R12A).
-U+14250	kEH_Func	Logogram (7-8th nome of Lower Egypt)
+U+14250	kEH_Func	Logogram (7th and 8th nomes of Lower Egypt)
 U+14250	kEH_FVal	wꜥ-m-ḥww
 U+14250	kEH_UniK	T083C
 U+14250	kEH_IFAO	424,10
 U+14251	kEH_Cat	T-13-066
 U+14251	kEH_Core	C
 U+14251	kEH_Desc	A spear, arrow without fletching or a harpoon without handle, written horizontally, on top of a crescent moon shape, connected by three lines, point towards the front; on a standard used for carrying religious symbols, with a loop under the horizontal beam, running over the vertical pole (R12A).
-U+14251	kEH_Func	Logogram (7-8th nome of Lower Egypt)
+U+14251	kEH_Func	Logogram (7th and 8th nomes of Lower Egypt)
 U+14251	kEH_FVal	wꜥ-m-ḥww
 U+14251	kEH_UniK	T083D
 U+14252	kEH_Cat	T-13-067
@@ -35083,7 +35084,7 @@ U+14267	kEH_HG	T26E
 U+14267	kEH_IFAO	426,4
 U+14268	kEH_Cat	T-16-004
 U+14268	kEH_Core	C
-U+14268	kEH_Desc	A bird trap, with one vertical and horizontal pole, with multiple lines running from the horizontal to the vertical pole, with two lines at 45° coming from the corner.
+U+14268	kEH_Desc	A bird trap, with one vertical and horizontal pole, with multiple lines running from the horizontal to the vertical pole, with two lines at 45 degree coming from the corner.
 U+14268	kEH_Func	Phonemogram
 U+14268	kEH_FVal	sḫt
 U+14268	kEH_UniK	HJ T026F
@@ -35132,7 +35133,7 @@ U+1426D	kEH_UniK	T026J
 U+1426D	kEH_IFAO	426,9
 U+1426E	kEH_Cat	T-16-011
 U+1426E	kEH_Core	C
-U+1426E	kEH_Desc	A bird trap, with a horizontal beam and an upstanding beam at 20° clockwise, with a line running from the front to the upstanding beam.
+U+1426E	kEH_Desc	A bird trap, with a horizontal beam and an upstanding beam at 20 degree clockwise, with a line running from the front to the upstanding beam.
 U+1426E	kEH_Func	Classifier catching, netting
 U+1426E	kEH_FVal	sḫt
 U+1426E	kEH_UniK	HJ T026D
@@ -35995,7 +35996,7 @@ U+142E2	kEH_IFAO	405,6
 U+142E3	kEH_Cat	U-16-003
 U+142E3	kEH_Core	C
 U+142E3	kEH_Desc	A balance, with the pole resembling a column with a base, with a tenon at the top (O28B), with a plummet, resembling a heart (F34).
-U+142E3	kEH_Func	Logogram (balance; in mḫꜣ.t-tꜣ.wy)
+U+142E3	kEH_Func	Logogram (balance (in mḫꜣ.t-tꜣ.wy))
 U+142E3	kEH_FVal	mḫꜣ.t
 U+142E3	kEH_UniK	HJ U038C
 U+142E3	kEH_JSesh	U38C
@@ -36078,7 +36079,7 @@ U+142ED	kEH_IFAO	406,16
 U+142EE	kEH_Cat	U-16-029
 U+142EE	kEH_Core	C
 U+142EE	kEH_Desc	The pole of a balance, represented as a vertical line with a curved hook at the front.
-U+142EE	kEH_Func	Classifier to raise to lift up
+U+142EE	kEH_Func	Classifier to raise, to lift up
 U+142EE	kEH_FVal	sṯsꞽ
 U+142EE	kEH_UniK	HJ U039Q
 U+142EE	kEH_JSesh	U39Q
@@ -36343,7 +36344,7 @@ U+14312	kEH_IFAO	479,4
 U+14313	kEH_Cat	U-19-001
 U+14313	kEH_Core	C
 U+14313	kEH_Desc	A circular sieve.
-U+14313	kEH_Func	Classifier gold-dust
+U+14313	kEH_Func	Classifier gold dust
 U+14313	kEH_FVal	nḳr
 U+14313	kEH_UniK	HJ U101
 U+14313	kEH_JSesh	U101
@@ -36458,7 +36459,7 @@ U+14321	kEH_JSesh	V45
 U+14321	kEH_HG	V45
 U+14322	kEH_Cat	V-01-043
 U+14322	kEH_Core	C
-U+14322	kEH_Desc	A loop of cord with the ends upwards (V6), combined with a folded piece of cloth (S29).
+U+14322	kEH_Desc	A loop of cord with the ends upwards (V006), combined with a folded piece of cloth (S029) mirrored horizontally.
 U+14322	kEH_Func	Classifier clothing
 U+14322	kEH_FVal	ḥbs
 U+14322	kEH_UniK	HJ V048
@@ -36476,7 +36477,7 @@ U+14323	kEH_HG	V49
 U+14323	kEH_IFAO	433,2
 U+14324	kEH_Cat	V-02-007
 U+14324	kEH_Core	C
-U+14324	kEH_Desc	An egg (H8), written inside a cartouche in a round form (V9), with three stems of papyrus with a bud (M13) at the front, and three stems of papyrus with a flowering bud (M127) at the back.
+U+14324	kEH_Desc	An egg (H008) above a stroke shaped like an eyebrow (D013), written inside a cartouche in a round form (V009), with three stems of papyrus with a bud (M013) at the front, and three stems of papyrus with a flowering bud (M127) at the back.
 U+14324	kEH_Func	Logogram (cult image?)
 U+14324	kEH_FVal	dmꞽ/ḫꜣdb
 U+14324	kEH_UniK	HJ V054
@@ -36661,7 +36662,7 @@ U+1433C	kEH_FVal	ḫsr
 U+1433C	kEH_UniK	V084A
 U+1433D	kEH_Cat	V-08-031
 U+1433D	kEH_Core	C
-U+1433D	kEH_Desc	A mace with a pear-shaped head, written at a 45° angle forwards (T2), with the mace-head leaning against a wick of twisted flax, consisting of three loops (V28).
+U+1433D	kEH_Desc	A mace with a pear-shaped head, rotated 45 degree forwards (T2), with the mace-head leaning against a wick of twisted flax, consisting of three loops (V28).
 U+1433D	kEH_Func	Logogram (to strike, to drive)
 U+1433D	kEH_FVal	ḥwꞽ
 U+1433D	kEH_UniK	V149
@@ -36992,7 +36993,7 @@ U+14366	kEH_JSesh	W39
 U+14366	kEH_HG	W39
 U+14367	kEH_Cat	W-03-002
 U+14367	kEH_Core	C
-U+14367	kEH_Desc	A stone jug, with the base nearly a point, with a large handle connecting to the rim, without a small handle.
+U+14367	kEH_Desc	A stone jug, with a very narrow base, with a large handle connecting to the rim, without a small handle.
 U+14367	kEH_Func	Phonemogram
 U+14367	kEH_FVal	ẖnm
 U+14367	kEH_UniK	W009E
@@ -37081,7 +37082,7 @@ U+14371	kEH_FVal	ḳbḥ.w
 U+14371	kEH_UniK	W015D
 U+14372	kEH_Cat	W-06-021
 U+14372	kEH_Core	C
-U+14372	kEH_Desc	A tall water pot, written at a 45° forward angle, with a forward, downward dotted line coming from the top.
+U+14372	kEH_Desc	A tall water pot, rotated 45 degree forward angle, with a forward, downward dotted line coming from the top.
 U+14372	kEH_Func	Classifier to pour, to sprinkle
 U+14372	kEH_FVal	sṯ(ꞽ)
 U+14372	kEH_UniK	HJ W045
@@ -37252,7 +37253,7 @@ U+14387	kEH_JSesh	W57
 U+14387	kEH_HG	W57
 U+14388	kEH_Cat	W-09-006
 U+14388	kEH_Core	C
-U+14388	kEH_Desc	A vase with a broad rim, written at a 45° forward angle, with a forward line of liquid coming from the vase.
+U+14388	kEH_Desc	A vase with a broad rim, rotated 45 degree forwards, with a forward line of liquid coming from the vase.
 U+14388	kEH_Func	Phonemogram
 U+14388	kEH_FVal	rd
 U+14388	kEH_UniK	HJ W056
@@ -37461,7 +37462,7 @@ U+143A2	kEH_IFAO	457,10
 U+143A3	kEH_Cat	W-11-056
 U+143A3	kEH_Core	C
 U+143A3	kEH_Desc	A pointed vessel with a broad rim, with a spout at the front.
-U+143A3	kEH_Func	Logogram (Nemset vase)
+U+143A3	kEH_Func	Logogram (nemset vase)
 U+143A3	kEH_FVal	nms.t
 U+143A3	kEH_UniK	HJ W112
 U+143A3	kEH_JSesh	W112
@@ -37557,7 +37558,7 @@ U+143AF	kEH_UniK	W128
 U+143B0	kEH_Cat	W-11-100
 U+143B0	kEH_Core	C
 U+143B0	kEH_Desc	A round vessel with a broad rim, with a downward line at either side of the neck.
-U+143B0	kEH_Func	Classifier vessel (which might be some type of oil)
+U+143B0	kEH_Func	Classifier vessel (possibly for oil)
 U+143B0	kEH_FVal	bꜥ/bꜥꜥ
 U+143B0	kEH_UniK	W131
 U+143B1	kEH_Cat	W-11-102
@@ -37873,13 +37874,13 @@ U+143DA	kEH_FVal	ṯt
 U+143DA	kEH_UniK	Y007D
 U+143DB	kEH_Cat	Y-04-006
 U+143DB	kEH_Core	C
-U+143DB	kEH_Desc	A rounded harp, with a female human head, in profile, with a headdress of bovine horns with a sun disk with two plumes on top of the sun-disk (S65) on the tip.
+U+143DB	kEH_Desc	A rounded harp, with a female human head, in profile, with a headdress of bovine horns with a sun disk with two plumes on top of the sun disk (S65) on the tip.
 U+143DB	kEH_Func	Logogram (to say, to speak)
 U+143DB	kEH_FVal	ḏd
 U+143DB	kEH_UniK	Y007C
 U+143DC	kEH_Cat	Y-04-007
 U+143DC	kEH_Core	C
-U+143DC	kEH_Desc	A rounded harp, with a female human head, in profile, with a headdress consisting of two plumes, with a sun-disk between them (S63A), on the tip.
+U+143DC	kEH_Desc	A rounded harp, with a female human head, in profile, with a headdress consisting of two plumes, with a sun disk between them (S63A), on the tip.
 U+143DC	kEH_Func	Logogram (to say, to speak)
 U+143DC	kEH_FVal	ḏd
 U+143DC	kEH_UniK	Y007E


### PR DESCRIPTION
From @Ken-Whistler:

Michel has provided what he intends as the final version of Unikemet.txt for 17.0. I have pulled it into my framework and have done a quick check that the changes look reasonable.

This includes normative changes to kEH_Desc field values that the UTC will need to rubber-stamp this week, but also a bunch of changes to the FVal and Func fields which show up in the names list.