### PR TITLE
184-A71 Clarify the SpecialCasing.txt heading Unconditional mappings

### DIFF
--- a/unicodetools/data/ucd/dev/SpecialCasing.txt
+++ b/unicodetools/data/ucd/dev/SpecialCasing.txt
@@ -1,5 +1,5 @@
 # SpecialCasing-17.0.0.txt
-# Date: 2025-01-27, 18:09:41 GMT
+# Date: 2025-07-29
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -57,6 +57,10 @@
 
 # ================================================================================
 # Unconditional mappings
+# The mappings in this section are not language-sensitive nor context-sensitive.
+#
+# Note that comments provide additional information but
+# do not modify the case mapping algorithms in the core specification, chapter 3.
 # ================================================================================
 
 # The German es-zed is special--the normal mapping is to SS.


### PR DESCRIPTION
[[184-A71](https://www.unicode.org/cgi-bin/GetL2Ref.pl?184-A71)] Action Item for Markus Scherer, PAG: Clarify the SpecialCasing.txt heading “Unconditional mappings”, saying that the mappings are not language-sensitive nor context-sensitive. For Unicode Version 17.0. See [L2/25-183](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/25-183) item 2.4.