### PR TITLE
make data files refer to core spec sections by name not number

### DIFF
--- a/unicodetools/data/security/dev/IdentifierStatus.txt
+++ b/unicodetools/data/security/dev/IdentifierStatus.txt
@@ -1,5 +1,5 @@
 # IdentifierStatus.txt
-# Date: 2025-07-29, 02:36:52 GMT
+# Date: 2025-08-01, 18:11:48 GMT
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -12,7 +12,10 @@
 # Format
 #
 # Field 0: code point
-# Field 1: Identifier_Status value (see Table 1 of http://www.unicode.org/reports/tr39)
+# Field 1: Identifier_Status value
+#          See the "Identifier_Status and Identifier_Type" table of UTS #39:
+#          https://www.unicode.org/reports/tr39/#Identifier_Status_and_Type
+
 #
 # For the purpose of regular expressions, the property Identifier_Status is defined as
 # an enumerated property of code points.

--- a/unicodetools/data/security/dev/IdentifierType.txt
+++ b/unicodetools/data/security/dev/IdentifierType.txt
@@ -1,5 +1,5 @@
 # IdentifierType.txt
-# Date: 2025-07-29, 02:36:51 GMT
+# Date: 2025-08-01, 18:11:44 GMT
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -12,7 +12,10 @@
 # Format
 #
 # Field 0: code point
-# Field 1: set of Identifier_Type values (see Table 1 of http://www.unicode.org/reports/tr39)
+# Field 1: set of Identifier_Type values
+#          See the "Identifier_Status and Identifier_Type" table of UTS #39:
+#          https://www.unicode.org/reports/tr39/#Identifier_Status_and_Type
+
 #
 # For the purpose of regular expressions, the property Identifier_Type is defined as
 # mapping each code point to a set of enumerated values.

--- a/unicodetools/data/ucd/dev/CaseFolding.txt
+++ b/unicodetools/data/ucd/dev/CaseFolding.txt
@@ -1,5 +1,5 @@
 # CaseFolding-17.0.0.txt
-# Date: 2025-05-02, 21:48:45 GMT
+# Date: 2025-07-30, 23:54:36 GMT
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -25,8 +25,8 @@
 # NOTE: case folding does not preserve normalization formats!
 #
 # For information on case folding, including how to have case folding
-# preserve normalization formats, see Section 3.13 Default Case Algorithms in
-# The Unicode Standard.
+# preserve normalization formats, see the
+# "Conformance" / "Default Case Algorithms" section of the core specification.
 #
 # ================================================================================
 # Format

--- a/unicodetools/data/ucd/dev/DerivedAge.txt
+++ b/unicodetools/data/ucd/dev/DerivedAge.txt
@@ -1,5 +1,5 @@
 # DerivedAge-17.0.0.txt
-# Date: 2025-07-24, 00:12:18 GMT
+# Date: 2025-07-30, 23:54:38 GMT
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -15,7 +15,8 @@
 # - The term 'assigned' means that a previously reserved code point was assigned
 #   to be a character (graphic, format, control, or private-use);
 #   a noncharacter code point; or a surrogate code point.
-#   For more information, see The Unicode Standard Section 2.4
+#   For more information, see the
+#   "General Structure" / "Code Points and Characters" section of the core specification.
 #
 # - Versions are only tracked from 1.1 onwards, since version 1.0
 #   predated changes required by the ISO 10646 merger.

--- a/unicodetools/data/ucd/dev/DerivedCoreProperties.txt
+++ b/unicodetools/data/ucd/dev/DerivedCoreProperties.txt
@@ -1,5 +1,5 @@
 # DerivedCoreProperties-17.0.0.txt
-# Date: 2025-07-24, 00:12:47 GMT
+# Date: 2025-07-30, 23:55:08 GMT
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -3553,7 +3553,8 @@ E0100..E01EF  ; Case_Ignorable # Mn [240] VARIATION SELECTOR-17..VARIATION SELEC
 
 # Derived Property:   Changes_When_Lowercased (CWL)
 #  Characters whose normalized forms are not stable under a toLowercase mapping.
-#  For more information, see D139 in Section 3.13, "Default Case Algorithms".
+#  For more information, see the definition of "isLowercase(X)"
+#  in the "Conformance" / "Default Case Algorithms" section of the core specification.
 #  Changes_When_Lowercased(X) is true when toLowercase(toNFD(X)) != toNFD(X)
 
 0041..005A    ; Changes_When_Lowercased # L&  [26] LATIN CAPITAL LETTER A..LATIN CAPITAL LETTER Z
@@ -4181,7 +4182,8 @@ FF21..FF3A    ; Changes_When_Lowercased # L&  [26] FULLWIDTH LATIN CAPITAL LETTE
 
 # Derived Property:   Changes_When_Uppercased (CWU)
 #  Characters whose normalized forms are not stable under a toUppercase mapping.
-#  For more information, see D140 in Section 3.13, "Default Case Algorithms".
+#  For more information, see the definition of "isUppercase(X)"
+#  in the "Conformance" / "Default Case Algorithms" section of the core specification.
 #  Changes_When_Uppercased(X) is true when toUppercase(toNFD(X)) != toNFD(X)
 
 0061..007A    ; Changes_When_Uppercased # L&  [26] LATIN SMALL LETTER A..LATIN SMALL LETTER Z
@@ -4825,7 +4827,8 @@ FF41..FF5A    ; Changes_When_Uppercased # L&  [26] FULLWIDTH LATIN SMALL LETTER 
 
 # Derived Property:   Changes_When_Titlecased (CWT)
 #  Characters whose normalized forms are not stable under a toTitlecase mapping.
-#  For more information, see D141 in Section 3.13, "Default Case Algorithms".
+#  For more information, see the definition of "isTitlecase(X)"
+#  in the "Conformance" / "Default Case Algorithms" section of the core specification.
 #  Changes_When_Titlecased(X) is true when toTitlecase(toNFD(X)) != toNFD(X)
 
 0061..007A    ; Changes_When_Titlecased # L&  [26] LATIN SMALL LETTER A..LATIN SMALL LETTER Z
@@ -5468,7 +5471,8 @@ FF41..FF5A    ; Changes_When_Titlecased # L&  [26] FULLWIDTH LATIN SMALL LETTER 
 
 # Derived Property:   Changes_When_Casefolded (CWCF)
 #  Characters whose normalized forms are not stable under case folding.
-#  For more information, see D142 in Section 3.13, "Default Case Algorithms".
+#  For more information, see the definition of "isCasefolded(X)"
+#  in the "Conformance" / "Default Case Algorithms" section of the core specification.
 #  Changes_When_Casefolded(X) is true when toCasefold(toNFD(X)) != toNFD(X)
 
 0041..005A    ; Changes_When_Casefolded # L&  [26] LATIN CAPITAL LETTER A..LATIN CAPITAL LETTER Z
@@ -6108,7 +6112,8 @@ FF21..FF3A    ; Changes_When_Casefolded # L&  [26] FULLWIDTH LATIN CAPITAL LETTE
 
 # Derived Property:   Changes_When_Casemapped (CWCM)
 #  Characters whose normalized forms are not stable under case mapping.
-#  For more information, see D143 in Section 3.13, "Default Case Algorithms".
+#  For more information, see the definition of "isCased(X)"
+#  in the "Conformance" / "Default Case Algorithms" section of the core specification.
 #  Changes_When_Casemapped(X) is true when CWL(X), or CWT(X), or CWU(X)
 
 0041..005A    ; Changes_When_Casemapped # L&  [26] LATIN CAPITAL LETTER A..LATIN CAPITAL LETTER Z

--- a/unicodetools/data/ucd/dev/DoNotEmit.txt
+++ b/unicodetools/data/ucd/dev/DoNotEmit.txt
@@ -1,5 +1,5 @@
 # DoNotEmit-17.0.0.txt
-# Date: 2025-05-13, 04:43:00 GMT
+# Date: 2025-07-30
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -332,7 +332,7 @@
 # Deprecated characters and other discouraged characters and sequences
 # ================================================
 
-# Latin, from text of Section 7.1, the NamesList, and the uppercase mapping
+# Latin, from text in the "Latin" section of the core specification, the NamesList, and the uppercase mapping
 0140; 006C 00B7; Preferred_Spelling # LATIN SMALL LETTER L WITH MIDDLE DOT; LATIN SMALL LETTER L, MIDDLE DOT
 0149; 2019 006E; Deprecated # LATIN SMALL LETTER N PRECEDED BY APOSTROPHE; RIGHT SINGLE QUOTATION MARK, LATIN SMALL LETTER N
 0131 0307; 0069 0307; Dotless_Form # LATIN SMALL LETTER DOTLESS I, COMBINING DOT ABOVE; LATIN SMALL LETTER I, COMBINING DOT ABOVE
@@ -432,7 +432,7 @@
 107A6 0322; 107A7; Precomposed_Form # MODIFIER LETTER SMALL TURNED R WITH LONG LEG, COMBINING RETROFLEX HOOK BELOW; MODIFIER LETTER SMALL TURNED R WITH LONG LEG AND RETROFLEX HOOK
 107AC 0322; 107AD; Precomposed_Form # MODIFIER LETTER SMALL TS DIGRAPH, COMBINING RETROFLEX HOOK BELOW; MODIFIER LETTER SMALL TS DIGRAPH WITH RETROFLEX HOOK
 
-# Arabic, from text of Section 9.2 and the NamesList
+# Arabic, from text in the "Arabic" section of the core specification, and the NamesList
 0649 0654; 0626; Hamza_Form # ARABIC LETTER ALEF MAKSURA, ARABIC HAMZA ABOVE; ARABIC LETTER YEH WITH HAMZA ABOVE
 064E 064E; 064B; Arabic_Tashkil # ARABIC FATHA, ARABIC FATHA; ARABIC FATHATAN
 0650 0650; 064D; Arabic_Tashkil # ARABIC KASRA, ARABIC KASRA; ARABIC KASRATAN
@@ -442,11 +442,11 @@
 0677; 0674 06C7; Preferred_Spelling # ARABIC LETTER U WITH HAMZA ABOVE; ARABIC LETTER HIGH HAMZA, ARABIC LETTER U
 0678; 0674 0649; Preferred_Spelling # ARABIC LETTER HIGH HAMZA YEH; ARABIC LETTER HIGH HAMZA, ARABIC LETTER ALEF MAKSURA
 
-# Devanagari, from Section 12.1 and the NamesList
+# Devanagari, from the "Devanagari" section of the core specification, and the NamesList
 0953; 0300; Discouraged # DEVANAGARI GRAVE ACCENT; COMBINING GRAVE ACCENT
 0954; 0301; Discouraged # DEVANAGARI ACUTE ACCENT; COMBINING ACUTE ACCENT
 
-# Bengali, from Section 12.2
+# Bengali, from the "Bengali (Bangla)" section of the core specification
 09A4 09CD 200D; 09CE; Bengali_Khanda_Ta # BENGALI LETTER TA, BENGALI SIGN VIRAMA, ZERO WIDTH JOINER; BENGALI LETTER KHANDA TA
 
 # Gujarati, from the NamesList
@@ -462,11 +462,11 @@
 0D32 0D4D 200D; 0D7D; Malayalam_Chillu # MALAYALAM LETTER LA, MALAYALAM SIGN VIRAMA, ZERO WIDTH JOINER; MALAYALAM LETTER CHILLU L
 0D33 0D4D 200D; 0D7E; Malayalam_Chillu # MALAYALAM LETTER LLA, MALAYALAM SIGN VIRAMA, ZERO WIDTH JOINER; MALAYALAM LETTER CHILLU LL
 
-# Tibetan, from text of Section 13.4, the NamesList, and the decompositions
+# Tibetan, from text in the "Tibetan" section of the core specification, the NamesList, and the decompositions
 0F77; 0FB2 0F71 0F80; Deprecated # TIBETAN VOWEL SIGN VOCALIC RR; TIBETAN SUBJOINED LETTER RA, TIBETAN VOWEL SIGN AA, TIBETAN VOWEL SIGN REVERSED I
 0F79; 0FB3 0F71 0F80; Deprecated # TIBETAN VOWEL SIGN VOCALIC LL; TIBETAN SUBJOINED LETTER LA, TIBETAN VOWEL SIGN AA, TIBETAN VOWEL SIGN REVERSED I
 
-# Khmer, from text of Section 16.4 and the NamesList
+# Khmer, from text in the "Khmer" section of the core specification, and the NamesList
 17A3; 17A2; Deprecated # KHMER INDEPENDENT VOWEL QAQ; KHMER LETTER QA
 17A4; 17A2 17B6; Deprecated # KHMER INDEPENDENT VOWEL QAA; KHMER LETTER QA, KHMER VOWEL SIGN AA
 17D8; 17D4 179B 17D4; Discouraged # KHMER SIGN BEYYAL; KHMER SIGN KHAN, KHMER LETTER LO, KHMER SIGN KHAN

--- a/unicodetools/data/ucd/dev/Jamo.txt
+++ b/unicodetools/data/ucd/dev/Jamo.txt
@@ -1,6 +1,6 @@
 # Jamo-17.0.0.txt
-# Date: 2024-02-02
-# © 2024 Unicode®, Inc.
+# Date: 2025-07-30
+# © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
 #
@@ -9,7 +9,7 @@
 #
 # This file defines the Jamo_Short_Name property.
 #
-# See Section 3.12 of the core specification of the Unicode Standard
+# See the "Conformance" / "Conjoining Jamo Behavior" section of the core specification
 # for more information.
 #
 # Each line contains two fields, separated by a semicolon.

--- a/unicodetools/data/ucd/dev/NamedSequences.txt
+++ b/unicodetools/data/ucd/dev/NamedSequences.txt
@@ -1,6 +1,6 @@
 # NamedSequences-17.0.0.txt
-# Date: 2024-02-02
-# © 2024 Unicode®, Inc.
+# Date: 2025-07-30
+# © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
 #
@@ -209,8 +209,8 @@ BENGALI LETTER KHINYA;0995 09CD 09B7
 # Provisional 2008-02-08, Approved 2009-08-14
 #
 # A visual display of the Tamil named character sequences is available
-# in the documentation for the Unicode Standard. See Section 12.6, Tamil in
-# https://www.unicode.org/versions/latest/
+# in the documentation for the Unicode Standard.
+# See the "Tamil" section in the core specification.
 
 TAMIL CONSONANT K;  0B95 0BCD
 TAMIL CONSONANT NG; 0B99 0BCD

--- a/unicodetools/data/ucd/dev/SpecialCasing.txt
+++ b/unicodetools/data/ucd/dev/SpecialCasing.txt
@@ -1,5 +1,5 @@
 # SpecialCasing-17.0.0.txt
-# Date: 2025-07-29, 22:01:10 GMT
+# Date: 2025-07-31, 22:11:55 GMT
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -47,8 +47,8 @@
 #
 # A language ID is defined by BCP 47, with '-' and '_' treated equivalently.
 #
-# A casing context for a character is defined by Section 3.13 Default Case Algorithms
-# of The Unicode Standard.
+# A casing context for a character is defined in the
+# "Conformance" / "Default Case Algorithms" section of the core specification.
 #
 # Parsers of this file must be prepared to deal with future additions to this format:
 #  * Additional contexts

--- a/unicodetools/data/ucd/dev/StandardizedVariants.txt
+++ b/unicodetools/data/ucd/dev/StandardizedVariants.txt
@@ -1,5 +1,5 @@
 # StandardizedVariants-17.0.0.txt
-# Date: 2025-07-23, 00:00:00 GMT [KW]
+# Date: 2025-07-30
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -26,8 +26,8 @@
 # from what it would have had in the absence of the variation selector.
 #
 # For more information on standardized variation sequences,
-# see Section 23.4, Variation Selectors,
-# in the core specification of the Unicode Standard.
+# see the "Special Areas and Format Characters" / "Variation Selectors" section
+# of the core specification.
 #
 # For more information on the Ideographic Variation Database,
 # see https://www.unicode.org/ivd/

--- a/unicodetools/data/ucd/dev/TangutSources.txt
+++ b/unicodetools/data/ucd/dev/TangutSources.txt
@@ -1,5 +1,5 @@
 # TangutSources-17.0.0.txt
-# Date: 2025-06-30 [MS, KW]
+# Date: 2025-07-30 [MS, KW]
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -53,8 +53,7 @@
 #UTN42 = Andrew West and Viacheslav Zaytsev, Tangut Character Additions and Glyph Corrections,
 # Unicode Technical Note #42. 2019-12-21.
 #
-#	For more information, see Section 18.11, Tangut, of the
-#	core specification.
+#	For more information, see the "Tangut" section of the core specification.
 #
 U+17000	kTGT_MergedSrc	L2008-0008
 U+17000	kTGT_RSUnicode	1.6

--- a/unicodetools/data/ucd/dev/extracted/DerivedName.txt
+++ b/unicodetools/data/ucd/dev/extracted/DerivedName.txt
@@ -1,5 +1,5 @@
 # DerivedName-17.0.0.txt
-# Date: 2025-07-24, 00:12:52 GMT
+# Date: 2025-07-30, 23:55:12 GMT
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -9,7 +9,7 @@
 #
 # This file lists the values of the Name property.
 # This property is specified by the derivation documented in
-# Section 4.8 of the Unicode Standard, Version 13.0,
+# the "Character Properties" / "Name" section of the core specification,
 # based on the Name field in UnicodeData.txt,
 # the Jamo_Short_Name property in Jamo.txt,
 # and a specified list of pattern strings used to derive names

--- a/unicodetools/src/main/java/org/unicode/text/UCD/IdentifierInfo.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/IdentifierInfo.java
@@ -1066,10 +1066,12 @@ public class IdentifierInfo {
                         filename,
                         "Security Profile for General Identifiers: " + propName)) {
             out2.println(
-                    "# Format"
-                            + "\n#"
-                            + "\n# Field 0: code point"
-                            + "\n# Field 1: set of Identifier_Type values (see Table 1 of http://www.unicode.org/reports/tr39)");
+                    "# Format\n"
+                            + "#\n"
+                            + "# Field 0: code point\n"
+                            + "# Field 1: set of Identifier_Type values\n"
+                            + "#          See the \"Identifier_Status and Identifier_Type\" table of UTS #39:\n"
+                            + "#          https://www.unicode.org/reports/tr39/#Identifier_Status_and_Type\n");
 
             out2.println(
                     "#\n"
@@ -1137,10 +1139,12 @@ public class IdentifierInfo {
                         "IdentifierStatus.txt",
                         "Security Profile for General Identifiers: " + propName)) {
             out2.println(
-                    "# Format"
-                            + "\n#"
-                            + "\n# Field 0: code point"
-                            + "\n# Field 1: Identifier_Status value (see Table 1 of http://www.unicode.org/reports/tr39)");
+                    "# Format\n"
+                            + "#\n"
+                            + "# Field 0: code point\n"
+                            + "# Field 1: Identifier_Status value\n"
+                            + "#          See the \"Identifier_Status and Identifier_Type\" table of UTS #39:\n"
+                            + "#          https://www.unicode.org/reports/tr39/#Identifier_Status_and_Type\n");
 
             out2.println(
                     "#\n"

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/CaseFoldingHeader.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/CaseFoldingHeader.txt
@@ -17,8 +17,8 @@
 # NOTE: case folding does not preserve normalization formats!
 #
 # For information on case folding, including how to have case folding
-# preserve normalization formats, see Section 3.13 Default Case Algorithms in
-# The Unicode Standard.
+# preserve normalization formats, see the
+# "Conformance" / "Default Case Algorithms" section of the core specification.
 #
 # ================================================================================
 # Format

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/DerivedAgeHeader.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/DerivedAgeHeader.txt
@@ -7,7 +7,8 @@
 # - The term 'assigned' means that a previously reserved code point was assigned
 #   to be a character (graphic, format, control, or private-use);
 #   a noncharacter code point; or a surrogate code point.
-#   For more information, see The Unicode Standard Section 2.4
+#   For more information, see the
+#   "General Structure" / "Code Points and Characters" section of the core specification.
 #
 # - Versions are only tracked from 1.1 onwards, since version 1.0
 #   predated changes required by the ISO 10646 merger.

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/MakeUnicodeFiles.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/MakeUnicodeFiles.txt
@@ -10,7 +10,7 @@ File: extracted/DerivedName
 #
 # This file lists the values of the Name property.
 # This property is specified by the derivation documented in
-# Section 4.8 of the Unicode Standard, Version 13.0,
+# the "Character Properties" / "Name" section of the core specification,
 # based on the Name field in UnicodeData.txt,
 # the Jamo_Short_Name property in Jamo.txt,
 # and a specified list of pattern strings used to derive names
@@ -284,31 +284,36 @@ Property:   Case_Ignorable
 Property:   Changes_When_Lowercased
 # Derived Property:   Changes_When_Lowercased (CWL)
 #  Characters whose normalized forms are not stable under a toLowercase mapping.
-#  For more information, see D139 in Section 3.13, "Default Case Algorithms". 
+#  For more information, see the definition of "isLowercase(X)"
+#  in the "Conformance" / "Default Case Algorithms" section of the core specification.
 #  Changes_When_Lowercased(X) is true when toLowercase(toNFD(X)) != toNFD(X)
 
 Property:   Changes_When_Uppercased
 # Derived Property:   Changes_When_Uppercased (CWU)
 #  Characters whose normalized forms are not stable under a toUppercase mapping.
-#  For more information, see D140 in Section 3.13, "Default Case Algorithms". 
+#  For more information, see the definition of "isUppercase(X)"
+#  in the "Conformance" / "Default Case Algorithms" section of the core specification.
 #  Changes_When_Uppercased(X) is true when toUppercase(toNFD(X)) != toNFD(X)
 
 Property:   Changes_When_Titlecased
 # Derived Property:   Changes_When_Titlecased (CWT)
 #  Characters whose normalized forms are not stable under a toTitlecase mapping.
-#  For more information, see D141 in Section 3.13, "Default Case Algorithms". 
+#  For more information, see the definition of "isTitlecase(X)"
+#  in the "Conformance" / "Default Case Algorithms" section of the core specification.
 #  Changes_When_Titlecased(X) is true when toTitlecase(toNFD(X)) != toNFD(X)
 
 Property:   Changes_When_Casefolded
 # Derived Property:   Changes_When_Casefolded (CWCF)
 #  Characters whose normalized forms are not stable under case folding.
-#  For more information, see D142 in Section 3.13, "Default Case Algorithms". 
+#  For more information, see the definition of "isCasefolded(X)"
+#  in the "Conformance" / "Default Case Algorithms" section of the core specification.
 #  Changes_When_Casefolded(X) is true when toCasefold(toNFD(X)) != toNFD(X)
 
 Property:   Changes_When_Casemapped
 # Derived Property:   Changes_When_Casemapped (CWCM)
 #  Characters whose normalized forms are not stable under case mapping.
-#  For more information, see D143 in Section 3.13, "Default Case Algorithms". 
+#  For more information, see the definition of "isCased(X)"
+#  in the "Conformance" / "Default Case Algorithms" section of the core specification.
 #  Changes_When_Casemapped(X) is true when CWL(X), or CWT(X), or CWU(X)
 
 Property:	ID_Start

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/SpecialCasingHeader.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/SpecialCasingHeader.txt
@@ -39,8 +39,8 @@
 #
 # A language ID is defined by BCP 47, with '-' and '_' treated equivalently.
 #
-# A casing context for a character is defined by Section 3.13 Default Case Algorithms
-# of The Unicode Standard.
+# A casing context for a character is defined in the
+# "Conformance" / "Default Case Algorithms" section of the core specification.
 #
 # Parsers of this file must be prepared to deal with future additions to this format:
 #  * Additional contexts


### PR DESCRIPTION
... so that we need not track section numbers changing as chapters and sections are inserted or reordered.

Exception: I have not tackled **ArabicShaping.txt** which has many section and table numbers, mostly in a table near the top, and without section/table names. **Could we remove this table of numbers?** The sections are easy to find by script name, and the relevant tables are all those that show contextually shaped glyphs.
- discussed, see [this comment below](https://github.com/unicode-org/unicodetools/pull/1178#issuecomment-3141514285)

----
The core specification is here: https://www.unicode.org/versions/latest/core-spec/

I refer to the "chapter-name" / "section-name" section when the chapter-name looks stable (e.g., "Conformance"), but only to the "section-name" when the chapter-name looks like it might change (e.g., "South and Central Asia-III") and the section-name looks unambiguous (e.g., "Tamil", as opposed to "Name").

@michelsu FYI