### PR TITLE
Update InSC comments for exceptional consonant classes

### DIFF
--- a/unicodetools/data/ucd/dev/IndicSyllabicCategory.txt
+++ b/unicodetools/data/ucd/dev/IndicSyllabicCategory.txt
@@ -1,5 +1,5 @@
 # IndicSyllabicCategory-17.0.0.txt
-# Date: 2025-06-30, 06:20:25 GMT
+# Date: 2025-08-01, 04:02:23 GMT
 # © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -812,7 +812,7 @@ AA74..AA76    ; Consonant_Placeholder # Lo   [3] MYANMAR LOGOGRAM KHAMTI OAY..MY
 # otherwise represents the inherent vowel, that vowel carrier has the
 # Indic_Syllabic_Category Consonant, as a null consonant. Such vowel carriers
 # can often also be analyzed as glottal stops with inherent vowels.
-# An example is U+0F68 ཨ TIBETAN LETTER A.
+# An example is U+0F68 TIBETAN LETTER A.
 
 # [Not derivable]
 
@@ -999,8 +999,8 @@ ABD2..ABDA    ; Consonant # Lo   [9] MEETEI MAYEK LETTER GOK..MEETEI MAYEK LETTE
 
 # Indic_Syllabic_Category=Consonant_With_Stacker
 
-# Consonants that may make stacked ligatures with the next consonant
-# without the use of a virama
+# Consonants that may cause conjunct formation or consonant stacking with the
+# next consonant, without the use of a stacker
 
 # [Not derivable]
 
@@ -1014,7 +1014,7 @@ ABD2..ABDA    ; Consonant # Lo   [9] MEETEI MAYEK LETTER GOK..MEETEI MAYEK LETTE
 
 # Indic_Syllabic_Category=Consonant_Prefixed
 
-# Cluster-initial consonants
+# Other consonants that behave like a Consonant_Preceding_Repha
 
 # [Not derivable]
 
@@ -1027,8 +1027,10 @@ ABD2..ABDA    ; Consonant # Lo   [9] MEETEI MAYEK LETTER GOK..MEETEI MAYEK LETTE
 
 # Indic_Syllabic_Category=Consonant_Preceding_Repha
 
-# Repha Form of RA (reanalyzed in some scripts), when preceding the main
-# consonant.
+# Cluster-initial "r" consonants in the form of a dependent sign (also known as
+# "repha") that precede the base character in the encoding order, but are
+# reordered in text rendering to be somewhere after the base. Reanalyzed in
+# some orthographies to be a final consonant.
 
 # [Not derivable]
 
@@ -1043,8 +1045,7 @@ ABD2..ABDA    ; Consonant # Lo   [9] MEETEI MAYEK LETTER GOK..MEETEI MAYEK LETTE
 
 # Indic_Syllabic_Category=Consonant_Initial_Postfixed
 
-# Consonants that succeed the main consonant in character sequences, but are
-# pronounced before it.
+# Other consonants that behave like a Consonant_Succeeding_Repha
 
 # [Not derivable]
 
@@ -1054,7 +1055,9 @@ ABD2..ABDA    ; Consonant # Lo   [9] MEETEI MAYEK LETTER GOK..MEETEI MAYEK LETTE
 
 # Indic_Syllabic_Category=Consonant_Succeeding_Repha
 
-# Repha Form of RA (reanalyzed in some scripts), when succeeding the main
+# Cluster-initial "r" consonants that behave like a Consonant_Preceding_Repha
+# but succeed the base character in the encoding order, and are thus not
+# reordered in text rendering. Reanalyzed in some orthographies to be a final
 # consonant.
 
 # [Not derivable]

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/MakeUnicodeFiles.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/MakeUnicodeFiles.txt
@@ -1180,7 +1180,7 @@ Value: Consonant
 # otherwise represents the inherent vowel, that vowel carrier has the
 # Indic_Syllabic_Category Consonant, as a null consonant. Such vowel carriers
 # can often also be analyzed as glottal stops with inherent vowels.
-# An example is U+0F68 ཨ TIBETAN LETTER A.
+# An example is U+0F68 TIBETAN LETTER A.
 
 # [Not derivable]
 Value: Consonant_Dead
@@ -1188,26 +1188,29 @@ Value: Consonant_Dead
 
 # [Not derivable]
 Value: Consonant_With_Stacker
-# Consonants that may make stacked ligatures with the next consonant
-# without the use of a virama
+# Consonants that may cause conjunct formation or consonant stacking with the
+# next consonant, without the use of a stacker
 
 # [Not derivable]
 Value: Consonant_Prefixed
-# Cluster-initial consonants
+# Other consonants that behave like a Consonant_Preceding_Repha
 
 # [Not derivable]
 Value: Consonant_Preceding_Repha
-# Repha Form of RA (reanalyzed in some scripts), when preceding the main
-# consonant.
+# Cluster-initial "r" consonants in the form of a dependent sign (also known as
+# "repha") that precede the base character in the encoding order, but are
+# reordered in text rendering to be somewhere after the base. Reanalyzed in
+# some orthographies to be a final consonant.
 
 # [Not derivable]
 Value: Consonant_Initial_Postfixed
-# Consonants that succeed the main consonant in character sequences, but are
-# pronounced before it.
+# Other consonants that behave like a Consonant_Succeeding_Repha
 
 # [Not derivable]
 Value: Consonant_Succeeding_Repha
-# Repha Form of RA (reanalyzed in some scripts), when succeeding the main
+# Cluster-initial "r" consonants that behave like a Consonant_Preceding_Repha
+# but succeed the base character in the encoding order, and are thus not
+# reordered in text rendering. Reanalyzed in some orthographies to be a final
 # consonant.
 
 # [Not derivable]


### PR DESCRIPTION
[UTC-181-A119] Action Item for Roozbeh Pournader, SAH: Update comments in IndicSyllabicCategory.txt to better reflect the meaning of InSC values Consonant_With_Stacker, Consonant_Prefixed, Consonant_Preceding_Repha, Consonant_Initial_Postfixed, and Consonant_Succeeding_Repha, for Unicode Version 17.0. [Ref. Section 5.3 of document L2/24-228]