### PR TITLE
Update to ICU 78.0.1-SNAPSHOT and fix the VersionedSymbolTable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
             For ICU versions, see https://github.com/orgs/unicode-org/packages?repo_name=icu
             or use vanilla *released* ICU versions like 76.1 which come from Maven Central.
           -->
-        <icu.version>76.1</icu.version>
+        <icu.version>78.0.1-SNAPSHOT</icu.version>
 
         <!--
              For CLDR versions, see https://github.com/orgs/unicode-org/packages?repo_name=cldr


### PR DESCRIPTION
Since unicode-org/icu#3456, applyPropertyAlias can get a null `afterEquals`.

This should unblock #1198.