### PR TITLE
Document the exact process for pushing the JSPs from Windows

### DIFF
--- a/docs/egg.md
+++ b/docs/egg.md
@@ -14,11 +14,13 @@ Powershell:
 ```powershell
 mvn -B package -am -pl UnicodeJsps -DskipTests=true
 $CLDR_REF = $(mvn help:evaluate "-Dexpression=cldr.version" -q -DforceStdout).Split("-")[2]
-if (-not Test-Path cldr) {
+if (-not (Test-Path cldr)) {
   git clone https://github.com/unicode-org/cldr.git "--reference=..\cldr"
 }
-Set-Location cldr
+Push-Location cldr
+git fetch
 git reset --hard $CLDR_REF
+Pop-Location
 ```
 WSL:
 ```bash

--- a/docs/egg.md
+++ b/docs/egg.md
@@ -1,0 +1,39 @@
+This is the procedure used by eggrobin to build and deploy the JSPs from his
+Windows machines. Some of the commands must be run in PowerShell, others in the
+wsl bash.
+
+WSL:
+```bash
+pushd UnicodeJsps
+./update-bidic-ucd.sh
+popd
+wget https://github.com/unicode-org/last-resort-font/releases/latest/download/LastResort-Regular.ttf
+mv ./LastResort-Regular.ttf ./UnicodeJsps/src/main/webapp/
+```
+Powershell:
+```powershell
+mvn -B package -am -pl UnicodeJsps -DskipTests=true
+$CLDR_REF = $(mvn help:evaluate "-Dexpression=cldr.version" -q -DforceStdout).Split("-")[2]
+if (-not Test-Path cldr) {
+  git clone https://github.com/unicode-org/cldr.git "--reference=..\cldr"
+}
+Set-Location cldr
+git reset --hard $CLDR_REF
+```
+WSL:
+```bash
+mkdir -p UnicodeJsps/target && tar -cpz --exclude=.git -f UnicodeJsps/target/cldr-unicodetools.tgz ./cldr/ ./unicodetools/
+```
+Powershell:
+```powershell
+mvn compile exec:java '-Dexec.mainClass="org.unicode.jsp.RebuildPropertyCache"' -am -pl unicodetools   "-DUNICODETOOLS_GEN_DIR=Generated"  "-DUNICODETOOLS_REPO_DIR=." "-DCLDR_DIR=..\cldr\"
+```
+WSL:
+```bash
+tar -cpz -f UnicodeJsps/target/generated.tgz ./Generated/
+docker build -t us-central1-docker.pkg.dev/goog-unicode-dev/unicode-jsps/unicode-jsps:latest UnicodeJsps/
+```
+Powershell:
+```powershell
+docker push us-central1-docker.pkg.dev/goog-unicode-dev/unicode-jsps/unicode-jsps:latest
+```

--- a/docs/egg.md
+++ b/docs/egg.md
@@ -26,6 +26,7 @@ mkdir -p UnicodeJsps/target && tar -cpz --exclude=.git -f UnicodeJsps/target/cld
 ```
 Powershell:
 ```powershell
+rm .\Generated\* -recurse -force;
 mvn compile exec:java '-Dexec.mainClass="org.unicode.jsp.RebuildPropertyCache"' -am -pl unicodetools   "-DUNICODETOOLS_GEN_DIR=Generated"  "-DUNICODETOOLS_REPO_DIR=." "-DCLDR_DIR=..\cldr\"
 ```
 WSL:


### PR DESCRIPTION
This is intentionally not explaining the steps nor providing any options for other directory structures, running locally, etc. Those are found in the neighbouring index.md and gcp-run.md. Instead the point here is to have some reproducibility when it comes to pushing stuff to util.unicode.org, to avoid #1209 or similar mishaps.

See the minutes of the 2024-11-26 tools meeting, item 1h.