### PR TITLE
Only read confusables source files ending in '.txt'

### DIFF
--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java
@@ -2273,7 +2273,8 @@ public class GenerateConfusables {
             if (new File(indir, names[i]).isDirectory()) {
                 continue;
             }
-            if (!names[i].startsWith("confusables-")) {
+            // Skip files not matching "confusables-*.txt"
+            if (!names[i].startsWith("confusables-") || !names[i].endsWith(".txt")) {
                 continue;
             }
             if (DEBUG) System.out.println(names[i]);


### PR DESCRIPTION
The confusables tool used to read every data file in certain directories, even if they were backup files ending in '.txt~'. Now we restrict it only to '.txt' files.

This requires https://github.com/unicode-org/unicodetools/pull/1216 to merge first.