### PR TITLE
kTGT_RSUnicode (née kRSTUnicode) is now a Provisional property rather than non-property UCD data

### DIFF
--- a/unicodetools/src/main/java/org/unicode/props/UcdProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UcdProperty.java
@@ -560,7 +560,7 @@ public enum UcdProperty {
     kTGT_MergedSrc(PropertyType.Miscellaneous, DerivedPropertyStatus.Approved, "kTGT_MergedSrc"),
     kTGT_RSUnicode(
             PropertyType.Miscellaneous,
-            DerivedPropertyStatus.UCDNonProperty,
+            DerivedPropertyStatus.Provisional,
             "kTGT_RSUnicode",
             "kRSTUnicode"),
     kTaiwanTelegraph(

--- a/unicodetools/src/main/resources/org/unicode/props/ExtraPropertyAliases.txt
+++ b/unicodetools/src/main/resources/org/unicode/props/ExtraPropertyAliases.txt
@@ -208,7 +208,7 @@ cjkZhuang                ; kZhuang ; Provisional
 # change the tag kRSTUnicode to kTGT_RSUnicode.
 # For Unicode Version 17.0. See L2/25-087 item 1.9.
 # (Changed between 17 alpha and beta.)
-kTGT_RSUnicode           ; kTGT_RSUnicode ; kRSTUnicode ; UCDNonProperty
+kTGT_RSUnicode           ; kTGT_RSUnicode ; kRSTUnicode ; Provisional
 
 # [183-C30] Consensus: In NushuSources.txt,
 # change the tag kSrc_NushuDuben to kNSHU_DubenSrc, and change the tag kReading to kNSHU_Reading.


### PR DESCRIPTION
Missed in #1233.

See https://www.unicode.org/reports/tr60/#kTGT_RSUnicode.