### PR TITLE
update spotless & apply

### DIFF
--- a/UnicodeJsps/src/main/java/org/unicode/jsp/ScriptTester.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/ScriptTester.java
@@ -493,7 +493,7 @@ public class ScriptTester {
                         }
                         addCompatible(UScript.LATIN, i);
                     }
-                    // FALL THRU!
+                // FALL THRU!
                 case Highly_Restrictive:
                     addCompatible(UScript.LATIN, UScript.HAN, UScript.HIRAGANA, UScript.KATAKANA);
                     // addCompatible(UScript.LATIN, HANT, UScript.HIRAGANA, UScript.KATAKANA);
@@ -505,8 +505,8 @@ public class ScriptTester {
 
                     addCompatible(UScript.LATIN, UScript.HAN, UScript.BOPOMOFO);
                     addCompatible(UScript.LATIN, UScript.HAN);
-                    // ?? Asomtavruli, Nuskhuri, and Mkhedruli (georgian)
-                    // FALL THRU!
+                // ?? Asomtavruli, Nuskhuri, and Mkhedruli (georgian)
+                // FALL THRU!
                 default:
                     // addCompatible(UScript.HAN, HANT);
                     // addCompatible(UScript.HAN, HANS);

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,9 @@
         <!-- Need to use an updated surefire plugin here. -->
         <maven-surefire-plugin-version>3.0.0-M5</maven-surefire-plugin-version>
 
-        <spotless.version>2.43.0</spotless.version>
+        <spotless.version>3.1.0</spotless.version>
+        <!-- https://mvnrepository.com/artifact/com.google.googlejavaformat/google-java-format -->
+        <google-java-style.version>1.35.0</google-java-style.version>
     </properties>
 
     <modules>
@@ -131,9 +133,7 @@
                             <!-- no need to specify files, inferred automatically, but you can if you want -->
                             <!-- apply a specific flavor of google-java-format and reflow long strings -->
                             <googleJavaFormat>
-                                <!-- version of google-java-style, see
-                                    https://mvnrepository.com/artifact/com.google.googlejavaformat/google-java-format -->
-                                <version>1.22.0</version>
+                                <version>${google-java-style.version}</version>
                                 <style>AOSP</style>
                                 <reflowLongStrings>false</reflowLongStrings>
                             </googleJavaFormat>

--- a/unicodetools/src/main/java/org/unicode/bidi/BidiReference.java
+++ b/unicodetools/src/main/java/org/unicode/bidi/BidiReference.java
@@ -470,7 +470,7 @@ public final class BidiReference {
                     }
                     break;
 
-                    // Rule X6a
+                // Rule X6a
                 case PDI:
                     if (overflowIsolateCount > 0) {
                         --overflowIsolateCount;
@@ -487,7 +487,7 @@ public final class BidiReference {
                     resultLevels[i] = stack.lastEmbeddingLevel();
                     break;
 
-                    // Rule X7
+                // Rule X7
                 case PDF:
                     // Not really part of the spec
                     resultLevels[i] = stack.lastEmbeddingLevel();

--- a/unicodetools/src/main/java/org/unicode/draft/Ids2.java
+++ b/unicodetools/src/main/java/org/unicode/draft/Ids2.java
@@ -179,7 +179,7 @@ public abstract class Ids2 implements Comparable<Ids2> {
         codePoints.next();
         int cp = codePoints.getCodePoint();
         switch (cp) {
-                // double
+            // double
             case '\u2FF0':
             case '\u2FF1':
             case '\u2FF4':
@@ -191,7 +191,7 @@ public abstract class Ids2 implements Comparable<Ids2> {
             case '\u2FFA':
             case '\u2FFB':
                 return new Dual(cp, codePoints);
-                // triple
+            // triple
             case '\u2FF2':
             case '\u2FF3':
                 return new Trial(cp, codePoints);

--- a/unicodetools/src/main/java/org/unicode/idna/Uts46.java
+++ b/unicodetools/src/main/java/org/unicode/idna/Uts46.java
@@ -547,16 +547,16 @@ public class Uts46 extends Idna {
                     }
                     buffer.appendCodePoint(cp);
                     break;
-                    // ignored: Remove the code point from the string. This is
-                    // equivalent to mapping the code point to an empty string.
+                // ignored: Remove the code point from the string. This is
+                // equivalent to mapping the code point to an empty string.
                 case ignored:
                     break;
-                    // mapped: Replace the code point in the string by the value for the
-                    // mapping in Section 5, IDNA Mapping Table.
-                    // Except, starting with 15.1:
-                    // If transitional and capital sharp s, then map to ss
-                    // to keep the mapping idempotent, and to
-                    // avoid the small sharp s failing the mode=transitional validity check.
+                // mapped: Replace the code point in the string by the value for the
+                // mapping in Section 5, IDNA Mapping Table.
+                // Except, starting with 15.1:
+                // If transitional and capital sharp s, then map to ss
+                // to keep the mapping idempotent, and to
+                // avoid the small sharp s failing the mode=transitional validity check.
                 case mapped:
                     String mapped;
                     if (idnaChoice == IdnaChoice.transitional && cp == 'ẞ') {
@@ -566,11 +566,11 @@ public class Uts46 extends Idna {
                     }
                     buffer.append(mapped);
                     break;
-                    // deviation:
-                    // For Transitional Processing, replace the code point in the string
-                    // by the value for the mapping in Section 5, IDNA Mapping Table.
-                    // For Nontransitional Processing, leave the code point unchanged in
-                    // the string.
+                // deviation:
+                // For Transitional Processing, replace the code point in the string
+                // by the value for the mapping in Section 5, IDNA Mapping Table.
+                // For Nontransitional Processing, leave the code point unchanged in
+                // the string.
                 case deviation:
                     if (idnaChoice == IdnaChoice.transitional) {
                         mapped = mappings.get(cp);
@@ -579,7 +579,7 @@ public class Uts46 extends Idna {
                         buffer.appendCodePoint(cp);
                     }
                     break;
-                    // valid: Leave the code point unchanged in the string.
+                // valid: Leave the code point unchanged in the string.
                 case valid:
                     buffer.appendCodePoint(cp);
                     break;

--- a/unicodetools/src/main/java/org/unicode/props/PropertyParsingInfo.java
+++ b/unicodetools/src/main/java/org/unicode/props/PropertyParsingInfo.java
@@ -818,7 +818,7 @@ public class PropertyParsingInfo implements Comparable<PropertyParsingInfo> {
             //                propInfo.defaultValue = "<none>";
             //            }
             switch (propInfo.defaultValueType) {
-                    // TODO(egg): Consider also storing only the changed values here.
+                // TODO(egg): Consider also storing only the changed values here.
                 case Script:
                 case Simple_Lowercase_Mapping:
                 case Simple_Titlecase_Mapping:

--- a/unicodetools/src/main/java/org/unicode/props/ShimUnicodePropertyFactory.java
+++ b/unicodetools/src/main/java/org/unicode/props/ShimUnicodePropertyFactory.java
@@ -95,16 +95,16 @@ public class ShimUnicodePropertyFactory extends UnicodeProperty.Factory {
                 case "Unicode_1_Name":
                     prop = replaceValues(prop, oldValue -> oldValue == null ? "" : oldValue);
                     break;
-                    // The following are "fake" in ToolUnicodeProperty
-                    // I think they are just present for the types and aliases
+                // The following are "fake" in ToolUnicodeProperty
+                // I think they are just present for the types and aliases
                 case "ISO_Comment":
                     prop =
                             copyPropReplacingMap(
                                     prop,
                                     new UnicodeMap<String>().putAll(0, 0x10ffff, "").freeze());
                     break;
-                    // The following are not really supported in TUP; values are all "". So just
-                    // match that.
+                // The following are not really supported in TUP; values are all "". So just
+                // match that.
                 case "Name_Alias":
                 case "kAccountingNumeric":
                 case "kCompatibilityVariant":

--- a/unicodetools/src/main/java/org/unicode/text/UCA/ReorderCodes.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/ReorderCodes.java
@@ -91,8 +91,8 @@ public class ReorderCodes {
             // - Remove scripts supported by ICU4J UScript and CLDR ScriptMetadata.
             // - Add scripts not yet supported there.
             switch (reorderCode) {
-                    //            case UCD_Types.Old_Hungarian:
-                    //                return "Old_Hungarian";
+                //            case UCD_Types.Old_Hungarian:
+                //                return "Old_Hungarian";
                 default:
                     throw new UnsupportedOperationException("unknown reorderCode " + reorderCode);
             }
@@ -111,8 +111,8 @@ public class ReorderCodes {
             // - Remove scripts supported by ICU4J UScript and CLDR ScriptMetadata.
             // - Add scripts not yet supported there.
             switch (reorderCode) {
-                    //            case UCD_Types.Old_Hungarian:
-                    //                return "Hung";
+                //            case UCD_Types.Old_Hungarian:
+                //                return "Hung";
                 default:
                     throw new UnsupportedOperationException("unknown reorderCode " + reorderCode);
             }
@@ -143,7 +143,7 @@ public class ReorderCodes {
             // See https://www.unicode.org/alloc/Pipeline.html
             // and https://cldr.unicode.org/development/updating-codes/updating-script-metadata
             switch (reorderCode) {
-                    // Approved for Unicode 18:
+                // Approved for Unicode 18:
                 case UCD_Types.Chisoi:
                     return Character.toString(0x16D93);
                 case UCD_Types.Jurchen:
@@ -152,8 +152,8 @@ public class ReorderCodes {
                     return Character.toString(0x125AD);
                 case UCD_Types.Seal:
                     return Character.toString(0x3EA10);
-                    // Provisionally assigned so far:
-                    // (none of these needed right now)
+                // Provisionally assigned so far:
+                // (none of these needed right now)
                 default:
                     throw new UnsupportedOperationException(
                             "ReorderCodes.getSampleCharacter() for unknown reorderCode "

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java
@@ -666,7 +666,7 @@ public class GenerateConfusables {
                     case valid:
                     case deviation:
                         IDNOutputSet.add(cp);
-                        // fall thru!
+                    // fall thru!
                     case mapped:
                     case ignored:
                         IDNInputSet.add(cp);

--- a/unicodetools/src/main/java/org/unicode/text/UCD/IdentifierInfo.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/IdentifierInfo.java
@@ -536,9 +536,9 @@ public class IdentifierInfo {
             final IdUsage idUsage = getScriptUsage(script);
             IdentifierInfo.Identifier_Type status;
             switch (idUsage) {
-                    //            case ASPIRATIONAL:
-                    //                status = Identifier_Type.aspirational;
-                    //                break;
+                //            case ASPIRATIONAL:
+                //                status = Identifier_Type.aspirational;
+                //                break;
                 case LIMITED_USE:
                     status = Identifier_Type.limited_use;
                     break;

--- a/unicodetools/src/main/java/org/unicode/text/UCD/UCD.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/UCD.java
@@ -1666,29 +1666,29 @@ public final class UCD implements UCD_Types {
                 }
                 // isRemapped = true;
                 break;
-                // FALL THROUGH!!!!
-                // default:
-                /*
-                result = getRaw(codePoint);
-                if (result == null) {
-                    result = UData.UNASSIGNED;
-                    result.name = null; // clean this up, since we reuse UNASSIGNED
-                    result.shortName = null;
-                    if (fixStrings) {
-                        result.name = "<unassigned-" + Utility.hex(codePoint, 4) + ">";
-                    }
-                }
+            // FALL THROUGH!!!!
+            // default:
+            /*
+            result = getRaw(codePoint);
+            if (result == null) {
+                result = UData.UNASSIGNED;
+                result.name = null; // clean this up, since we reuse UNASSIGNED
+                result.shortName = null;
                 if (fixStrings) {
-                    if (result.name == null) {
-                        result.name = "<unassigned-" + Utility.hex(codePoint, 4) + ">";
-                        // System.out.println("Warning: fixing name for " + result.name);
-                    }
-                    if (result.shortName == null) {
-                        result.shortName = Utility.replace(result.name, UCD_Names.NAME_ABBREVIATIONS);
-                    }
+                    result.name = "<unassigned-" + Utility.hex(codePoint, 4) + ">";
                 }
-                 */
-                // break;
+            }
+            if (fixStrings) {
+                if (result.name == null) {
+                    result.name = "<unassigned-" + Utility.hex(codePoint, 4) + ">";
+                    // System.out.println("Warning: fixing name for " + result.name);
+                }
+                if (result.shortName == null) {
+                    result.shortName = Utility.replace(result.name, UCD_Names.NAME_ABBREVIATIONS);
+                }
+            }
+             */
+            // break;
             case CJK_A_BASE: // CJK Ideograph Extension A
             case CJK_BASE: // CJK Ideograph
             case CJK_B_BASE: // Extension B

--- a/unicodetools/src/main/java/org/unicode/text/UCD/UCD_Names.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/UCD_Names.java
@@ -920,12 +920,12 @@ public final class UCD_Names implements UCD_Types {
                     case 202:
                         s = style < LONG ? "ATB" : "AttachedBelow";
                         break;
-                        /*
-                           case 204: s = style < LONG ? "ATBR" :  "AttachedBelowRight"; break;
-                           case 208: s = style < LONG ? "ATL" :  "AttachedLeft"; break;
-                           case 210: s = style < LONG ? "ATR" :  "AttachedRight"; break;
-                           case 212: s = style < LONG ? "ATAL" :  "AttachedAboveLeft"; break;
-                        */
+                    /*
+                       case 204: s = style < LONG ? "ATBR" :  "AttachedBelowRight"; break;
+                       case 208: s = style < LONG ? "ATL" :  "AttachedLeft"; break;
+                       case 210: s = style < LONG ? "ATR" :  "AttachedRight"; break;
+                       case 212: s = style < LONG ? "ATAL" :  "AttachedAboveLeft"; break;
+                    */
                     case 214:
                         s = style < LONG ? "ATA" : "AttachedAbove";
                         break;

--- a/unicodetools/src/main/java/org/unicode/text/UCD/UnicodeMapParser.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/UnicodeMapParser.java
@@ -176,7 +176,7 @@ public class UnicodeMapParser<V> {
                         us = doUnicodeSet(source, pos, op, doAssignment, resultToAddTo);
                         break;
                     }
-                    // fall through
+                // fall through
                 default:
                     if (op != Operation.ADD) {
                         return setError(pos);

--- a/unicodetools/src/main/java/org/unicode/text/UCD/UnifiedBinaryProperty.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/UnifiedBinaryProperty.java
@@ -295,13 +295,13 @@ public final class UnifiedBinaryProperty extends UCDProperty {
     @Override
     public boolean skipInDerivedListing() {
         switch ((majorProp << 8) | propValue) {
-                // case CATEGORY | Cn:
-                // case COMBINING_CLASS | 0:
-                // case BIDI_CLASS | BIDI_L:
+            // case CATEGORY | Cn:
+            // case COMBINING_CLASS | 0:
+            // case BIDI_CLASS | BIDI_L:
             case DECOMPOSITION_TYPE | NONE:
             case NUMERIC_TYPE | NUMERIC_NONE:
-                // case EAST_ASIAN_WIDTH | EAN:
-                // case LINE_BREAK | LB_XX:
+            // case EAST_ASIAN_WIDTH | EAN:
+            // case LINE_BREAK | LB_XX:
             case JOINING_TYPE | JT_U:
             case JOINING_GROUP | NO_SHAPING:
             case SCRIPT | COMMON_SCRIPT:

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VersionedSymbolTable.java
@@ -282,10 +282,10 @@ public class VersionedSymbolTable extends UnicodeSet.XSymbolTable {
         } else {
             switch (versionQualifier.charAt(0)) {
                 case 'R':
-                    // Extension: we allow a version-qualifier starting with R for retroactive
-                    // properties, that is, property derivations applied before the property
-                    // existed.
-                    // TODO(egg): Actually support that.
+                // Extension: we allow a version-qualifier starting with R for retroactive
+                // properties, that is, property derivations applied before the property
+                // existed.
+                // TODO(egg): Actually support that.
                 case 'U':
                     break;
                 default:

--- a/unicodetools/src/main/java/org/unicode/text/utility/FastBinarySearch.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/FastBinarySearch.java
@@ -210,8 +210,8 @@ public final class FastBinarySearch {
         // The invariant AFTER each line is that data[low] < searchValue <= data[high]
 
         switch (power) {
-                // case 31: if (searchValue < data[temp = high-0x40000000]) high = temp; // no
-                // unsigned int in Java
+            // case 31: if (searchValue < data[temp = high-0x40000000]) high = temp; // no
+            // unsigned int in Java
             case 30:
                 if (searchValue < data[temp = high - 0x20000000]) {
                     high = temp;

--- a/unicodetools/src/main/java/org/unicode/text/utility/UTF8StreamReader.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/UTF8StreamReader.java
@@ -115,7 +115,7 @@ public final class UTF8StreamReader extends Reader {
             int b = bBuffer[bIndex++] & 0xFF;
 
             switch (bRemaining) {
-                    // First Byte case
+                // First Byte case
                 case 0:
                     bRemaining = BYTES_REMAINING[b];
                     switch (bRemaining) {
@@ -139,7 +139,7 @@ public final class UTF8StreamReader extends Reader {
                     }
                     break;
 
-                    // Trailing bytes
+                // Trailing bytes
                 case 2:
                 case 3:
                     b ^= 0x80;
@@ -151,7 +151,7 @@ public final class UTF8StreamReader extends Reader {
                     --bRemaining;
                     break;
 
-                    // Last trailing byte, time to assemble
+                // Last trailing byte, time to assemble
                 case 1:
                     b ^= 0x80;
                     if (b > 0x3F) {

--- a/unicodetools/src/main/java/org/unicode/text/utility/Utility.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/Utility.java
@@ -491,7 +491,7 @@ public final class Utility implements UCD_Types { // COMMON UTILITIES
                                 "bad hex value: ‘{0}’ at position {1} in \"{2}\"",
                                 new Object[] {String.valueOf(ch), new Integer(i), p});
                     }
-                    // fall through!!
+                // fall through!!
                 case 'U':
                 case 'u':
                 case '+': // for the U+ case
@@ -741,9 +741,9 @@ public final class Utility implements UCD_Types { // COMMON UTILITIES
             case '"':
                 return "&quot;";
 
-                // fix controls, since XML can't handle
+            // fix controls, since XML can't handle
 
-                // also do this for 09, 0A, and 0D, so we can see them.
+            // also do this for 09, 0A, and 0D, so we can see them.
             case 0x00:
             case 0x01:
             case 0x02:
@@ -778,7 +778,7 @@ public final class Utility implements UCD_Types { // COMMON UTILITIES
             case 0x1F:
             case 0x7F:
 
-                // fix noncharacters, since XML can't handle
+            // fix noncharacters, since XML can't handle
             case 0xFFFE:
             case 0xFFFF:
                 return HTML ? '#' + hex(c, 4) : "<codepoint hex=\"" + hex(c, 1) + "\"/>";

--- a/unicodetools/src/main/java/org/unicode/tools/FixedProps.java
+++ b/unicodetools/src/main/java/org/unicode/tools/FixedProps.java
@@ -333,9 +333,9 @@ public class FixedProps {
         switch (s) {
             case Japanese:
                 return "Punc";
-                //        case Korean: return "Zmth";
-                //        case Han_with_Bopomofo: return "Zsye";
-                //        case Katakana_Or_Hiragana: return "Zsym";
+            //        case Korean: return "Zmth";
+            //        case Han_with_Bopomofo: return "Zsye";
+            //        case Katakana_Or_Hiragana: return "Zsym";
             default:
                 return s.getShortName();
         }
@@ -345,9 +345,9 @@ public class FixedProps {
         switch (s) {
             case Japanese:
                 return "Punctuation";
-                //        case Korean: return "Math Symbol";
-                //        case Han_with_Bopomofo: return "Emoji";
-                //        case Katakana_Or_Hiragana: return "Other Symbol";
+            //        case Korean: return "Math Symbol";
+            //        case Han_with_Bopomofo: return "Emoji";
+            //        case Katakana_Or_Hiragana: return "Other Symbol";
             default:
                 return s.toString();
         }

--- a/unicodetools/src/main/java/org/unicode/tools/Ids.java
+++ b/unicodetools/src/main/java/org/unicode/tools/Ids.java
@@ -648,7 +648,7 @@ public class Ids {
                                 }
                                 break;
                             }
-                            // ⿱&CDP-8B5E;廾[UG]    ⿱&CDP-88F0;廾[T]
+                        // ⿱&CDP-8B5E;廾[UG]    ⿱&CDP-88F0;廾[T]
                         case '&':
                             {
                                 StringBuilder sb = new StringBuilder();

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/CandidateData.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/CandidateData.java
@@ -242,7 +242,7 @@ public class CandidateData implements Transform<String, String>, EmojiDataSource
                     String rightSide = equalPos < 0 ? null : line.substring(equalPos + 1).trim();
                     switch (leftSide) {
 
-                            // go before character
+                        // go before character
                         case "Status":
                             status = CandidateData.Status.fromString(rightSide);
                             break;
@@ -260,7 +260,7 @@ public class CandidateData implements Transform<String, String>, EmojiDataSource
                             proposalItem = rightSide;
                             break;
 
-                            // go after character
+                        // go after character
                         case "Name":
                             final String name = rightSide;
                             if (name.contains("|")) {

--- a/unicodetools/src/main/java/org/unicode/xml/AttributeResolver.java
+++ b/unicodetools/src/main/java/org/unicode/xml/AttributeResolver.java
@@ -276,7 +276,7 @@ public class AttributeResolver {
             case Binary:
                 {
                     switch (resolvedValue) {
-                            // Seems overkill to get this from UcdPropertyValues.Binary
+                        // Seems overkill to get this from UcdPropertyValues.Binary
                         case "No":
                             return "N";
                         case "Yes":

--- a/unicodetools/src/main/java/org/unicode/xml/GeneratePropertyValues.java
+++ b/unicodetools/src/main/java/org/unicode/xml/GeneratePropertyValues.java
@@ -552,22 +552,22 @@ public class GeneratePropertyValues {
                         : "    attribute " + ucdProperty.getShortName() + " ";
         String formattedAttributeString;
         switch (ucdProperty) {
-                // { text }
+            // { text }
             case ISO_Comment:
                 formattedAttributeString = attributeString + "{ text }?";
                 break;
 
-                // { single-code-point }
+            // { single-code-point }
             case Equivalent_Unified_Ideograph:
                 formattedAttributeString = attributeString + "{ single-code-point }?";
                 break;
 
-                // { "" | single-code-point }
+            // { "" | single-code-point }
             case Bidi_Mirroring_Glyph:
                 formattedAttributeString = attributeString + "{ \"\" | single-code-point }?";
                 break;
 
-                // { "#" | single-code-point }
+            // { "#" | single-code-point }
             case Bidi_Paired_Bracket:
             case Simple_Uppercase_Mapping:
             case Simple_Lowercase_Mapping:
@@ -576,7 +576,7 @@ public class GeneratePropertyValues {
                 formattedAttributeString = attributeString + "{ \"#\" | single-code-point }?";
                 break;
 
-                // { "#" | zero-or-more-code-points }
+            // { "#" | zero-or-more-code-points }
             case Decomposition_Mapping:
             case NFKC_Casefold:
             case NFKC_Simple_Casefold:
@@ -584,7 +584,7 @@ public class GeneratePropertyValues {
                         attributeString + "{ \"#\" | zero-or-more-code-points }?";
                 break;
 
-                // { "#" | one-or-more-code-points }
+            // { "#" | one-or-more-code-points }
             case Uppercase_Mapping:
             case Lowercase_Mapping:
             case Titlecase_Mapping:
@@ -592,7 +592,7 @@ public class GeneratePropertyValues {
                 formattedAttributeString = attributeString + "{ \"#\" | one-or-more-code-points }?";
                 break;
 
-                // { "NaN" | RegEx }
+            // { "NaN" | RegEx }
             case Numeric_Value:
                 formattedAttributeString =
                         attributeString
@@ -601,7 +601,7 @@ public class GeneratePropertyValues {
                                 + "\" } }?";
                 break;
 
-                // Special cases
+            // Special cases
             case Name:
                 formattedAttributeString =
                         attributeString
@@ -1813,9 +1813,9 @@ public class GeneratePropertyValues {
             switch (delimiter) {
                 case "N/A":
                     break;
-                    // The next two are to support two Provisional attributes in Unikemet. We'll
-                    // process these as
-                    // exceptions for now
+                // The next two are to support two Provisional attributes in Unikemet. We'll
+                // process these as
+                // exceptions for now
                 case "/ (see description)": // kEH_Func
                 case "/ or | (see description)": // kEH_FVal
                     break;

--- a/unicodetools/src/main/java/org/unicode/xml/XMLProperties.java
+++ b/unicodetools/src/main/java/org/unicode/xml/XMLProperties.java
@@ -439,7 +439,7 @@ public class XMLProperties {
                     }
                     break;
                 }
-                // $FALL-THROUGH$
+            // $FALL-THROUGH$
             case Enumerated:
             case Catalog:
                 if (propertyValue != null) {
@@ -469,8 +469,8 @@ public class XMLProperties {
                             propertyValue =
                                     IndexUnicodeProperties.normalizeValue(property, propertyValue);
                             break;
-                            //                case Name:
-                            //                    break;
+                        //                case Name:
+                        //                    break;
                         default:
                             propertyValue = propertyValue.replace("#", Utility.hex(codePoint));
                     }

--- a/unicodetools/src/test/java/org/unicode/propstest/XMLProperties.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/XMLProperties.java
@@ -361,7 +361,7 @@ public class XMLProperties {
                             break;
                         }
                     case NORMALIZATION_CORRECTION:
-                        // ucd/normalization-corrections/normalization-correction[@cp="F951"][@old="96FB"][@new="964B"][@version="3.2.0"
+                    // ucd/normalization-corrections/normalization-correction[@cp="F951"][@old="96FB"][@new="964B"][@version="3.2.0"
                     default:
                         leavesNotHandled.add(qName);
                         break;
@@ -508,7 +508,7 @@ public class XMLProperties {
                     }
                     break;
                 }
-                // $FALL-THROUGH$
+            // $FALL-THROUGH$
             case Enumerated:
             case Catalog:
                 if (propertyValue != null) {
@@ -529,8 +529,8 @@ public class XMLProperties {
                             propertyValue =
                                     IndexUnicodeProperties.normalizeValue(property, propertyValue);
                             break;
-                            //                case Name:
-                            //                    break;
+                        //                case Name:
+                        //                    break;
                         default:
                             propertyValue = propertyValue.replace("#", Utility.hex(codePoint));
                     }

--- a/unicodetools/src/test/java/org/unicode/unittest/LocaleExtensions.java
+++ b/unicodetools/src/test/java/org/unicode/unittest/LocaleExtensions.java
@@ -254,7 +254,7 @@ public class LocaleExtensions {
                         builder.setExtension('t', tValue.toString());
                         tValue = null;
                     }
-                    // fall through
+                // fall through
                 default:
                     builder.setExtension(key.charAt(0), value);
                     break;


### PR DESCRIPTION
My machine updated to Java 25, and spotless throws exceptions.

I updated spotless to the same version that ICU is using for the last couple of months, and the underlying google-java-format to its latest version.

Then I ran spotless, and it changed a few files. Mostly (maybe only), comments before a switch-case are indented only as much as the `case CONSTANT`, not as much as the preceding case body code.

This broke CI initially, because it was using the same Java 11 for compiling Unicode Tools code as well as for building and running spotless. @mihnita fixed this with PR #1342.

@mihnita FYI