### PR TITLE
fix some deprecated-type warnings

### DIFF
--- a/unicodetools/src/main/java/org/unicode/draft/UnicodeIntMap.java
+++ b/unicodetools/src/main/java/org/unicode/draft/UnicodeIntMap.java
@@ -884,18 +884,6 @@ public final class UnicodeIntMap
         return this;
     }
 
-    /**
-     * Utility for extracting map
-     *
-     * @deprecated
-     */
-    public UnicodeIntMap putAllIn(Map<? super String, ? super Integer> map) {
-        for (String key : keySet()) {
-            map.put(key, get(key));
-        }
-        return this;
-    }
-
     /** Utility for extracting map */
     public <U extends Map<String, Integer>> U putAllInto(U map) {
         for (EntryRange<Integer> entry : entryRanges()) {

--- a/unicodetools/src/main/java/org/unicode/tools/NormalizeForMatch.java
+++ b/unicodetools/src/main/java/org/unicode/tools/NormalizeForMatch.java
@@ -78,13 +78,6 @@ public class NormalizeForMatch {
 
     static String TEST = Utility.fromHex("1F19B");
 
-    /**
-     * @deprecated Use {@link #load(String,String,boolean)} instead
-     */
-    public static NormalizeForMatch load(String directory, String file) {
-        return load(directory, file, true);
-    }
-
     public static NormalizeForMatch load(String directory, String file, boolean acceptRawChars) {
         UnicodeMap<String> sourceToTarget = new UnicodeMap<>();
         UnicodeMap<SpecialReason> sourceToReason = new UnicodeMap<>();

--- a/unicodetools/src/main/java/org/unicode/tools/NormalizeForMatchDiff.java
+++ b/unicodetools/src/main/java/org/unicode/tools/NormalizeForMatchDiff.java
@@ -11,15 +11,20 @@ public class NormalizeForMatchDiff {
         NormalizeForMatch production =
                 NormalizeForMatch.load(
                         "/Users/markdavis/Google Drive/workspace/Generated/n4m-old/",
-                        "xnfkccf_curated.txt");
-        NormalizeForMatch sourceDirectory = NormalizeForMatch.load(null, "XNFKCCF-Curated.txt");
+                        "xnfkccf_curated.txt",
+                        /* acceptRawChars= */ true);
+        NormalizeForMatch sourceDirectory =
+                NormalizeForMatch.load(null, "XNFKCCF-Curated.txt", /* acceptRawChars= */ true);
         NormalizeForMatch dir90 =
                 NormalizeForMatch.load(
-                        Settings.UnicodeTools.DATA_DIR + "n4m/9.0.0/", "XNFKCCF-Curated.txt");
+                        Settings.UnicodeTools.DATA_DIR + "n4m/9.0.0/",
+                        "XNFKCCF-Curated.txt",
+                        /* acceptRawChars= */ true);
         NormalizeForMatch gen =
                 NormalizeForMatch.load(
                         "/Users/markdavis/Google Drive/workspace/Generated/n4m/",
-                        "XNFKCCF-Curated.txt");
+                        "XNFKCCF-Curated.txt",
+                        /* acceptRawChars= */ true);
 
         UnicodeSet keys =
                 new UnicodeSet()

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/CountEmoji.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/CountEmoji.java
@@ -657,6 +657,7 @@ public class CountEmoji {
     /**
      * @deprecated Replace by the {@link CountEmoji.Category}
      */
+    @Deprecated
     public enum ZwjType {
         roleWithHair,
         roleWithObject,

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/EmojiAnnotations.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/EmojiAnnotations.java
@@ -55,13 +55,6 @@ public class EmojiAnnotations extends Birelation<String, String> {
     public static final EmojiAnnotations ANNOTATIONS_TO_CHARS =
             new EmojiAnnotations("en", EmojiOrder.STD_ORDER.codepointCompare);
 
-    /**
-     * @deprecated Use {@link #EmojiAnnotations(String,Comparator<String>,String...)} instead
-     */
-    public EmojiAnnotations(Comparator<String> codepointCompare, String... filenames) {
-        this("en", codepointCompare, filenames);
-    }
-
     public EmojiAnnotations(
             String localeString, Comparator<String> codepointCompare, String... filenames) {
         super(

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/GenerateEmojiData.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/GenerateEmojiData.java
@@ -121,6 +121,7 @@ public class GenerateEmojiData {
     /**
      * @deprecated Replace by the CountEmoji.Category
      */
+    @Deprecated
     public enum ZwjType {
         roleWithHair,
         roleWithObject,


### PR DESCRIPTION
In a recent CI log, I noticed warnings about deprecated methods and enums.
- two deprecated methods are unused, so I delete them
- two deprecated enum types are in use, so I add the `@Deprecated` annotation
- one deprecated constructor has 4 call sites, so I update them and delete the constructor

- [x] Approver: Feel free to merge on my behalf
    - [x] rebase & merge one or more commits
    - [ ] squash & merge multiple commits into one