### PR TITLE
add maven.config: no-transfer-progress, UTF-8

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,11 @@
+# Copyright (C) 2026 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+
+# See https://maven.apache.org/configure.html
+
+# Here you can define Maven options instead of passing them in command line.
+# Each single argument must be put on a new line.
+
+# Do not display transfer progress when downloading or uploading
+--no-transfer-progress
+-Dfile.encoding=UTF-8


### PR DESCRIPTION
Copy ICU's .mvn/maven.config file:

a) suppress "Progress" output lines like in
```
Downloading from central: (URL)
Progress (1): 415 kB
Progress (2): 415 kB | 7.7/790 kB
Progress (2): 415 kB | 16/790 kB 
Progress (2): 415 kB | 24/790 kB
Progress (2): 415 kB | 40/790 kB
```

b) make Maven invocations default to reading/writing files using UTF-8, which should avoid having to specify this in each Maven target

Suggested by @mihnita.

- [x] Approver: Feel free to merge on my behalf
    - [x] rebase & merge one or more commits
    - [ ] squash & merge multiple commits into one