### PR TITLE
remove cldrWithoutFFFx collator option & move getCollator() to UCA

### DIFF
--- a/unicodetools/src/main/java/org/unicode/draft/ScriptCount.java
+++ b/unicodetools/src/main/java/org/unicode/draft/ScriptCount.java
@@ -83,7 +83,7 @@ public class ScriptCount {
     }
 
     static class SecondaryCounts {
-        private final UCA uca = UCA.buildDucetCollator();
+        private final UCA uca = UCA.getDucetCollator();
         private final Map<Integer, SecondaryInfo> counter = new HashMap<Integer, SecondaryInfo>();
 
         void add(int sourceString, long count) {

--- a/unicodetools/src/main/java/org/unicode/text/UCA/FractionalUCA.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/FractionalUCA.java
@@ -18,7 +18,6 @@ import java.util.stream.Collectors;
 import org.unicode.cldr.util.Counter;
 import org.unicode.text.UCA.MappingsForFractionalUCA.MappingWithSortKey;
 import org.unicode.text.UCA.PrimariesToFractional.PrimaryToFractional;
-import org.unicode.text.UCA.UCA.CollatorType;
 import org.unicode.text.UCD.Default;
 import org.unicode.text.UCD.ToolUnicodePropertySource;
 import org.unicode.text.UCD.UCD_Types;
@@ -1377,7 +1376,7 @@ public class FractionalUCA {
     }
 
     private static UCA getCollator() {
-        return WriteCollationData.getCollator(CollatorType.cldr);
+        return UCA.getCldrCollator();
     }
 
     private static String cpToScript(int codePoint) {

--- a/unicodetools/src/main/java/org/unicode/text/UCA/FractionalUCA.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/FractionalUCA.java
@@ -1377,7 +1377,7 @@ public class FractionalUCA {
     }
 
     private static UCA getCollator() {
-        return WriteCollationData.getCollator(CollatorType.cldrWithoutFFFx);
+        return WriteCollationData.getCollator(CollatorType.cldr);
     }
 
     private static String cpToScript(int codePoint) {

--- a/unicodetools/src/main/java/org/unicode/text/UCA/Main.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/Main.java
@@ -178,7 +178,7 @@ public class Main {
                         "CollationTest_SHIFTED", UCA_Types.SHIFTED, true, CollatorType.cldr);
             } else if (arg.equalsIgnoreCase("testCompatibilityCharacters")) {
                 TestCompatibilityCharacters.testCompatibilityCharacters(
-                        WriteCollationData.getCollator(CollatorType.cldrWithoutFFFx));
+                        WriteCollationData.getCollator(CollatorType.cldr));
             } else if (arg.equalsIgnoreCase("writeCollationValidityLog")) {
                 Validity.writeCollationValidityLog();
             } else if (arg.equalsIgnoreCase("writeJavascriptInfo")) {

--- a/unicodetools/src/main/java/org/unicode/text/UCA/Main.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/Main.java
@@ -81,13 +81,13 @@ public class Main {
                 continue;
             }
             if (arg.equalsIgnoreCase("GenOverlap")) {
-                GenOverlap.test(WriteCollationData.getCollator(CollatorType.ducet));
+                GenOverlap.test(UCA.getDucetCollator());
             } else if (arg.equalsIgnoreCase("validateUCA")) {
-                GenOverlap.validateUCA(WriteCollationData.getCollator(CollatorType.ducet));
+                GenOverlap.validateUCA(UCA.getDucetCollator());
                 // else if (arg.equalsIgnoreCase("writeNonspacingDifference"))
                 // WriteCollationData.writeNonspacingDifference();
             } else if (arg.equalsIgnoreCase("collationChart")) {
-                WriteCharts.collationChart(WriteCollationData.getCollator(CollatorType.ducet));
+                WriteCharts.collationChart(UCA.getDucetCollator());
             } else if (arg.equalsIgnoreCase("scriptChart")) {
                 WriteCharts.scriptChart();
             } else if (arg.equalsIgnoreCase("normalizationChart")) {
@@ -103,11 +103,11 @@ public class Main {
             } else if (arg.equalsIgnoreCase("writeCompositionChart")) {
                 WriteCharts.writeCompositionChart();
             } else if (arg.equalsIgnoreCase("CheckHash")) {
-                GenOverlap.checkHash(WriteCollationData.getCollator(CollatorType.ducet));
+                GenOverlap.checkHash(UCA.getDucetCollator());
             } else if (arg.equalsIgnoreCase("generateRevision")) {
-                GenOverlap.generateRevision(WriteCollationData.getCollator(CollatorType.ducet));
+                GenOverlap.generateRevision(UCA.getDucetCollator());
             } else if (arg.equalsIgnoreCase("listCyrillic")) {
-                GenOverlap.listCyrillic(WriteCollationData.getCollator(CollatorType.ducet));
+                GenOverlap.listCyrillic(UCA.getDucetCollator());
             } else if (arg.equalsIgnoreCase("WriteRules")) {
                 WriteCollationData.writeRules(
                         WriteCollationData.WITHOUT_NAMES, shortPrint, noCE, CollatorType.ducet);
@@ -177,8 +177,7 @@ public class Main {
                 WriteConformanceTest.writeConformance(
                         "CollationTest_SHIFTED", UCA_Types.SHIFTED, true, CollatorType.cldr);
             } else if (arg.equalsIgnoreCase("testCompatibilityCharacters")) {
-                TestCompatibilityCharacters.testCompatibilityCharacters(
-                        WriteCollationData.getCollator(CollatorType.cldr));
+                TestCompatibilityCharacters.testCompatibilityCharacters(UCA.getCldrCollator());
             } else if (arg.equalsIgnoreCase("writeCollationValidityLog")) {
                 Validity.writeCollationValidityLog();
             } else if (arg.equalsIgnoreCase("writeJavascriptInfo")) {

--- a/unicodetools/src/main/java/org/unicode/text/UCA/PrimariesToFractional.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/PrimariesToFractional.java
@@ -815,12 +815,6 @@ public final class PrimariesToFractional {
                 UCA.Primary up = regularPrimaries.next();
                 primary = up.primary;
                 nextPrimary = up.nextPrimary;
-                if (primary >= 0xfffd) {
-                    // Special UCA primary FFFD for U+FFFD, gets a hardcoded fractional CE.
-                    // Other special high primaries might get added.
-                    // CLDR already hardcodes one for U+FFFF.
-                    continue;
-                }
                 representativeCP = Character.codePointAt(up.getRepresentative(), 0);
                 props = getOrCreateProps(primary);
             } else if (siniformRanges.hasNext()) {
@@ -1142,8 +1136,8 @@ public final class PrimariesToFractional {
         if (ucaPrimary < Implicit.UNASSIGNED_BASE) {
             return HAN_INDEX;
         }
-        if (0xfffd <= ucaPrimary && ucaPrimary <= 0xffff) {
-            return FFFD_INDEX + ucaPrimary - 0xfffd;
+        if (UCA.MIN_HIGH_SPECIAL_PRIMARY <= ucaPrimary && ucaPrimary <= 0xffff) {
+            return FFFD_INDEX + ucaPrimary - UCA.MIN_HIGH_SPECIAL_PRIMARY;
         }
         throw new IllegalArgumentException(
                 "no properties for unassigned or trailing UCA primary " + Utility.hex(ucaPrimary));
@@ -1235,11 +1229,6 @@ public final class PrimariesToFractional {
             if (script == UCD_Types.COMMON_SCRIPT
                     || script == UCD_Types.INHERITED_SCRIPT
                     || script == UCD_Types.Unknown_Script) {
-                if (primary == 0xfffd) {
-                    // Special UCA primary FFFD for U+FFFD, gets a hardcoded fractional CE.
-                    // Do not include it in the last regular script.
-                    options = null;
-                }
                 // Otherwise: Not a real script, keep current options.
             } else if (script != options.reorderCode) {
                 ScriptOptions newOptions = getOrCreateOptionsForScript(script);

--- a/unicodetools/src/main/java/org/unicode/text/UCA/UCA.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/UCA.java
@@ -99,10 +99,12 @@ public final class UCA implements Comparator<String>, UCA_Types {
 
     // --------------------------------------------------------------------
 
+    public static final int MAX_LOW_SPECIAL_PRIMARY = 0x200; // for U+FFFE
+    public static final int MIN_HIGH_SPECIAL_PRIMARY = 0xfffd; // for U+FFFD; FFFF for U+FFFF
+
     public enum CollatorType {
         ducet,
         cldr,
-        cldrWithoutFFFx
     }
 
     public static final String copyright =
@@ -165,7 +167,23 @@ public final class UCA implements Comparator<String>, UCA_Types {
         final RoBitSet primarySet = getStatistics().getPrimarySet();
 
         PrimaryIterator(int start) {
-            p.nextPrimary = primarySet.nextSetBit(start);
+            p.nextPrimary = getNextRegularPrimary(start);
+        }
+
+        private int getNextRegularPrimary(int next) {
+            for (; ; ) {
+                next = primarySet.nextSetBit(next);
+                // skip special primaries:
+                // 0200 special low primary for U+FFFE
+                // FFFD special high primary for U+FFFD
+                // FFFF special high primary for U+FFFF
+                if (next >= 0
+                        && (next <= MAX_LOW_SPECIAL_PRIMARY || MIN_HIGH_SPECIAL_PRIMARY <= next)) {
+                    ++next;
+                } else {
+                    return next;
+                }
+            }
         }
 
         @Override
@@ -177,7 +195,7 @@ public final class UCA implements Comparator<String>, UCA_Types {
         public Primary next() {
             if (p.nextPrimary >= 0) {
                 p.primary = p.nextPrimary;
-                p.nextPrimary = primarySet.nextSetBit(p.primary + 1);
+                p.nextPrimary = getNextRegularPrimary(p.primary + 1);
                 p.representative = getRepresentativePrimary(p.primary);
                 return p;
             } else {
@@ -269,21 +287,16 @@ public final class UCA implements Comparator<String>, UCA_Types {
         cleanup();
     }
 
-    /** Returns all non-ignorable, below-implicit UCA primary weights. */
+    /** Returns all non-ignorable, below-implicit, non-special UCA primary weights. */
     Iterable<Primary> getRegularPrimaries() {
         // Start after the ignorable primary 0.
         return new PrimaryIterable(1);
     }
 
-    /** Returns all below-Han UCA primary weights, starting with ignorable 0. */
-    PrimaryIterable getIgnorableAndRegularPrimaries() {
-        return new PrimaryIterable(0);
-    }
-
     int getLastRegularPrimary() {
         UCA_Statistics.RoBitSet set = getStatistics().getPrimarySet();
         int last = set.length() - 1;
-        while (last >= 0xfffd) {
+        while (last >= MIN_HIGH_SPECIAL_PRIMARY) {
             last = set.previousSetBit(last - 1);
         }
         return last;

--- a/unicodetools/src/main/java/org/unicode/text/UCA/UCA.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/UCA.java
@@ -107,8 +107,33 @@ public final class UCA implements Comparator<String>, UCA_Types {
         cldr,
     }
 
-    public static final String copyright =
-            "Copyright (C) 2000, IBM Corp. and others. All Rights Reserved.";
+    private static UCA ducetCollator;
+    private static UCA cldrCollator;
+
+    public static UCA getDucetCollator() {
+        if (ducetCollator == null) {
+            ducetCollator = buildDucetCollator();
+        }
+        return ducetCollator;
+    }
+
+    public static UCA getCldrCollator() {
+        if (cldrCollator == null) {
+            cldrCollator = buildCldrCollator();
+        }
+        return cldrCollator;
+    }
+
+    public static UCA getCollator(CollatorType type) {
+        switch (type) {
+            case cldr:
+                return getCldrCollator();
+            case ducet:
+                return getDucetCollator();
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
 
     @Override
     public int compare(String a, String b) {
@@ -1797,7 +1822,7 @@ public final class UCA implements Comparator<String>, UCA_Types {
         return buildCollator(-1, -1);
     }
 
-    static UCA buildCollator(int variableHigh, int firstNonVariable) {
+    private static UCA buildCollator(int variableHigh, int firstNonVariable) {
         try {
             if (VERBOSE) System.out.println("Building UCA");
             final Path dataPath = Settings.UnicodeTools.getDataPathForLatestVersion("uca");
@@ -1815,6 +1840,116 @@ public final class UCA implements Comparator<String>, UCA_Types {
         } catch (final IOException e) {
             throw new IllegalArgumentException(e);
         }
+    }
+
+    private static UCA buildCldrCollator() {
+        final UCA ducet = getDucetCollator();
+
+        final int ducetVariableHigh = CEList.getPrimary(ducet.getVariableHighCE());
+        int cldrVariableHigh = 0;
+        // This will normally come out as ducetVariableHigh + 1.
+        int firstDucetNonVariable = -1;
+
+        // DUCET: variable primary weights include spaces, punctuation, and symbols
+        // CLDR: variable primary weights include only spaces and punctuation
+        for (final UCA.Primary up : ducet.getRegularPrimaries()) {
+            final int ducetPrimary = up.primary;
+            if (firstDucetNonVariable < 0 && ducetPrimary > ducetVariableHigh) {
+                firstDucetNonVariable = ducetPrimary;
+            }
+
+            final String repChar = up.getRepresentative();
+            final int firstChar = Character.codePointAt(repChar, 0);
+            final int cat = Default.ucd().getCategory(firstChar);
+            switch (cat) {
+                case UCD_Types.DASH_PUNCTUATION:
+                case UCD_Types.START_PUNCTUATION:
+                case UCD_Types.END_PUNCTUATION:
+                case UCD_Types.CONNECTOR_PUNCTUATION:
+                case UCD_Types.OTHER_PUNCTUATION:
+                case UCD_Types.INITIAL_PUNCTUATION:
+                case UCD_Types.FINAL_PUNCTUATION:
+                    if (ducetPrimary <= ducetVariableHigh && ducetPrimary > cldrVariableHigh) {
+                        cldrVariableHigh = ducetPrimary;
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+        final UCA result = buildCollator(cldrVariableHigh, firstDucetNonVariable);
+
+        result.overrideCE("\uFFFE", 0x1, 0x20, 2);
+        result.overrideCE("\uFFFF", 0xFFFE, 0x20, 2);
+
+        if (
+        /* ADD_TIBETAN */ true) {
+            final CEList fb2 = result.getCEList("\u0FB2", true);
+            final CEList fb3 = result.getCEList("\u0FB3", true);
+            final CEList f71_f72 = result.getCEList("\u0F71\u0F72", true);
+            final CEList f71_f74 = result.getCEList("\u0F71\u0F74", true);
+            final CEList fb2_f71 = result.getCEList("\u0FB2\u0F71", true);
+            final CEList fb3_f71 = result.getCEList("\u0FB3\u0F71", true);
+
+            addOverride(
+                    result,
+                    "\u0FB2\u0F71",
+                    fb2_f71); // 0FB2 0F71      ;     [.255A.0020.0002.0FB2][.2570.0020.0002.0F71] -
+            // concat 0FB2 + 0F71
+            addOverride(
+                    result,
+                    "\u0FB2\u0F71\u0F72",
+                    fb2,
+                    f71_f72); // 0FB2 0F71 0F72 ;    [.255A.0020.0002.0FB2][.2572.0020.0002.0F73] -
+            // concat 0FB2 + (0F71/0F72)
+            addOverride(result, "\u0FB2\u0F73", fb2, f71_f72); // 0FB2 0F73      ;
+            // [.255A.0020.0002.0FB2][.2572.0020.0002.0F73] = prev
+            addOverride(
+                    result,
+                    "\u0FB2\u0F71\u0F74",
+                    fb2,
+                    f71_f74); // 0FB2 0F71 0F74 ;    [.255A.0020.0002.0FB2][.2576.0020.0002.0F75] -
+            // concat 0FB2 + (0F71/0F74)
+            addOverride(result, "\u0FB2\u0F75", fb2, f71_f74); // 0FB2 0F75      ;
+            // [.255A.0020.0002.0FB2][.2576.0020.0002.0F75]  = prev
+
+            // same as above, but 0FB2 => 0FB3 and fb2 => fb3
+
+            addOverride(
+                    result,
+                    "\u0FB3\u0F71",
+                    fb3_f71); // 0FB3 0F71      ;     [.255A.0020.0002.0FB3][.2570.0020.0002.0F71] -
+            // concat 0FB3 + 0F71
+            addOverride(
+                    result,
+                    "\u0FB3\u0F71\u0F72",
+                    fb3,
+                    f71_f72); // 0FB3 0F71 0F72 ;    [.255A.0020.0002.0FB3][.2572.0020.0002.0F73] -
+            // concat 0FB3 + (0F71/0F72)
+            addOverride(result, "\u0FB3\u0F73", fb3, f71_f72); // 0FB3 0F73      ;
+            // [.255A.0020.0002.0FB3][.2572.0020.0002.0F73] = prev
+            addOverride(
+                    result,
+                    "\u0FB3\u0F71\u0F74",
+                    fb3,
+                    f71_f74); // 0FB3 0F71 0F74 ;    [.255A.0020.0002.0FB3][.2576.0020.0002.0F75] -
+            // concat 0FB3 + (0F71/0F74)
+            addOverride(result, "\u0FB3\u0F75", fb3, f71_f74); // 0FB3 0F75      ;
+            // [.255A.0020.0002.0FB3][.2576.0020.0002.0F75]  = prev
+        }
+
+        return result;
+    }
+
+    private static void addOverride(UCA result, String string, CEList... ceLists) {
+        final IntStack tempStack = new IntStack(10);
+        for (final CEList ceList : ceLists) {
+            for (int i = 0; i < ceList.length(); ++i) {
+                final int ce = ceList.at(i);
+                tempStack.append(ce);
+            }
+        }
+        result.overrideCE(string, tempStack);
     }
 
     UCA_Statistics getStatistics() {

--- a/unicodetools/src/main/java/org/unicode/text/UCA/Validity.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/Validity.java
@@ -54,7 +54,7 @@ final class Validity {
         log =
                 Utility.openPrintWriter(
                         UCA.getOutputDir(), "CheckCollationValidity.html", Utility.UTF8_WINDOWS);
-        uca = WriteCollationData.getCollator(CollatorType.ducet);
+        uca = UCA.getDucetCollator();
 
         log.println(
                 "<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01 Transitional//EN' 'http://www.w3.org/TR/html4/loose.dtd'>\n"
@@ -936,13 +936,11 @@ final class Validity {
 
     private static void addString(String ch, byte option, CollatorType collatorType) {
         final String colDbase =
-                WriteCollationData.getCollator(collatorType)
-                        .getSortKey(ch, option, true, AppendToCe.none);
+                UCA.getCollator(collatorType).getSortKey(ch, option, true, AppendToCe.none);
         final String colNbase =
-                WriteCollationData.getCollator(collatorType)
-                        .getSortKey(ch, option, false, AppendToCe.none);
+                UCA.getCollator(collatorType).getSortKey(ch, option, false, AppendToCe.none);
         final String colCbase =
-                WriteCollationData.getCollator(collatorType)
+                UCA.getCollator(collatorType)
                         .getSortKey(Default.nfc().normalize(ch), option, false, AppendToCe.none);
         if (!colNbase.equals(colCbase) || !colNbase.equals(colDbase)) {
             /*

--- a/unicodetools/src/main/java/org/unicode/text/UCA/Validity.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/Validity.java
@@ -822,7 +822,7 @@ final class Validity {
                 // IF we are in the trailing range, something is wrong.
                 // UCA 6.3+ sets aside primary weights FFFD..FFFF as specials, so those are ok.
                 // See http://www.unicode.org/reports/tr10/#Trailing_Weights
-                if (Implicit.LIMIT <= p && p < 0xfffd) {
+                if (Implicit.LIMIT <= p && p < UCA.MIN_HIGH_SPECIAL_PRIMARY) {
                     log.println(
                             "<tr><td>"
                                     + (++errorCount)

--- a/unicodetools/src/main/java/org/unicode/text/UCA/WriteAllkeys.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/WriteAllkeys.java
@@ -45,7 +45,7 @@ public class WriteAllkeys {
                             + "# Unlike the DUCET, the ordering is by non-ignorable sort order.\n");
         }
 
-        final UCA collator = WriteCollationData.getCollator(collatorType);
+        final UCA collator = UCA.getCollator(collatorType);
         final UCA.UCAContents cc = collator.getContents(null);
         log.println("@version " + collator.getDataVersion() + "\n");
 

--- a/unicodetools/src/main/java/org/unicode/text/UCA/WriteCollationData.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/WriteCollationData.java
@@ -54,7 +54,6 @@ public class WriteCollationData {
 
     private static UCA ducetCollator;
     private static UCA cldrCollator;
-    private static UCA cldrWithoutFFFxCollator;
 
     private static PrintWriter log;
 
@@ -1858,7 +1857,7 @@ public class WriteCollationData {
         switch (type) {
             case cldr:
                 if (cldrCollator == null) {
-                    cldrCollator = buildCldrCollator(true);
+                    cldrCollator = buildCldrCollator();
                 }
                 return cldrCollator;
             case ducet:
@@ -1866,17 +1865,12 @@ public class WriteCollationData {
                     ducetCollator = UCA.buildDucetCollator();
                 }
                 return ducetCollator;
-            case cldrWithoutFFFx:
-                if (cldrWithoutFFFxCollator == null) {
-                    cldrWithoutFFFxCollator = buildCldrCollator(false);
-                }
-                return cldrWithoutFFFxCollator;
             default:
                 throw new IllegalArgumentException();
         }
     }
 
-    private static UCA buildCldrCollator(boolean addFFFx) {
+    private static UCA buildCldrCollator() {
         final UCA ducet = getCollator(CollatorType.ducet);
 
         final int ducetVariableHigh = CEList.getPrimary(ducet.getVariableHighCE());
@@ -1888,10 +1882,6 @@ public class WriteCollationData {
         // CLDR: variable primary weights include only spaces and punctuation
         for (final UCA.Primary up : ducet.getRegularPrimaries()) {
             final int ducetPrimary = up.primary;
-            if (ducetPrimary == 0xFFFD) {
-                // Do not remap the REPLACEMENT CHARACTER which has the special FFFD primary.
-                continue;
-            }
             if (firstDucetNonVariable < 0 && ducetPrimary > ducetVariableHigh) {
                 firstDucetNonVariable = ducetPrimary;
             }
@@ -1917,10 +1907,8 @@ public class WriteCollationData {
         }
         final UCA result = UCA.buildCollator(cldrVariableHigh, firstDucetNonVariable);
 
-        if (addFFFx) {
-            result.overrideCE("\uFFFE", 0x1, 0x20, 2);
-            result.overrideCE("\uFFFF", 0xFFFE, 0x20, 2);
-        }
+        result.overrideCE("\uFFFE", 0x1, 0x20, 2);
+        result.overrideCE("\uFFFF", 0xFFFE, 0x20, 2);
 
         if (ADD_TIBETAN) {
             final CEList fb2 = result.getCEList("\u0FB2", true);

--- a/unicodetools/src/main/java/org/unicode/text/UCA/WriteCollationData.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/WriteCollationData.java
@@ -46,14 +46,7 @@ import org.unicode.text.utility.Settings;
 import org.unicode.text.utility.Utility;
 
 public class WriteCollationData {
-    private static final boolean SHOW_NON_MAPPED = false;
-
-    private static final boolean ADD_TIBETAN = true;
-
     private static final String UNICODE_VERSION = Settings.latestVersion;
-
-    private static UCA ducetCollator;
-    private static UCA cldrCollator;
 
     private static PrintWriter log;
 
@@ -286,8 +279,9 @@ public class WriteCollationData {
 
     static void writeVersionAndDate(PrintWriter log, String filename, boolean auxiliary) {
         log.println(Utility.getDataHeader(filename));
-        log.println("# UCA Version: " + getCollator(CollatorType.ducet).getDataVersion());
-        log.println("# UCD Version: " + getCollator(CollatorType.ducet).getDataVersion());
+        String version = UCA.getDucetCollator().getDataVersion();
+        log.println("# UCA Version: " + version);
+        log.println("# UCD Version: " + version);
         if (auxiliary) {
             log.println(
                     "# For a description of the format and usage, see\n"
@@ -306,7 +300,7 @@ public class WriteCollationData {
 
         diLog.write('\uFEFF');
 
-        final UCA.UCAContents cc = getCollator(CollatorType.ducet).getContents(Default.nfd());
+        final UCA.UCAContents cc = UCA.getDucetCollator().getContents(Default.nfd());
 
         diLog.println("# Contractions");
         writeVersionAndDate(diLog, fullFileName, true);
@@ -374,7 +368,7 @@ public class WriteCollationData {
          * String s = String.valueOf(ch); int len = collator.getCEs(s, true,
          * ces);
          */
-        final UCA.UCAContents cc = getCollator(CollatorType.ducet).getContents(Default.nfd());
+        final UCA.UCAContents cc = UCA.getDucetCollator().getContents(Default.nfd());
 
         final Set<String> sortedCodes = new TreeSet<String>();
         final Set<String> mixedCEs = new TreeSet<String>();
@@ -420,7 +414,7 @@ public class WriteCollationData {
                 if (haveMixture == 3) {
                     continue;
                 }
-                if (getCollator(CollatorType.ducet).isVariable(ce)) {
+                if (UCA.getDucetCollator().isVariable(ce)) {
                     haveMixture |= 1;
                 } else {
                     haveMixture |= 2;
@@ -505,13 +499,10 @@ public class WriteCollationData {
         diLog.println("# All characters with 'mixed' CEs: variable and non-variable");
         diLog.println(
                 "# Note: variables are in "
-                        + Utility.hex(
-                                CEList.getPrimary(
-                                        getCollator(CollatorType.ducet).getVariableLowCE()))
+                        + Utility.hex(CEList.getPrimary(UCA.getDucetCollator().getVariableLowCE()))
                         + " to "
                         + Utility.hex(
-                                CEList.getPrimary(
-                                        getCollator(CollatorType.ducet).getVariableHighCE())));
+                                CEList.getPrimary(UCA.getDucetCollator().getVariableHighCE())));
         diLog.println();
 
         Iterator<String> it;
@@ -544,7 +535,7 @@ public class WriteCollationData {
     private static void showSampleOverlap(
             PrintWriter diLog, boolean doNew, String head, String src) {
         final int[] ces = new int[30];
-        final int len = getCollator(CollatorType.ducet).getCEs(src, true, ces);
+        final int len = UCA.getDucetCollator().getCEs(src, true, ces);
         int[] newCes = null;
         int newLen = 0;
         if (doNew) {
@@ -593,7 +584,7 @@ public class WriteCollationData {
             expansionStart = 2; // move up if first is double-ce
         }
         if (len > expansionStart
-                && getCollator(CollatorType.ducet)
+                && UCA.getDucetCollator()
                         .getHomelessSecondaries()
                         .contains(CEList.getSecondary(ces.at(expansionStart)))) {
             if (log2 != null) {
@@ -613,7 +604,7 @@ public class WriteCollationData {
         final Map<ArrayWrapper, String> backMap = new HashMap<ArrayWrapper, String>();
         final Map<String, String> ordered = new TreeMap<String, String>();
 
-        final UCA uca = getCollator(collatorType);
+        final UCA uca = UCA.getCollator(collatorType);
         final UCA.UCAContents cc =
                 uca.getContents(SKIP_CANONICAL_DECOMPOSIBLES ? Default.nfd() : null);
 
@@ -1247,6 +1238,7 @@ public class WriteCollationData {
             Map<String, String> ordered,
             CollatorType collatorType,
             Set<String> removals) {
+        final UCA collator = UCA.getCollator(collatorType);
         final Map<String, String> equivalentsStrings = new LinkedHashMap<String, String>();
         final IntStack nextCes = new IntStack(10);
         final int[] startBuffer = new int[100];
@@ -1262,7 +1254,7 @@ public class WriteCollationData {
                 continue;
             }
             nextCes.clear();
-            getCollator(collatorType).getCEs(string, true, nextCes);
+            collator.getCEs(string, true, nextCes);
             final int len = nextCes.length();
             if (len < 2) {
                 continue;
@@ -1545,7 +1537,7 @@ public class WriteCollationData {
             int len,
             String chr,
             int[] rel) {
-        final UCA ducet = getCollator(CollatorType.ducet);
+        final UCA ducet = UCA.getDucetCollator();
         final int[] ces = new int[originalces.length()];
         originalces.appendTo(ces, 0);
 
@@ -1851,132 +1843,6 @@ public class WriteCollationData {
             }
         }
         return result.toString();
-    }
-
-    public static UCA getCollator(CollatorType type) {
-        switch (type) {
-            case cldr:
-                if (cldrCollator == null) {
-                    cldrCollator = buildCldrCollator();
-                }
-                return cldrCollator;
-            case ducet:
-                if (ducetCollator == null) {
-                    ducetCollator = UCA.buildDucetCollator();
-                }
-                return ducetCollator;
-            default:
-                throw new IllegalArgumentException();
-        }
-    }
-
-    private static UCA buildCldrCollator() {
-        final UCA ducet = getCollator(CollatorType.ducet);
-
-        final int ducetVariableHigh = CEList.getPrimary(ducet.getVariableHighCE());
-        int cldrVariableHigh = 0;
-        // This will normally come out as ducetVariableHigh + 1.
-        int firstDucetNonVariable = -1;
-
-        // DUCET: variable primary weights include spaces, punctuation, and symbols
-        // CLDR: variable primary weights include only spaces and punctuation
-        for (final UCA.Primary up : ducet.getRegularPrimaries()) {
-            final int ducetPrimary = up.primary;
-            if (firstDucetNonVariable < 0 && ducetPrimary > ducetVariableHigh) {
-                firstDucetNonVariable = ducetPrimary;
-            }
-
-            final String repChar = up.getRepresentative();
-            final int firstChar = Character.codePointAt(repChar, 0);
-            final int cat = Default.ucd().getCategory(firstChar);
-            switch (cat) {
-                case UCD_Types.DASH_PUNCTUATION:
-                case UCD_Types.START_PUNCTUATION:
-                case UCD_Types.END_PUNCTUATION:
-                case UCD_Types.CONNECTOR_PUNCTUATION:
-                case UCD_Types.OTHER_PUNCTUATION:
-                case UCD_Types.INITIAL_PUNCTUATION:
-                case UCD_Types.FINAL_PUNCTUATION:
-                    if (ducetPrimary <= ducetVariableHigh && ducetPrimary > cldrVariableHigh) {
-                        cldrVariableHigh = ducetPrimary;
-                    }
-                    break;
-                default:
-                    break;
-            }
-        }
-        final UCA result = UCA.buildCollator(cldrVariableHigh, firstDucetNonVariable);
-
-        result.overrideCE("\uFFFE", 0x1, 0x20, 2);
-        result.overrideCE("\uFFFF", 0xFFFE, 0x20, 2);
-
-        if (ADD_TIBETAN) {
-            final CEList fb2 = result.getCEList("\u0FB2", true);
-            final CEList fb3 = result.getCEList("\u0FB3", true);
-            final CEList f71_f72 = result.getCEList("\u0F71\u0F72", true);
-            final CEList f71_f74 = result.getCEList("\u0F71\u0F74", true);
-            final CEList fb2_f71 = result.getCEList("\u0FB2\u0F71", true);
-            final CEList fb3_f71 = result.getCEList("\u0FB3\u0F71", true);
-
-            addOverride(
-                    result,
-                    "\u0FB2\u0F71",
-                    fb2_f71); // 0FB2 0F71      ;     [.255A.0020.0002.0FB2][.2570.0020.0002.0F71] -
-            // concat 0FB2 + 0F71
-            addOverride(
-                    result,
-                    "\u0FB2\u0F71\u0F72",
-                    fb2,
-                    f71_f72); // 0FB2 0F71 0F72 ;    [.255A.0020.0002.0FB2][.2572.0020.0002.0F73] -
-            // concat 0FB2 + (0F71/0F72)
-            addOverride(result, "\u0FB2\u0F73", fb2, f71_f72); // 0FB2 0F73      ;
-            // [.255A.0020.0002.0FB2][.2572.0020.0002.0F73] = prev
-            addOverride(
-                    result,
-                    "\u0FB2\u0F71\u0F74",
-                    fb2,
-                    f71_f74); // 0FB2 0F71 0F74 ;    [.255A.0020.0002.0FB2][.2576.0020.0002.0F75] -
-            // concat 0FB2 + (0F71/0F74)
-            addOverride(result, "\u0FB2\u0F75", fb2, f71_f74); // 0FB2 0F75      ;
-            // [.255A.0020.0002.0FB2][.2576.0020.0002.0F75]  = prev
-
-            // same as above, but 0FB2 => 0FB3 and fb2 => fb3
-
-            addOverride(
-                    result,
-                    "\u0FB3\u0F71",
-                    fb3_f71); // 0FB3 0F71      ;     [.255A.0020.0002.0FB3][.2570.0020.0002.0F71] -
-            // concat 0FB3 + 0F71
-            addOverride(
-                    result,
-                    "\u0FB3\u0F71\u0F72",
-                    fb3,
-                    f71_f72); // 0FB3 0F71 0F72 ;    [.255A.0020.0002.0FB3][.2572.0020.0002.0F73] -
-            // concat 0FB3 + (0F71/0F72)
-            addOverride(result, "\u0FB3\u0F73", fb3, f71_f72); // 0FB3 0F73      ;
-            // [.255A.0020.0002.0FB3][.2572.0020.0002.0F73] = prev
-            addOverride(
-                    result,
-                    "\u0FB3\u0F71\u0F74",
-                    fb3,
-                    f71_f74); // 0FB3 0F71 0F74 ;    [.255A.0020.0002.0FB3][.2576.0020.0002.0F75] -
-            // concat 0FB3 + (0F71/0F74)
-            addOverride(result, "\u0FB3\u0F75", fb3, f71_f74); // 0FB3 0F75      ;
-            // [.255A.0020.0002.0FB3][.2576.0020.0002.0F75]  = prev
-        }
-
-        return result;
-    }
-
-    private static void addOverride(UCA result, String string, CEList... ceLists) {
-        final IntStack tempStack = new IntStack(10);
-        for (final CEList ceList : ceLists) {
-            for (int i = 0; i < ceList.length(); ++i) {
-                final int ce = ceList.at(i);
-                tempStack.append(ce);
-            }
-        }
-        result.overrideCE(string, tempStack);
     }
 
     private static CharSequence filter(CharSequence repChar) {

--- a/unicodetools/src/main/java/org/unicode/text/UCA/WriteConformanceTest.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/WriteConformanceTest.java
@@ -47,7 +47,7 @@ public class WriteConformanceTest {
             String filename, byte option, boolean shortPrint, CollatorType collatorType)
             throws IOException {
         ucd = Default.ucd();
-        collator = WriteCollationData.getCollator(collatorType);
+        collator = UCA.getCollator(collatorType);
         nfd = Default.nfd();
 
         /*

--- a/unicodetools/src/main/java/org/unicode/tools/CollatorEquivalencesNew.java
+++ b/unicodetools/src/main/java/org/unicode/tools/CollatorEquivalencesNew.java
@@ -3,9 +3,6 @@ package org.unicode.tools;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.impl.Utility;
-// import com.ibm.icu.text.CollationElementIterator;
-// import com.ibm.icu.text.Collator;
-// import com.ibm.icu.text.RuleBasedCollator;
 import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UTF16.StringComparator;
 import com.ibm.icu.text.UnicodeSet;
@@ -67,10 +64,13 @@ public class CollatorEquivalencesNew {
         // System.out.println(remapped.toPattern(false));
     }
 
-    private static final org.unicode.text.UCA.UCA uca_raw =
-            org.unicode.text.UCA.UCA.buildDucetCollator();
-    private static final org.unicode.text.UCA.UCA uca_level2Only =
-            org.unicode.text.UCA.UCA.buildDucetCollator();
+    private static final org.unicode.text.UCA.UCA uca_raw = UCA.getDucetCollator();
+
+    /**
+     * This collator is modified (set to secondary strength), so do not use UCA.getDucetCollator()
+     * which wants to be a singleton.
+     */
+    private static final org.unicode.text.UCA.UCA uca_level2Only = UCA.buildDucetCollator();
 
     static {
         uca_level2Only.setStrength(2);

--- a/unicodetools/src/main/java/org/unicode/tools/GenerateNormalizeForMatch.java
+++ b/unicodetools/src/main/java/org/unicode/tools/GenerateNormalizeForMatch.java
@@ -10,7 +10,6 @@ import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.lang.CharSequences;
 import com.ibm.icu.text.UTF16;
-import com.ibm.icu.text.UTF16.StringComparator;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSet.EntryRange;
 import java.io.IOException;
@@ -51,16 +50,6 @@ public class GenerateNormalizeForMatch {
             Settings.CLDR.BASE_DIRECTORY + "Google Drive/workspace/DATA/frequency/";
     private static final String GOOGLE_FOLDING_TXT = "google_folding.txt";
     private static final Pattern SPACES = Pattern.compile("[,\\s]+");
-
-    private static final Comparator<String> CODEPOINT =
-            new StringComparator(true, false, StringComparator.FOLD_CASE_DEFAULT);
-    private static final Comparator<String> UCA;
-
-    static {
-        org.unicode.text.UCA.UCA uca_raw = org.unicode.text.UCA.UCA.buildDucetCollator();
-        //        uca_raw.setDecomposition(Collator.CANONICAL_DECOMPOSITION);
-        UCA = new MultiComparator<String>((Comparator<String>) (Comparator<?>) uca_raw, CODEPOINT);
-    }
 
     private static final UnicodeMap<String> COLLATION_MAP = CollatorEquivalences.COLLATION_MAP;
 

--- a/unicodetools/src/main/java/org/unicode/unused/GenerateUcaDecompositions.java
+++ b/unicodetools/src/main/java/org/unicode/unused/GenerateUcaDecompositions.java
@@ -21,7 +21,7 @@ import org.unicode.text.utility.Utility;
 
 public class GenerateUcaDecompositions {
     private static final int LEAST_FAKE_SECONDARY = 0x139;
-    static final UCA uca = UCA.buildDucetCollator();
+    static final UCA uca = UCA.getDucetCollator();
     static Normalizer2 nfkcCf = Normalizer2.getNFKCCasefoldInstance();
     static Normalizer2 nfd = Normalizer2.getNFDInstance();
     static Normalizer2 nfkd = Normalizer2.getNFKDInstance();


### PR DESCRIPTION
remove cldrWithoutFFFx collator option
- replace with cldr option, always add mappings for U+FFFE and U+FFFF
- skip special primary weights inside getRegularPrimaries() rather than in each call site
- fixes https://github.com/unicode-org/unicodetools/issues/794

move getCollator(type) from WriteCollationData to UCA
- and add simpler getters for where the type was hardcoded
- avoids implementation back-and-forth
- fixes https://github.com/unicode-org/unicodetools/issues/793

- [ ] Approver: Feel free to merge on my behalf
    - [ ] rebase & merge one or more commits
    - [ ] squash & merge multiple commits into one