### PR TITLE
Java 21

### DIFF
--- a/.github/workflows/build-jsp.yml
+++ b/.github/workflows/build-jsp.yml
@@ -45,10 +45,10 @@ jobs:
     - name: Backup Unicodetools and CLDR for jsps  # this is needed only for the Docker build
       run:
         mkdir -p UnicodeJsps/target && tar -cpz --exclude=.git -f UnicodeJsps/target/cldr-unicodetools.tgz ./cldr ./unicodetools
-    - name: Set up JDK 11
+    - name: Set up JDK 21
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 21
     - name: Cache local Maven repository
       uses: actions/cache@v4
       with:

--- a/.github/workflows/cache_retain.yml
+++ b/.github/workflows/cache_retain.yml
@@ -37,10 +37,10 @@ jobs:
     steps:
       - name: Checkout and setup
         uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 21
       - name: Cache local Maven repository
         uses: actions/cache@v4
         with:

--- a/.github/workflows/cli-build-instructions.yml
+++ b/.github/workflows/cli-build-instructions.yml
@@ -70,10 +70,10 @@ jobs:
       - name: Symlink CLDR working copy to be sibling of Unicode Tools
         run: |
           ln -s $(pwd)/cldr ..
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 21
       - name: Cache local Maven repository
         uses: actions/cache@v4
         with:
@@ -339,10 +339,10 @@ jobs:
           fetch-depth: 0
       - name: Switch CLDR to CLDR_REF
         run: cd cldr/mine/src && git fetch && git checkout ${{ steps.cldr_ref.outputs.CLDR_REF }}
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 21
       - name: Cache local Maven repository
         uses: actions/cache@v4
         with:
@@ -417,10 +417,10 @@ jobs:
           fetch-depth: 0
       - name: Switch CLDR to CLDR_REF
         run: cd cldr/mine/src && git fetch && git checkout ${{ steps.cldr_ref.outputs.CLDR_REF }}
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 21
       - name: Cache local Maven repository
         uses: actions/cache@v4
         with:

--- a/.github/workflows/push-jsp-on-tag.yml
+++ b/.github/workflows/push-jsp-on-tag.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 21
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 21
     - name: Get the CLDR_REF from pom.xml
       id: cldr_ref
       run: echo "CLDR_REF="$(mvn help:evaluate -Dexpression=cldr.version -q -DforceStdout | cut -d- -f3) >> $GITHUB_OUTPUT && cat ${GITHUB_OUTPUT}

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
 
 
         <!-- these two set the JDK version for source and target -->
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
 
         <!-- Good hygiene. This is Unicode after all! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
With the spotless update, it is impossible to run spotless unless you have JDK 21 (well, I don’t know about 20, but at least JDK 19 does not work, I had to update yesterday). See [comments on the tools meeting minutes](https://docs.google.com/document/d/1hnkTMB62_PynKZ_D-GMBSnYDyf2Xbz0n0NC0RGdPKt4/edit?disco=AAAB4yQVxuM).

In practice, this means all contributors need to have JDK 21 or later, and since this is not a library we ship, no-one uses this but our contributors, so there is no sense in keeping the version at 11.

See [comments on the tools meeting minutes](https://docs.google.com/document/d/1hnkTMB62_PynKZ_D-GMBSnYDyf2Xbz0n0NC0RGdPKt4/edit?disco=AAAB4yQVxuM).

- [ ] Approver: Feel free to merge on my behalf
    - [ ] rebase & merge one or more commits
    - [ ] squash & merge multiple commits into one