### PR TITLE
surefire forkCount: parallel testing

### DIFF
--- a/.github/workflows/build-jsp.yml
+++ b/.github/workflows/build-jsp.yml
@@ -12,7 +12,8 @@ on:
     tags:
     - '*'
 jobs:
-  build:
+  build-jsp:
+    name: Build JSPs
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/cli-build-instructions.yml
+++ b/.github/workflows/cli-build-instructions.yml
@@ -192,10 +192,10 @@ jobs:
 
       # Only test once we know the UCD is internally consistent.
       # MakeUnicodeFiles is much faster than this anyway.
-      - name: Test invariants
+      - name: Run most tests
         run: |
           cd unicodetools/mine/src
-          MAVEN_OPTS="-ea" mvn -s .github/workflows/mvn-settings.xml package -Dtest=!TestTestUnicodeInvariants#testSecurityInvariants -DCLDR_DIR=$(cd ../../../cldr/mine/src ; pwd)  -DUNICODETOOLS_GEN_DIR=$(cd ../Generated ; pwd)  -DUNICODETOOLS_REPO_DIR=$(pwd)  -DEMIT_GITHUB_ERRORS  -DENABLE_PROP_FILE_CACHE
+          MAVEN_OPTS="-ea" mvn -s .github/workflows/mvn-settings.xml test -Dtest=!TestTestUnicodeInvariants#testSecurityInvariants -DCLDR_DIR=$(cd ../../../cldr/mine/src ; pwd)  -DUNICODETOOLS_GEN_DIR=$(cd ../Generated ; pwd)  -DUNICODETOOLS_REPO_DIR=$(pwd)  -DEMIT_GITHUB_ERRORS  -DENABLE_PROP_FILE_CACHE
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,9 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin-version}</version>
                     <configuration>
+                        <!-- Multiple JVM processes in parallel. -->
+                        <forkCount>4</forkCount>
+                        <!-- https://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html -->
                         <systemPropertyVariables>
                             <!-- These are variables which are picked up by test runs -->
                             <CLDR_ENVIRONMENT>UNITTEST</CLDR_ENVIRONMENT>

--- a/unicodetools/src/main/resources/org/unicode/props/ExtraPropertyValueAliases.txt
+++ b/unicodetools/src/main/resources/org/unicode/props/ExtraPropertyValueAliases.txt
@@ -89,6 +89,7 @@
 # @missing: 0000..10FFFF; kEH_NoMirror  ;  No
 # @missing: 0000..10FFFF; kEH_NoRotate  ;  No
 
+# @missing: 0000..10FFFF; Link_Bracket; <none>
 # @missing: 0000..10FFFF; Link_Email ; No
 
 # End of binary properties.


### PR DESCRIPTION
Trying to make tests run a bit faster by using the maven-surefire-plugin `forkCount` option to use multiple JVM processes in parallel. As before, subsequent test classes share JVMs.
- https://github.com/unicode-org/unicodetools/issues/1365
- https://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html#forked-test-execution
- CI runtime of running most tests in the out-of-source build goes down from about 8min to about 5min

Note: "println()" output from parallel unit tests gets intermingled, making the test log harder to read. When that's a problem, run just the failing unit test, or temporarily go back to forkCount=1.

One unit test failed here:
```
Error:  org.unicode.propstest.TestProperties.TestDefaults -- Time elapsed: 0.189 s <<< FAILURE!
org.opentest4j.AssertionFailedError: Null Link_Bracket for U+FFFF but property is String with default value type LITERAL. Add an @missing line to ExtraPropertyValueAliases.txt if needed. ==> expected: not <null>
```

It also failed locally for me when just running that one unit test alone. Apparently when it runs after _something else_ it passes.

I fixed it by adding an `@missing` value for Link_Bracket as the error message suggests.
- I did not try to add (generate) the `@missing` line in the data file itself.
- I did not try to figure out why this unit test failed when run alone, or which other previously-run unit test makes it pass.
- @eggrobin @macchiati FYI