### PR TITLE
mvn test serially again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,9 @@
                     <version>${maven-surefire-plugin-version}</version>
                     <configuration>
                         <!-- Multiple JVM processes in parallel. -->
-                        <forkCount>4</forkCount>
+                        <!-- Turned off: Currently makes tests flaky :-(
+                             https://github.com/unicode-org/unicodetools/pull/1368#issuecomment-4371865240 -->
+                        <forkCount>1</forkCount>
                         <!-- https://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html -->
                         <systemPropertyVariables>
                             <!-- These are variables which are picked up by test runs -->


### PR DESCRIPTION
Running tests in parallel currently makes tests flaky :-(
- https://github.com/unicode-org/unicodetools/pull/1368#issuecomment-4371865240
- https://github.com/unicode-org/unicodetools/issues/1365

Probably races among different tests reading/building/writing data files?

- [x] Approver: Feel free to merge on my behalf
    - [x] rebase & merge one or more commits