### PR TITLE
Regices for kJapaneseMeowVariant and the U-Source pseudoproperties

### DIFF
--- a/unicodetools/src/main/java/org/unicode/props/UcdProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UcdProperty.java
@@ -112,7 +112,11 @@ public enum UcdProperty {
     kJapaneseNewVariant(
             PropertyType.String, DerivedPropertyStatus.Provisional, "cjkJapaneseNewVariant"),
     kJapaneseOldVariant(
-            PropertyType.String, DerivedPropertyStatus.Provisional, "cjkJapaneseOldVariant"),
+            PropertyType.String,
+            DerivedPropertyStatus.Provisional,
+            null,
+            ValueCardinality.Unordered,
+            "cjkJapaneseOldVariant"),
     kSEAL_MCJK(PropertyType.String, DerivedPropertyStatus.Provisional, "kSEAL_MCJK"),
     kSimplifiedVariant(
             PropertyType.String,
@@ -246,30 +250,56 @@ public enum UcdProperty {
     cjkUSource_Comments(
             PropertyType.Miscellaneous,
             DerivedPropertyStatus.UCDNonProperty,
+            null,
+            ValueCardinality.Ordered,
             "cjkUSource_Comments"),
     cjkUSource_FirstResidualStroke(
             PropertyType.Miscellaneous,
             DerivedPropertyStatus.UCDNonProperty,
+            null,
+            ValueCardinality.Ordered,
             "cjkUSource_FirstResidualStroke"),
     cjkUSource_IDS(
-            PropertyType.Miscellaneous, DerivedPropertyStatus.UCDNonProperty, "cjkUSource_IDS"),
+            PropertyType.Miscellaneous,
+            DerivedPropertyStatus.UCDNonProperty,
+            null,
+            ValueCardinality.Ordered,
+            "cjkUSource_IDS"),
     cjkUSource_Identifier(
             PropertyType.Miscellaneous,
             DerivedPropertyStatus.UCDNonProperty,
+            null,
+            ValueCardinality.Ordered,
             "cjkUSource_Identifier"),
     cjkUSource_KangXi(
-            PropertyType.Miscellaneous, DerivedPropertyStatus.UCDNonProperty, "cjkUSource_KangXi"),
+            PropertyType.Miscellaneous,
+            DerivedPropertyStatus.UCDNonProperty,
+            null,
+            ValueCardinality.Ordered,
+            "cjkUSource_KangXi"),
     cjkUSource_RSUnicode(
             PropertyType.Miscellaneous,
             DerivedPropertyStatus.UCDNonProperty,
+            null,
+            ValueCardinality.Ordered,
             "cjkUSource_RSUnicode"),
     cjkUSource_Source(
-            PropertyType.Miscellaneous, DerivedPropertyStatus.UCDNonProperty, "cjkUSource_Source"),
+            PropertyType.Miscellaneous,
+            DerivedPropertyStatus.UCDNonProperty,
+            null,
+            ValueCardinality.Ordered,
+            "cjkUSource_Source"),
     cjkUSource_Status(
-            PropertyType.Miscellaneous, DerivedPropertyStatus.UCDNonProperty, "cjkUSource_Status"),
+            PropertyType.Miscellaneous,
+            DerivedPropertyStatus.UCDNonProperty,
+            null,
+            ValueCardinality.Ordered,
+            "cjkUSource_Status"),
     cjkUSource_TotalStrokes(
             PropertyType.Miscellaneous,
             DerivedPropertyStatus.UCDNonProperty,
+            null,
+            ValueCardinality.Ordered,
             "cjkUSource_TotalStrokes"),
     emoji_variation_sequence(
             PropertyType.Miscellaneous,

--- a/unicodetools/src/main/resources/org/unicode/props/IndexPropertyRegex.txt
+++ b/unicodetools/src/main/resources/org/unicode/props/IndexPropertyRegex.txt
@@ -171,6 +171,8 @@ kIRG_USource ;                SINGLE_VALUED ;                UTC-\d{5}
 kIRG_VSource ;                SINGLE_VALUED ;                V[0-4]-[0-9A-F]{4}|VN-[023F][0-9A-F]{4}
 kJapanese ;                   MULTI_VALUED ;                 [\x{3041}-\x{3096}\x{3099}\x{309A}\x{30A1}-\x{30FA}\x{30FC}]+
 kJapaneseKun ;                MULTI_VALUED ;                 [A-Z]+
+kJapaneseNewVariant ;         SINGLE_VALUED ;                U\+[23]?[0-9A-F]{4}
+kJapaneseOldVariant ;         MULTI_VALUED ;                 U\+[23]?[0-9A-F]{4}
 kJapaneseOn ;                 MULTI_VALUED ;                 [A-Z]+
 kJinmeiyoKanji ;              SINGLE_VALUED ;                (20\d{2})(:U\+[23]?[0-9A-F]{4})?
 kJis0 ;                       SINGLE_VALUED ;                \d{4}
@@ -262,3 +264,23 @@ kSEAL_MCJK ;                  SINGLE_VALUED ;                [0-9A-F]{4,5}
 kSEAL_QJZSrc ;                SINGLE_VALUED ;                K-\d{5}
 kSEAL_Rad ;                   MULTI_VALUED ;                 \d{1,3}\.[A-F0-9]{4,5}
 kSEAL_THXSrc ;                SINGLE_VALUED ;                TH-(\d{5}|X\d{3}|Y\d{3})
+
+# Regex patterns from UAX #45 (U-Source Ideographs)
+# Ordered because these pseudoproperties are mappings from field 2 to the other fields, so they
+# should all have the same cardinality, and the nth value of any of them corresponds to the nth
+# value of the others.
+cjkUSource_Identifier          ; ORDERED ; (UTC|UCI|UK)-\d{5}
+cjkUSource_Status              ; ORDERED ; Comp|Ext[A-J]|FutureWS|NoAction|Rejected|URO|Variant|WS-2024|(UTC|UCI|UK)-\d{5}
+# Same as kRSUnicode above.
+cjkUSource_RSUnicode           ; ORDERED ; [1-9]\d{0,2}\'{0,3}\.-?\d{1,2}
+# Always empty.
+cjkUSource_KangXi              ; ORDERED ;
+# TODO(egg): Parse the IDSes, some of these are ill-formed.
+cjkUSource_IDS                 ; ORDERED ; .*
+# TODO(egg): Turn https://www.unicode.org/reports/tr45/#Section22 into a regex.
+cjkUSource_Source              ; ORDERED ; .*
+cjkUSource_Comments            ; ORDERED ; .*
+# Same as kTotalStrokes above.
+cjkUSource_TotalStrokes        ; ORDERED ; [1-9]\d{0,2}
+# 53, 7, and q are anomalous.
+cjkUSource_FirstResidualStroke ; ORDERED ; [0-5]|53|7|q


### PR DESCRIPTION
Previously in #1376:
> _@markusicu_. @eggrobin Why would I get a [new test failure](https://github.com/unicode-org/unicodetools/actions/runs/25394130646/job/74476196367?pr=1376) _when all I do is turn off parallel testing_?
> _@eggrobin_. I was wondering why that one had not failed on me in https://github.com/unicode-org/unicodetools/pull/1370 (new properties now require entries in IndexPropertyRegex).
> Apparently the answer is that the parallel testing was hiding real failures.
> _@markusicu_. So... can I merge this one, and then you fix these issues?
> _@eggrobin_. Yes. But dinner will happen in between.

One beef Wellington later, here is the fix.