### PR TITLE
modernize call sites of ICU class UTF16

### DIFF
--- a/UnicodeJsps/src/main/java/org/unicode/jsp/BranchStringPrepData.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/BranchStringPrepData.java
@@ -354,14 +354,14 @@ public class BranchStringPrepData {
     //
     //    for (int i = 'A'; i <= 'Z'; ++i) {
     //      R3<StringPrepData.Idna2003Table, String, String> alphaMap = Row.of(Idna2003Table.B_1,
-    // UTF16.valueOf(i-'A'+'a'), (String)null);
+    // Character.toString(i-'A'+'a'), (String)null);
     //      DataSet tableSet = data.get(i);
     //      if (tableSet == null) {
     //        tableSet = new DataSet(PROHIBITED.contains(Idna2003Table.B_1),
-    // UTF16.valueOf(i-'A'+'a'), (String)null);
+    // Character.toString(i-'A'+'a'), (String)null);
     //      } else {
     //        tableSet = tableSet.add(PROHIBITED.contains(Idna2003Table.B_1),
-    // UTF16.valueOf(i-'A'+'a'), (String)null);
+    // Character.toString(i-'A'+'a'), (String)null);
     //      }
     //      data.put(i, tableSet);
     //    }

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/Common.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/Common.java
@@ -123,7 +123,7 @@ public class Common {
     //            // IdnaType idnaType = Idna2003.getIDNA2003Type(cp);
     //            // idnaTypeSet.get(idnaType).add(cp);
     //
-    //            String s = UTF16.valueOf(cp);
+    //            String s = Character.toString(cp);
     //            if (UCharacter.foldCase(s, true).equals(s)) {
     //                Common.isCaseFolded.add(cp);
     //            }

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/Confusables.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/Confusables.java
@@ -4,7 +4,6 @@ import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.text.Normalizer;
 import com.ibm.icu.text.Normalizer.Mode;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -75,7 +74,7 @@ public class Confusables implements Iterable<String> {
             if (!type.equals("MA")) return true;
             String result = Utility.fromHex(items[1], 4, " ");
             for (int i = start; i <= end; ++i) {
-                equivalents.add(UTF16.valueOf(i), result);
+                equivalents.add(Character.toString(i), result);
             }
             return true;
         }
@@ -112,7 +111,7 @@ public class Confusables implements Iterable<String> {
         int cp;
         for (int i = 0; i < source.length(); i += Character.charCount(cp)) {
             cp = source.codePointAt(i);
-            String cps = UTF16.valueOf(cp);
+            String cps = Character.toString(cp);
             Set<String> confusables = equivalents.getEquivalences(cps);
             Set<String> items = new HashSet<String>();
             for (String confusable : confusables) {

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/ScriptTester2.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/ScriptTester2.java
@@ -231,7 +231,7 @@ public class ScriptTester2 {
             }
         }
         for (Entry<String, Integer> entry : multipleToSingleConfusable.entrySet()) {
-            // System.out.println(entry.getKey() + "\t" + UTF16.valueOf(entry.getValue()));
+            // System.out.println(entry.getKey() + "\t" + Character.toString(entry.getValue()));
             // check for overlaps
             String source = entry.getKey();
             String partial = source;

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeJsp.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeJsp.java
@@ -6,7 +6,6 @@ import com.ibm.icu.text.Normalizer;
 import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.text.RuleBasedBreakIterator;
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ULocale;
 import com.ibm.icu.util.VersionInfo;
@@ -105,7 +104,8 @@ public class UnicodeJsp {
         while (decimalEscapes.find(start)) {
             int radix = 10;
             int code = Integer.parseInt(decimalEscapes.group(2), radix);
-            result2.append(text.substring(start, decimalEscapes.start()) + UTF16.valueOf(code));
+            result2.append(
+                    text.substring(start, decimalEscapes.start()) + Character.toString(code));
             start = decimalEscapes.end();
         }
         result2.append(text.substring(start));
@@ -262,7 +262,7 @@ public class UnicodeJsp {
         String digits = matcher.matches() ? matcher.group(1).replaceAll("['_]", "") : null;
         if (digits != null && digits.length() > 1) {
             try {
-                text = UTF16.valueOf(Integer.parseInt(digits, 16));
+                text = Character.toString(Integer.parseInt(digits, 16));
             } catch (Exception e) {
             }
         }

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
@@ -1245,7 +1245,7 @@ public class UnicodeUtilities {
         int charCount = 0;
         Status status = Status.NORMAL;
         for (int i = 0; i < a_out.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(a_out, i);
+            cp = a_out.codePointAt(i);
             ++charCount;
             switch (status) {
                 case AFTERSLASH:

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
@@ -1291,7 +1291,7 @@ public class UnicodeUtilities {
                     }
                     break;
             }
-            UTF16.append(out, cp);
+            out.appendCodePoint(cp);
             oldCp = cp;
         }
         return out.toString();

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
@@ -188,7 +188,7 @@ public class UnicodeUtilities {
         String s = Common.MyNormalize(codepoint, compat);
         int cp;
         String lastPart = null;
-        for (int i = 0; i < s.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(s, i);
             String part = Common.getXStringPropertyValue(propertyEnum, cp, nameChoice);
             if (lastPart == null) {
@@ -860,7 +860,7 @@ public class UnicodeUtilities {
             boolean plainText) {
         StringBuilder result = new StringBuilder();
         int cp;
-        for (int i = 0; i < string.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < string.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(string, i);
             if (i != 0) {
                 result.append(separator);
@@ -917,7 +917,7 @@ public class UnicodeUtilities {
             String string, String separator, boolean ucdFormat, List<String> additionalParameters) {
         StringBuilder result = new StringBuilder();
         int cp;
-        for (int i = 0; i < string.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < string.length(); i += Character.charCount(cp)) {
             if (i != 0) {
                 result.append(separator);
             }
@@ -929,7 +929,7 @@ public class UnicodeUtilities {
     //  private static void showString(String s, String separator, boolean ucdFormat, Writer out)
     // throws IOException {
     //    int cp;
-    //    for (int i = 0; i < s.length(); i += UTF16.getCharCount(cp)) {
+    //    for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
     //      if (i != 0) {
     //        out.write(separator);
     //      }
@@ -1244,7 +1244,7 @@ public class UnicodeUtilities {
         StringBuffer out = new StringBuffer();
         int charCount = 0;
         Status status = Status.NORMAL;
-        for (int i = 0; i < a_out.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < a_out.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(a_out, i);
             ++charCount;
             switch (status) {

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
@@ -13,7 +13,6 @@ import com.ibm.icu.text.SpoofChecker;
 import com.ibm.icu.text.StringTransform;
 import com.ibm.icu.text.Transform;
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import com.ibm.icu.util.ULocale;
@@ -607,7 +606,7 @@ public class UnicodeUtilities {
     private static UnicodeSet RTL = new UnicodeSet("[[:bc=R:][:bc=AL:]]");
 
     private static String showCodePoint(int codepoint) {
-        return showCodePoint(UTF16.valueOf(codepoint));
+        return showCodePoint(Character.toString(codepoint));
     }
 
     private static String showCodePoint(String s) {
@@ -620,7 +619,7 @@ public class UnicodeUtilities {
     }
 
     private static String getLiteral(int codepoint) {
-        return getLiteral(UTF16.valueOf(codepoint));
+        return getLiteral(Character.toString(codepoint));
     }
 
     private static String getLiteral(String s) {
@@ -668,7 +667,7 @@ public class UnicodeUtilities {
         }
 
         void showCodePoint(int codePoint, Appendable out) throws IOException {
-            final String string = UTF16.valueOf(codePoint);
+            final String string = Character.toString(codePoint);
             String separator = ", ";
             showString(string, separator, out);
         }
@@ -1157,7 +1156,7 @@ public class UnicodeUtilities {
     //    StringBuilder rules = new StringBuilder();
     //    for (UnicodeSetIterator it = new UnicodeSetIterator(MAPPING_SET); it.nextRange();) {
     //      for (int i = it.codepoint; i <= it.codepointEnd; ++i) {
-    //        String s = UTF16.valueOf(i);
+    //        String s = Character.toString(i);
     //        String caseFold = UCharacter.foldCase(s, true);
     //        String lower = UCharacter.toLowerCase(Locale.ENGLISH, s);
     //        if (!caseFold.equals(lower) || i == 'Σ') {
@@ -1412,7 +1411,7 @@ public class UnicodeUtilities {
             List<String> originalParameters,
             Appendable out)
             throws IOException {
-        String text = UTF16.valueOf(cp);
+        String text = Character.toString(cp);
 
         String name = getFactory().getProperty("Name").getValue(cp);
         final String devName =
@@ -1651,7 +1650,7 @@ public class UnicodeUtilities {
     private static StringBuilder displayConfusables(int codepoint) {
         StringBuilder confusableString = new StringBuilder();
         Set<String> skip = new HashSet<String>();
-        String same = UTF16.valueOf(codepoint);
+        String same = Character.toString(codepoint);
         String nfd = Normalizer.normalize(same, Normalizer.NFD);
 
         skip.add(same);
@@ -1689,7 +1688,8 @@ public class UnicodeUtilities {
                 }
                 cp = nfd.codePointAt(i);
                 Confusables currentCombos =
-                        new Confusables(UTF16.valueOf(cp)).setNormalizationCheck(Normalizer.NFKC);
+                        new Confusables(Character.toString(cp))
+                                .setNormalizationCheck(Normalizer.NFKC);
                 combos.add(currentCombos);
                 confusableString.append("<div class='char'>");
                 for (String s : currentCombos) {
@@ -1762,7 +1762,7 @@ public class UnicodeUtilities {
                                     + Utility.hex(cp)
                                     + "'>"
                                     + "&nbsp;")
-                    .append(toHTML(UTF16.valueOf(cp)))
+                    .append(toHTML(Character.toString(cp)))
                     .append("&nbsp;</a>");
         }
         confusableString.append("</div>");

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeUtilities.java
@@ -189,7 +189,7 @@ public class UnicodeUtilities {
         int cp;
         String lastPart = null;
         for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(s, i);
+            cp = s.codePointAt(i);
             String part = Common.getXStringPropertyValue(propertyEnum, cp, nameChoice);
             if (lastPart == null) {
                 lastPart = part;
@@ -861,7 +861,7 @@ public class UnicodeUtilities {
         StringBuilder result = new StringBuilder();
         int cp;
         for (int i = 0; i < string.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(string, i);
+            cp = string.codePointAt(i);
             if (i != 0) {
                 result.append(separator);
             }
@@ -921,7 +921,7 @@ public class UnicodeUtilities {
             if (i != 0) {
                 result.append(separator);
             }
-            result.append(getHex(cp = UTF16.charAt(string, i), ucdFormat, additionalParameters));
+            result.append(getHex(cp = string.codePointAt(i), ucdFormat, additionalParameters));
         }
         return result.toString();
     }
@@ -933,7 +933,7 @@ public class UnicodeUtilities {
     //      if (i != 0) {
     //        out.write(separator);
     //      }
-    //      showCodePoint(cp = UTF16.charAt(s, i), ucdFormat, out);
+    //      showCodePoint(cp = s.codePointAt(i), ucdFormat, out);
     //    }
     //  }
 

--- a/UnicodeJsps/src/main/java/org/unicode/jsp/XPropertyFactory.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/XPropertyFactory.java
@@ -11,7 +11,6 @@ import com.ibm.icu.text.RawCollationKey;
 import com.ibm.icu.text.RuleBasedCollator;
 import com.ibm.icu.text.StringTransform;
 import com.ibm.icu.text.Transform;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import com.ibm.icu.util.LocaleData;
@@ -552,7 +551,7 @@ public class XPropertyFactory extends UnicodeProperty.Factory {
 
         @Override
         protected String _getValue(int codepoint) {
-            return transform.transform(UTF16.valueOf(codepoint));
+            return transform.transform(Character.toString(codepoint));
         }
     }
 

--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestGenerate.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestGenerate.java
@@ -7,7 +7,6 @@ import com.ibm.icu.text.DateFormat;
 import com.ibm.icu.text.Normalizer;
 import com.ibm.icu.text.SimpleDateFormat;
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.TimeZone;
 import com.ibm.icu.util.ULocale;
@@ -76,7 +75,7 @@ public class TestGenerate extends TestFmwk {
         // hex_results.putAll(new UnicodeSet("[:cn:]"), "disallowed");
         // hex_results.putAll(new UnicodeSet("[:noncharactercodepoint:]"), "disallowed");
         for (int cp = 0; cp <= 0x10FFFF; ++cp) {
-            String s = UTF16.valueOf(cp);
+            String s = Character.toString(cp);
             String nfc = toNfc(s);
             String nfkc = Normalizer.normalize(s, Normalizer.NFKC);
             String uts46 = Uts46.SINGLETON.transform(s);

--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestJsp.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestJsp.java
@@ -9,7 +9,6 @@ import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.IDNA;
 import com.ibm.icu.text.StringPrepParseException;
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.LocaleData;
 import com.ibm.icu.util.ULocale;
@@ -162,7 +161,7 @@ public class TestJsp extends TestFmwkMinusMinus {
     //        assertNotNull("2003ignored", map2003);
     //      }
     //      if (type46 != type2003 || !UnicodeProperty.equals(map46, map2003)) {
-    //        String map2 = map2003 == null ? UTF16.valueOf(i) : map2003;
+    //        String map2 = map2003 == null ? Character.toString(i) : map2003;
     //        String nfcf = nfkc_cfMap.get(i);
     //        if (!map2.equals(nfcf)) continue;
     //        String typeDiff = type46 + "\tvs 2003\t" + type2003;
@@ -176,7 +175,7 @@ public class TestJsp extends TestFmwkMinusMinus {
     //  }
 
     private String codeAndName(int i) {
-        return Utility.hex(i) + " ( " + UTF16.valueOf(i) + " ) " + UCharacter.getName(i);
+        return Utility.hex(i) + " ( " + Character.toString(i) + " ) " + UCharacter.getName(i);
     }
 
     private String codeAndName(String i) {
@@ -219,7 +218,8 @@ public class TestJsp extends TestFmwkMinusMinus {
                                 + (!UnicodeProperty.equals(mapping, typeAndMapIcu.mapping)
                                         ? "\tmap:\t" + mapDiff
                                         : ""));
-                //        errln(Utility.hex(cp) + "\t( " + UTF16.valueOf(cp) + " )\tdifference:"
+                //        errln(Utility.hex(cp) + "\t( " + Character.toString(cp) + "
+                // )\tdifference:"
                 //                + (type != typeAndMapIcu.type ? "\ttype:\t" + typeDiff : "")
                 //                + (!UnicodeProperty.equals(mapping, typeAndMapIcu.mapping) ?
                 // "\tmap:\t" + mapDiff : ""));
@@ -375,8 +375,8 @@ public class TestJsp extends TestFmwkMinusMinus {
             String title, int cp, IdnaType t1, String m1, IdnaType t2, String m2) {
         if (t1 == IdnaType.disallowed || t2 == IdnaType.disallowed) return;
         if (t1 == IdnaType.valid && t2 == IdnaType.valid) return;
-        m1 = m1 == null ? UTF16.valueOf(cp) : m1;
-        m2 = m2 == null ? UTF16.valueOf(cp) : m2;
+        m1 = m1 == null ? Character.toString(cp) : m1;
+        m2 = m2 == null ? Character.toString(cp) : m2;
         if (m1.equals(m2)) return;
         assertEquals(title + "\t" + Utility.hex(cp), Utility.hex(m1), Utility.hex(m2));
     }

--- a/UnicodeJsps/src/test/java/org/unicode/jsptest/TestProperties.java
+++ b/UnicodeJsps/src/test/java/org/unicode/jsptest/TestProperties.java
@@ -10,7 +10,6 @@ import com.ibm.icu.lang.UProperty;
 import com.ibm.icu.lang.UProperty.NameChoice;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.RuleBasedCollator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ULocale;
 import java.io.IOException;
@@ -241,7 +240,7 @@ public class TestProperties extends TestFmwk2 {
                 Builder.with(new TreeSet<String>(col)).addAll(availableNames).remove("Name").get();
 
         int cp = 'a';
-        logln("Properties for " + UTF16.valueOf(cp));
+        logln("Properties for " + Character.toString(cp));
 
         for (String propName : sortedProps) {
             UnicodeProperty prop;

--- a/unicodetools/src/main/java/com/ibm/icu/dev/util/CollectionUtilities.java
+++ b/unicodetools/src/main/java/com/ibm/icu/dev/util/CollectionUtilities.java
@@ -134,7 +134,7 @@ public final class CollectionUtilities {
         StringBuffer result = new StringBuffer();
         int cp;
         for (int i = 0; i < source.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(source, i);
+            cp = source.codePointAt(i);
             if (!removals.contains(cp)) UTF16.append(result, cp);
         }
         return result.toString();

--- a/unicodetools/src/main/java/com/ibm/icu/dev/util/CollectionUtilities.java
+++ b/unicodetools/src/main/java/com/ibm/icu/dev/util/CollectionUtilities.java
@@ -11,7 +11,6 @@ package com.ibm.icu.dev.util;
 // This file was migrated from the ICU4J repo,
 // path icu4j/main/framework/src/test/java/com/ibm/icu/dev/util/CollectionUtilities.java
 
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.util.Collection;
 import java.util.Comparator;
@@ -135,7 +134,7 @@ public final class CollectionUtilities {
         int cp;
         for (int i = 0; i < source.length(); i += Character.charCount(cp)) {
             cp = source.codePointAt(i);
-            if (!removals.contains(cp)) UTF16.append(result, cp);
+            if (!removals.contains(cp)) result.appendCodePoint(cp);
         }
         return result.toString();
     }

--- a/unicodetools/src/main/java/com/ibm/icu/dev/util/CollectionUtilities.java
+++ b/unicodetools/src/main/java/com/ibm/icu/dev/util/CollectionUtilities.java
@@ -133,7 +133,7 @@ public final class CollectionUtilities {
     public static String remove(String source, UnicodeSet removals) {
         StringBuffer result = new StringBuffer();
         int cp;
-        for (int i = 0; i < source.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < source.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(source, i);
             if (!removals.contains(cp)) UTF16.append(result, cp);
         }

--- a/unicodetools/src/main/java/org/unicode/draft/CharacterFrequency.java
+++ b/unicodetools/src/main/java/org/unicode/draft/CharacterFrequency.java
@@ -118,7 +118,7 @@ public class CharacterFrequency {
     //            //          int cp;
     //            //          for (int i = 0; i < sequence.length(); i+=Character.charCount(cp)) {
     //            //            cp = sequence.codePointAt(i);
-    //            //            String cpStr = UTF16.valueOf(cp);
+    //            //            String cpStr = Character.toString(cp);
     //            //            long charCount = charCounter.get(cpStr);
     //            //            if (sequenceCount > charCount) { // debug
     //            //              System.out.println(language + "\tsequence:\t" + sequenceCount +
@@ -169,7 +169,7 @@ public class CharacterFrequency {
     //        int cp;
     //        for (int i = 0; i < nfcSequence.length(); i+=Character.charCount(cp)) {
     //            cp = nfcSequence.codePointAt(i);
-    //            combinedCounter.add(UTF16.valueOf(cp), countValue);
+    //            combinedCounter.add(Character.toString(cp), countValue);
     //        }
     //    }
 

--- a/unicodetools/src/main/java/org/unicode/draft/CldrUtility.java
+++ b/unicodetools/src/main/java/org/unicode/draft/CldrUtility.java
@@ -836,9 +836,9 @@ public class CldrUtility {
 
     private static void addBmpRange(
             int start, int limit, Transliterator escaper, StringBuilder base) {
-        base.append(escaper.transliterate(UTF16.valueOf(start)));
+        base.append(escaper.transliterate(Character.toString(start)));
         if (start != limit) {
-            base.append("-").append(escaper.transliterate(UTF16.valueOf(limit)));
+            base.append("-").append(escaper.transliterate(Character.toString(limit)));
         }
     }
 

--- a/unicodetools/src/main/java/org/unicode/draft/CldrUtility.java
+++ b/unicodetools/src/main/java/org/unicode/draft/CldrUtility.java
@@ -13,7 +13,6 @@ import com.ibm.icu.impl.Utility;
 import com.ibm.icu.text.DateFormat;
 import com.ibm.icu.text.SimpleDateFormat;
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import com.ibm.icu.util.Freezable;
@@ -775,10 +774,10 @@ public class CldrUtility {
                 // Lx [Tx - Ty])         (if Lx == Ly)
                 // Lx [Tx - DFFF] | Ly [DC00-Ty]        (if Lx == Ly - 1)
                 // Lx [Tx - DFFF] | [Lx+1 - Ly-1][DC00-DFFF] | Ly [DC00-Ty] (otherwise)
-                final int leadX = UTF16.getLeadSurrogate(it.codepoint);
-                final int trailX = UTF16.getTrailSurrogate(it.codepoint);
-                final int leadY = UTF16.getLeadSurrogate(it.codepointEnd);
-                final int trailY = UTF16.getTrailSurrogate(it.codepointEnd);
+                final int leadX = Character.highSurrogate(it.codepoint);
+                final int trailX = Character.lowSurrogate(it.codepoint);
+                final int leadY = Character.highSurrogate(it.codepointEnd);
+                final int trailY = Character.lowSurrogate(it.codepointEnd);
                 if (leadX == leadY) {
                     addSupplementalRange(leadX, leadX, trailX, trailY, escaper, lastToFirst);
                 } else {

--- a/unicodetools/src/main/java/org/unicode/draft/FindHanSizes.java
+++ b/unicodetools/src/main/java/org/unicode/draft/FindHanSizes.java
@@ -4,7 +4,6 @@ import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.Normalizer2;
 import com.ibm.icu.text.Normalizer2.Mode;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import com.ibm.icu.util.ULocale;
@@ -75,7 +74,7 @@ public class FindHanSizes {
         Map<Integer, EnumSet<NamedHanSet>> status = new HashMap();
 
         void add(int cp, NamedHanSet e) {
-            final String s = nfc.normalize(UTF16.valueOf(cp));
+            final String s = nfc.normalize(Character.toString(cp));
             final int newCp = s.codePointAt(0);
             if (cp != newCp) {
                 if (s.length() != Character.charCount(newCp)) {

--- a/unicodetools/src/main/java/org/unicode/draft/FrequencyData2.java
+++ b/unicodetools/src/main/java/org/unicode/draft/FrequencyData2.java
@@ -8,7 +8,6 @@ import com.ibm.icu.text.Normalizer;
 import com.ibm.icu.text.Normalizer.Mode;
 import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import java.io.BufferedReader;
@@ -371,7 +370,7 @@ public class FrequencyData2 {
                 System.out.print(", ");
             }
             final int codePointAtRank = relative.getCodePointAtRank(i);
-            System.out.print(fixOutput.transform(UTF16.valueOf(codePointAtRank)));
+            System.out.print(fixOutput.transform(Character.toString(codePointAtRank)));
         }
         if (relative.getRankCount() > maxCount) {
             System.out.print(", ...");

--- a/unicodetools/src/main/java/org/unicode/draft/FrequencyData2.java
+++ b/unicodetools/src/main/java/org/unicode/draft/FrequencyData2.java
@@ -227,7 +227,7 @@ public class FrequencyData2 {
                     norm = UCharacter.foldCase(norm, true);
                     norm = Normalizer.normalize(norm, compose);
                     int cp;
-                    for (int j = 0; j < norm.length(); j += UTF16.getCharCount(cp)) {
+                    for (int j = 0; j < norm.length(); j += Character.charCount(cp)) {
                         cp = UTF16.charAt(norm, j);
                         counter.add(cp, frequency);
                     }

--- a/unicodetools/src/main/java/org/unicode/draft/FrequencyData2.java
+++ b/unicodetools/src/main/java/org/unicode/draft/FrequencyData2.java
@@ -228,7 +228,7 @@ public class FrequencyData2 {
                     norm = Normalizer.normalize(norm, compose);
                     int cp;
                     for (int j = 0; j < norm.length(); j += Character.charCount(cp)) {
-                        cp = UTF16.charAt(norm, j);
+                        cp = norm.codePointAt(j);
                         counter.add(cp, frequency);
                     }
                 }

--- a/unicodetools/src/main/java/org/unicode/draft/GenerateNormalizeForMatch2.java
+++ b/unicodetools/src/main/java/org/unicode/draft/GenerateNormalizeForMatch2.java
@@ -387,7 +387,7 @@ public class GenerateNormalizeForMatch2 {
         StringBuilder result = new StringBuilder();
         boolean changed = false;
         int cp;
-        for (int i = 0; i < target.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < target.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(target, i);
             String remapped = (String) mappings.getValue(cp);
             if (remapped != null) {
@@ -542,7 +542,7 @@ public class GenerateNormalizeForMatch2 {
     private static VersionInfo getNewest(String string) {
         int cp;
         VersionInfo oldest = null;
-        for (int i = 0; i < string.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < string.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(string, i);
             VersionInfo age = UCharacter.getAge(cp);
             if (oldest == null || oldest.compareTo(age) < 0) {
@@ -834,7 +834,7 @@ public class GenerateNormalizeForMatch2 {
     public static String hex(String s, String separator) {
         StringBuffer result = new StringBuffer();
         int cp = 0;
-        for (int i = 0; i < s.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
             if (i != 0) result.append(separator);
             cp = UTF16.charAt(s, i);
             result.append(com.ibm.icu.impl.Utility.hex(cp, 4));

--- a/unicodetools/src/main/java/org/unicode/draft/GenerateNormalizeForMatch2.java
+++ b/unicodetools/src/main/java/org/unicode/draft/GenerateNormalizeForMatch2.java
@@ -388,7 +388,7 @@ public class GenerateNormalizeForMatch2 {
         boolean changed = false;
         int cp;
         for (int i = 0; i < target.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(target, i);
+            cp = target.codePointAt(i);
             String remapped = (String) mappings.getValue(cp);
             if (remapped != null) {
                 result.append(remapped);
@@ -543,7 +543,7 @@ public class GenerateNormalizeForMatch2 {
         int cp;
         VersionInfo oldest = null;
         for (int i = 0; i < string.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(string, i);
+            cp = string.codePointAt(i);
             VersionInfo age = UCharacter.getAge(cp);
             if (oldest == null || oldest.compareTo(age) < 0) {
                 oldest = age;
@@ -621,7 +621,7 @@ public class GenerateNormalizeForMatch2 {
         if (UnicodeSet.resemblesPattern(sourcePiece, 0)) {
             source.applyPattern(sourcePiece);
         } else if (UTF16.countCodePoint(sourcePiece) == 1) {
-            source.add(UTF16.charAt(sourcePiece, 0));
+            source.add(sourcePiece.codePointAt(0));
         } else {
             String[] starts = sourcePiece.split("\\s*-\\s*");
             int start = Integer.parseInt(starts[0], 16);
@@ -817,7 +817,7 @@ public class GenerateNormalizeForMatch2 {
         String otherName =
                 UTF16.countCodePoint(other) != 1
                         ? null
-                        : (String) JIM_NAMES.getValue(UTF16.charAt(other, 0));
+                        : (String) JIM_NAMES.getValue(other.codePointAt(0));
         if (otherName == null) {
             otherName = UCharacter.getName(other, " + ");
         }
@@ -836,7 +836,7 @@ public class GenerateNormalizeForMatch2 {
         int cp = 0;
         for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
             if (i != 0) result.append(separator);
-            cp = UTF16.charAt(s, i);
+            cp = s.codePointAt(i);
             result.append(com.ibm.icu.impl.Utility.hex(cp, 4));
         }
         return result.toString();

--- a/unicodetools/src/main/java/org/unicode/draft/GenerateNormalizeForMatch2.java
+++ b/unicodetools/src/main/java/org/unicode/draft/GenerateNormalizeForMatch2.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import org.unicode.cldr.util.PatternCache;
+import org.unicode.text.utility.UTF16Plus;
 
 @Deprecated
 public class GenerateNormalizeForMatch2 {
@@ -620,7 +621,7 @@ public class GenerateNormalizeForMatch2 {
         UnicodeSet source = new UnicodeSet();
         if (UnicodeSet.resemblesPattern(sourcePiece, 0)) {
             source.applyPattern(sourcePiece);
-        } else if (UTF16.countCodePoint(sourcePiece) == 1) {
+        } else if (UTF16Plus.isSingleCodePoint(sourcePiece)) {
             source.add(sourcePiece.codePointAt(0));
         } else {
             String[] starts = sourcePiece.split("\\s*-\\s*");
@@ -815,7 +816,7 @@ public class GenerateNormalizeForMatch2 {
      */
     private static String jimName(String other) {
         String otherName =
-                UTF16.countCodePoint(other) != 1
+                !UTF16Plus.isSingleCodePoint(other)
                         ? null
                         : (String) JIM_NAMES.getValue(other.codePointAt(0));
         if (otherName == null) {

--- a/unicodetools/src/main/java/org/unicode/draft/GenerateNormalizeForMatch2.java
+++ b/unicodetools/src/main/java/org/unicode/draft/GenerateNormalizeForMatch2.java
@@ -14,7 +14,6 @@ import com.ibm.icu.text.Normalizer.Mode;
 import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.text.SimpleDateFormat;
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import com.ibm.icu.util.VersionInfo;
@@ -282,7 +281,7 @@ public class GenerateNormalizeForMatch2 {
                             + countStr
                             + " ; # "
                             + showChanged(
-                                    UTF16.valueOf(cp),
+                                    Character.toString(cp),
                                     oldMapped,
                                     newMapped,
                                     Form.codeStringAndName);
@@ -426,7 +425,7 @@ public class GenerateNormalizeForMatch2 {
      * @return
      */
     private static String getRemapped(int codepoint, String special) {
-        String other = UTF16.valueOf(codepoint);
+        String other = Character.toString(codepoint);
         if (codepoint == DEBUG_CODE_POINT) {
             System.out.println("?debug?");
         }
@@ -803,7 +802,7 @@ public class GenerateNormalizeForMatch2 {
         StringBuilder result = new StringBuilder();
         String[] pieces = spaceDelimitedHex.split("\\s+");
         for (String piece : pieces) {
-            result.append(UTF16.valueOf(Integer.parseInt(piece, 16)));
+            result.append(Character.toString(Integer.parseInt(piece, 16)));
         }
         return result.toString();
     }

--- a/unicodetools/src/main/java/org/unicode/draft/GeneratePickerData2.java
+++ b/unicodetools/src/main/java/org/unicode/draft/GeneratePickerData2.java
@@ -2715,7 +2715,7 @@ class GeneratePickerData2 {
         int cp;
         int len = 0;
         for (int i = 0; i < x.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(x, i);
+            cp = x.codePointAt(i);
             len += cp < 0x80 ? 1 : cp < 0x800 ? 2 : cp < 0x10000 ? 3 : 4;
         }
         return len;

--- a/unicodetools/src/main/java/org/unicode/draft/GeneratePickerData2.java
+++ b/unicodetools/src/main/java/org/unicode/draft/GeneratePickerData2.java
@@ -394,7 +394,7 @@ class GeneratePickerData2 {
                                             ? "11..17"
                                             : String.valueOf(radicalStrokes))
                                     + "-Stroke Radicals";
-                    String subCat = UTF16.valueOf(radicalChar);
+                    String subCat = Character.toString(radicalChar);
                     // if (DEBUG) System.out.println(radical + " => " + radicalToChar.get(radical));
                     // String radChar = getRadicalName(radicalToChar, radical);
                     // String subCat = radChar + " Han";
@@ -570,7 +570,7 @@ class GeneratePickerData2 {
     private static UnicodeSet closeOver(UnicodeSet closed) {
         for (int i = 0; i < 0x10FFFF; ++i) {
             if (closed.contains(i)) continue;
-            final String str = UTF16.valueOf(i);
+            final String str = Character.toString(i);
             String s = UCharacter.foldCase(str, true);
             if (s.equals(str)) continue;
             if (closed.contains(s)) {
@@ -864,7 +864,7 @@ class GeneratePickerData2 {
             CATEGORYTABLE.add(
                     "Hangul",
                     true,
-                    UTF16.valueOf(decompCodePoint1)
+                    Character.toString(decompCodePoint1)
                             + " "
                             + UCharacter.getExtendedName(decompCodePoint1),
                     buttonComparator,
@@ -1086,7 +1086,7 @@ class GeneratePickerData2 {
             GeneratePickerData2.USet oldValue =
                     getValues(category, sortSubcategory, subcategory, sortValues);
             if (!SKIP.contains(codePoint)) {
-                oldValue.strings.add(UTF16.valueOf(codePoint));
+                oldValue.strings.add(Character.toString(codePoint));
             }
         }
 

--- a/unicodetools/src/main/java/org/unicode/draft/GeneratePickerData2.java
+++ b/unicodetools/src/main/java/org/unicode/draft/GeneratePickerData2.java
@@ -1003,7 +1003,7 @@ class GeneratePickerData2 {
                 Separation separateOld,
                 String values) {
             int cp;
-            for (int i = 0; i < values.length(); i += UTF16.getCharCount(cp)) {
+            for (int i = 0; i < values.length(); i += Character.charCount(cp)) {
                 add(
                         category,
                         sortSubcategory,
@@ -2714,7 +2714,7 @@ class GeneratePickerData2 {
     public static int utf8Length(String x) {
         int cp;
         int len = 0;
-        for (int i = 0; i < x.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < x.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(x, i);
             len += cp < 0x80 ? 1 : cp < 0x800 ? 2 : cp < 0x10000 ? 3 : 4;
         }

--- a/unicodetools/src/main/java/org/unicode/draft/GenerateUnihanCollators.java
+++ b/unicodetools/src/main/java/org/unicode/draft/GenerateUnihanCollators.java
@@ -1237,7 +1237,7 @@ public class GenerateUnihanCollators {
                                         + hexConstant(s)
                                         + "\", "
                                         + "// "
-                                        + UTF16.valueOf(alpha)
+                                        + Character.toString(alpha)
                                         + " : "
                                         + s
                                         + " ["
@@ -1519,7 +1519,7 @@ public class GenerateUnihanCollators {
             if (countHasPinyin != s.size() && hasPinyin != null) {
                 for (final Integer cp : s) {
                     if (!bestPinyin.containsKey(cp)) {
-                        addPinyin(title, UTF16.valueOf(cp), hasPinyin, OverrideItems.keepOld);
+                        addPinyin(title, Character.toString(cp), hasPinyin, OverrideItems.keepOld);
                         count++;
                     }
                 }
@@ -1714,7 +1714,7 @@ public class GenerateUnihanCollators {
                 throw new RuntimeException(hex);
             } else {
                 final int hexValue = Integer.parseInt(hex.substring(2), 16);
-                if (!character.equals(UTF16.valueOf(hexValue))) {
+                if (!character.equals(Character.toString(hexValue))) {
                     throw new RuntimeException(hex + "!=" + character);
                 }
             }
@@ -1797,7 +1797,7 @@ public class GenerateUnihanCollators {
             }
             String codepoint = items[0];
             if (codepoint.startsWith("U+")) {
-                codepoint = UTF16.valueOf(Integer.parseInt(codepoint.substring(2), 16));
+                codepoint = Character.toString(Integer.parseInt(codepoint.substring(2), 16));
             }
             if (!UNIHAN.contains(codepoint)) {
                 throw new IllegalArgumentException(

--- a/unicodetools/src/main/java/org/unicode/draft/GenerateUnihanCollators.java
+++ b/unicodetools/src/main/java/org/unicode/draft/GenerateUnihanCollators.java
@@ -52,6 +52,7 @@ import org.unicode.text.UCA.RadicalStroke;
 import org.unicode.text.UCD.Default;
 import org.unicode.text.UCD.Normalizer;
 import org.unicode.text.utility.Settings;
+import org.unicode.text.utility.UTF16Plus;
 import org.unicode.text.utility.Utility;
 
 public class GenerateUnihanCollators {
@@ -1133,7 +1134,7 @@ public class GenerateUnihanCollators {
         for (final String s : unicodeMap) {
             //            S newValue = unicodeMap.get(s);
             //            if (newValue == null) continue;
-            if (UTF16.countCodePoint(s) != 1) {
+            if (!UTF16Plus.isSingleCodePoint(s)) {
                 throw new IllegalArgumentException("Wrong length!!");
             }
             rsSorted.add(s);

--- a/unicodetools/src/main/java/org/unicode/draft/HanFrequencies.java
+++ b/unicodetools/src/main/java/org/unicode/draft/HanFrequencies.java
@@ -3,7 +3,6 @@ package org.unicode.draft;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
 import com.ibm.icu.impl.UnicodeMap;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -216,7 +215,7 @@ public class HanFrequencies {
         int rank = 0;
         for (final Integer item : counter1.getKeysetSortedByCount(false)) {
             if (HAN.contains(item)) {
-                list1.put(UTF16.valueOf(item), ++rank);
+                list1.put(Character.toString(item), ++rank);
             }
         }
         return list1;

--- a/unicodetools/src/main/java/org/unicode/draft/IdnaFrequency.java
+++ b/unicodetools/src/main/java/org/unicode/draft/IdnaFrequency.java
@@ -5,7 +5,6 @@ import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UProperty;
 import com.ibm.icu.lang.UProperty.NameChoice;
 import com.ibm.icu.text.Normalizer;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -41,7 +40,7 @@ public class IdnaFrequency {
         Counter<Integer> charTotal = getData(true);
         for (int cp : charTotal.getKeysetSortedByCount(false)) {
             String norm = normalize(cp);
-            if (!norm.equals(UTF16.valueOf(cp))) {
+            if (!norm.equals(Character.toString(cp))) {
                 final int dt = UCharacter.getIntPropertyValue(cp, UProperty.DECOMPOSITION_TYPE);
                 final String tdName =
                         UCharacter.getPropertyValueName(
@@ -138,7 +137,7 @@ public class IdnaFrequency {
         return "U+"
                 + Utility.hex(cp, 4)
                 + "\t( "
-                + com.ibm.icu.text.UTF16.valueOf(cp)
+                + Character.toString(cp)
                 + " )\t"
                 + UCharacter.getName(cp);
     }

--- a/unicodetools/src/main/java/org/unicode/draft/IdnaLabelTester2.java
+++ b/unicodetools/src/main/java/org/unicode/draft/IdnaLabelTester2.java
@@ -17,7 +17,6 @@ import com.ibm.icu.text.Normalizer;
 import com.ibm.icu.text.StringPrep;
 import com.ibm.icu.text.StringPrepParseException;
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ULocale;
 import com.ibm.icu.util.VersionInfo;
@@ -654,7 +653,7 @@ public class IdnaLabelTester2 {
                 // System.out.println("debug?");
                 // }
 
-                String s = UTF16.valueOf(cp);
+                String s = Character.toString(cp);
 
                 IdnaStatus idna2008 = IdnaStatus.valueOf(parts[1]);
                 // String rule2008 = parts[2];
@@ -912,14 +911,15 @@ public class IdnaLabelTester2 {
             String myName = getName(it.codepoint);
             String myGc = getGc(it.codepoint);
             String myScript = UScript.getShortName(UScript.getScript(it.codepoint));
-            String charsHex = TransliteratorUtilities.toHTML.transform(UTF16.valueOf(it.codepoint));
+            String charsHex =
+                    TransliteratorUtilities.toHTML.transform(Character.toString(it.codepoint));
             if (it.codepoint != it.codepointEnd) {
                 codepointsHex += "\u200B.." + Utility.hex(it.codepointEnd, 4);
                 myName += "\u200B.." + getName(it.codepointEnd);
                 charsHex +=
                         "\u200B.."
                                 + TransliteratorUtilities.toHTML.transform(
-                                        UTF16.valueOf(it.codepointEnd));
+                                        Character.toString(it.codepointEnd));
                 gcs.clear();
                 scripts.clear();
                 for (int cp = it.codepoint; cp < it.codepointEnd; ++cp) {
@@ -1247,14 +1247,18 @@ public class IdnaLabelTester2 {
                 result.append(" + ");
             }
             result.append(
-                    Utility.hex(cp) + " (" + UTF16.valueOf(cp) + ") " + UCharacter.getName(cp));
+                    Utility.hex(cp)
+                            + " ("
+                            + Character.toString(cp)
+                            + ") "
+                            + UCharacter.getName(cp));
             if (cp > 0xFFFF) ++i;
         }
         return result.toString();
     }
 
     private static void addMapping(Map<String, UnicodeSet> mapping, int i, String mapped) {
-        String s = UTF16.valueOf(i);
+        String s = Character.toString(i);
         if (!s.equals(mapped)) {
             UnicodeSet x = mapping.get(mapped);
             if (x == null) mapping.put(mapped, x = new UnicodeSet());

--- a/unicodetools/src/main/java/org/unicode/draft/Ids2.java
+++ b/unicodetools/src/main/java/org/unicode/draft/Ids2.java
@@ -7,7 +7,6 @@ import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.Normalizer2;
 import com.ibm.icu.text.NumberFormat;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import com.ibm.icu.util.ULocale;
@@ -83,7 +82,7 @@ public abstract class Ids2 implements Comparable<Ids2> {
 
         public int getHackCode(int cp) {
             hacks.badChars.add(cp, 1);
-            return getHackCode("Illegal-" + UTF16.valueOf(cp) + "-" + Utility.hex(cp));
+            return getHackCode("Illegal-" + Character.toString(cp) + "-" + Utility.hex(cp));
         }
 
         public String getHackString(int codepoint) {
@@ -167,11 +166,11 @@ public abstract class Ids2 implements Comparable<Ids2> {
             result = null;
         }
         return result == null
-                ? UTF16.valueOf(codepoint)
+                ? Character.toString(codepoint)
                 : !replace
-                        ? "*" + UTF16.valueOf(codepoint)
+                        ? "*" + Character.toString(codepoint)
                         : maxLevel <= 0
-                                ? "†" + UTF16.valueOf(codepoint)
+                                ? "†" + Character.toString(codepoint)
                                 : result.toString(data, replace, maxLevel - 1);
     }
 
@@ -239,7 +238,7 @@ public abstract class Ids2 implements Comparable<Ids2> {
 
     static final class Leaf extends Ids2 {
         Leaf(int cp) {
-            String nfcForm = nfc.normalize(UTF16.valueOf(cp));
+            String nfcForm = nfc.normalize(Character.toString(cp));
             if (nfcForm.codePointCount(0, nfcForm.length()) != 1) {
                 throw new IllegalArgumentException(
                         "NFC form is too long:\t" + Utility.hex(nfcForm));
@@ -264,7 +263,7 @@ public abstract class Ids2 implements Comparable<Ids2> {
             // if (codepoint >= 0xE000 && codepoint <= 0xEFFF) {
             // return hacks.getHackString(codepoint);
             // }
-            return UTF16.valueOf(codepoint);
+            return Character.toString(codepoint);
         }
 
         public int compareTo(Ids2 o) {
@@ -313,7 +312,7 @@ public abstract class Ids2 implements Comparable<Ids2> {
         }
 
         public String toString() {
-            return "{" + UTF16.valueOf(codepoint) + first.toString() + second.toString() + "}";
+            return "{" + Character.toString(codepoint) + first.toString() + second.toString() + "}";
         }
 
         public String toString(UnicodeMap<Ids2> data, boolean replace, int maxLevel) {
@@ -405,7 +404,7 @@ public abstract class Ids2 implements Comparable<Ids2> {
 
         public String toString() {
             return "{"
-                    + UTF16.valueOf(codepoint)
+                    + Character.toString(codepoint)
                     + first.toString()
                     + second.toString()
                     + third.toString()
@@ -750,7 +749,7 @@ public abstract class Ids2 implements Comparable<Ids2> {
                     nf.format(++counter)
                             + ")\t"
                             + strokes
-                            + UTF16.valueOf(radical)
+                            + Character.toString(radical)
                             + "\t"
                             + charAndHex(containingChar)
                             + "\t"
@@ -786,7 +785,7 @@ public abstract class Ids2 implements Comparable<Ids2> {
                             nf.format(++counter)
                                     + ")\t"
                                     + oldStrokes
-                                    + UTF16.valueOf(oldRadical)
+                                    + Character.toString(oldRadical)
                                     + "\t"
                                     + pp.format(temp));
                 }
@@ -803,7 +802,7 @@ public abstract class Ids2 implements Comparable<Ids2> {
                 nf.format(++counter)
                         + ")\t"
                         + oldStrokes
-                        + UTF16.valueOf(oldRadical)
+                        + Character.toString(oldRadical)
                         + "\t"
                         + pp.format(temp));
 
@@ -912,7 +911,7 @@ public abstract class Ids2 implements Comparable<Ids2> {
 
     private static String charAndHex(int codepoint) {
         String hack = hacks.getHackString(codepoint);
-        return UTF16.valueOf(codepoint)
+        return Character.toString(codepoint)
                 + "\t("
                 + (hack == null ? Utility.hex(codepoint) : hack)
                 + ")";

--- a/unicodetools/src/main/java/org/unicode/draft/OldPunycode.java
+++ b/unicodetools/src/main/java/org/unicode/draft/OldPunycode.java
@@ -9,7 +9,6 @@ package org.unicode.draft;
 
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.StringPrepParseException;
-import com.ibm.icu.text.UTF16;
 
 /**
  * Ported code from ICU punycode.c
@@ -166,11 +165,11 @@ public final class OldPunycode {
                 ++destLength;
             } else {
                 n = ((caseFlags != null && caseFlags[j]) ? 1 : 0) << 31L;
-                if (!UTF16.isSurrogate(c)) {
+                if (!Character.isSurrogate(c)) {
                     n |= c;
-                } else if (UTF16.isLeadSurrogate(c)
+                } else if (Character.isHighSurrogate(c)
                         && (j + 1) < srcLength
-                        && UTF16.isTrailSurrogate(c2 = src.charAt(j + 1))) {
+                        && Character.isLowSurrogate(c2 = src.charAt(j + 1))) {
                     ++j;
 
                     n |= UCharacter.getCodePoint(c, c2);
@@ -486,7 +485,7 @@ public final class OldPunycode {
                 } else {
                     codeUnitIndex = firstSupplementaryIndex;
                     codeUnitIndex =
-                            UTF16.moveCodePointOffset(
+                            Character.offsetByCodePoints(
                                     dest, 0, destLength, codeUnitIndex, i - codeUnitIndex);
                 }
 
@@ -512,8 +511,8 @@ public final class OldPunycode {
                     dest[codeUnitIndex] = (char) n;
                 } else {
                     /* supplementary character, insert two code units */
-                    dest[codeUnitIndex] = UTF16.getLeadSurrogate(n);
-                    dest[codeUnitIndex + 1] = UTF16.getTrailSurrogate(n);
+                    dest[codeUnitIndex] = Character.highSurrogate(n);
+                    dest[codeUnitIndex + 1] = Character.lowSurrogate(n);
                 }
                 if (caseFlags != null) {
                     /* Case of last character determines uppercase flag: */

--- a/unicodetools/src/main/java/org/unicode/draft/OldPunycode.java
+++ b/unicodetools/src/main/java/org/unicode/draft/OldPunycode.java
@@ -462,7 +462,7 @@ public final class OldPunycode {
             }
 
             /* Insert n at position i of the output: */
-            cpLength = UTF16.getCharCount(n);
+            cpLength = Character.charCount(n);
             if ((destLength + cpLength) < destCapacity) {
                 int codeUnitIndex;
 

--- a/unicodetools/src/main/java/org/unicode/draft/Punycode.java
+++ b/unicodetools/src/main/java/org/unicode/draft/Punycode.java
@@ -9,7 +9,6 @@ package org.unicode.draft;
 
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.StringPrepParseException;
-import com.ibm.icu.text.UTF16;
 
 /**
  * Ported code from ICU punycode.c
@@ -141,11 +140,11 @@ public final class Punycode {
                 dest.append(c);
             } else {
                 cpBeingEncoded = 0;
-                if (!UTF16.isSurrogate(c)) {
+                if (!Character.isSurrogate(c)) {
                     cpBeingEncoded |= c;
-                } else if (UTF16.isLeadSurrogate(c)
+                } else if (Character.isHighSurrogate(c)
                         && (j + 1) < srcLength
-                        && UTF16.isTrailSurrogate(c2 = src.charAt(j + 1))) {
+                        && Character.isLowSurrogate(c2 = src.charAt(j + 1))) {
                     ++j;
 
                     cpBeingEncoded |= UCharacter.getCodePoint(c, c2);
@@ -435,7 +434,8 @@ public final class Punycode {
                 }
             } else {
                 codeUnitIndex = firstSupplementaryIndex;
-                codeUnitIndex = UTF16.moveCodePointOffset(dest, codeUnitIndex, i - codeUnitIndex);
+                codeUnitIndex =
+                        Character.offsetByCodePoints(dest, codeUnitIndex, i - codeUnitIndex);
             }
 
             /* use the UChar index codeUnitIndex instead of the code point index i */

--- a/unicodetools/src/main/java/org/unicode/draft/RadicalStroke2.java
+++ b/unicodetools/src/main/java/org/unicode/draft/RadicalStroke2.java
@@ -126,14 +126,16 @@ public class RadicalStroke2 {
             // temp.add(it.codepoint);
             // if (temp.size() >= 800) {
             // int code = temp.charAt(0);
-            // CATEGORYTABLE.add("Han (CJK)", false, UTF16.valueOf(code) + " Han " + toHex(code,
+            // CATEGORYTABLE.add("Han (CJK)", false, Character.toString(code) + " Han " +
+            // toHex(code,
             // false), false, temp);
             // temp.clear();
             // }
             // }
             // if (temp.size() > 0) {
             // int code = temp.charAt(0);
-            // CATEGORYTABLE.add("Han (CJK)", false, UTF16.valueOf(code) + " Han " + toHex(code,
+            // CATEGORYTABLE.add("Han (CJK)", false, Character.toString(code) + " Han " +
+            // toHex(code,
             // false), false, temp);
             // }
         } catch (IOException e) {

--- a/unicodetools/src/main/java/org/unicode/draft/ScriptCount.java
+++ b/unicodetools/src/main/java/org/unicode/draft/ScriptCount.java
@@ -9,7 +9,6 @@ import com.ibm.icu.lang.UScript;
 import com.ibm.icu.text.DecimalFormat;
 import com.ibm.icu.text.Normalizer2;
 import com.ibm.icu.text.NumberFormat;
-import com.ibm.icu.text.UTF16;
 import java.io.PrintWriter;
 import java.util.BitSet;
 import java.util.HashMap;
@@ -87,7 +86,7 @@ public class ScriptCount {
         private final Map<Integer, SecondaryInfo> counter = new HashMap<Integer, SecondaryInfo>();
 
         void add(int sourceString, long count) {
-            final CEList celist = uca.getCEList(UTF16.valueOf(sourceString), true);
+            final CEList celist = uca.getCEList(Character.toString(sourceString), true);
             final int length = celist.length();
             for (int i = 0; i < length; ++i) {
                 final int ce = celist.at(i);
@@ -390,9 +389,9 @@ public class ScriptCount {
             return "U+" + Utility.hex(s);
         }
         if (s == '\'' || s == '"' || s == '=') {
-            return "'" + UTF16.valueOf(s);
+            return "'" + Character.toString(s);
         }
-        return UTF16.valueOf(s);
+        return Character.toString(s);
     }
 
     private static int getScript(String norm) {

--- a/unicodetools/src/main/java/org/unicode/draft/UnicodeIntMap.java
+++ b/unicodetools/src/main/java/org/unicode/draft/UnicodeIntMap.java
@@ -672,7 +672,7 @@ public final class UnicodeIntMap
             if (mResult != UNASSIGNED) {
                 result.append(mResult);
             } else {
-                UTF16.append(result, cp);
+                result.appendCodePoint(cp);
             }
         }
         return result.toString();

--- a/unicodetools/src/main/java/org/unicode/draft/UnicodeIntMap.java
+++ b/unicodetools/src/main/java/org/unicode/draft/UnicodeIntMap.java
@@ -666,7 +666,7 @@ public final class UnicodeIntMap
     public String transform(String source) {
         StringBuffer result = new StringBuffer();
         int cp;
-        for (int i = 0; i < source.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < source.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(source, i);
             int mResult = getValue(cp);
             if (mResult != UNASSIGNED) {

--- a/unicodetools/src/main/java/org/unicode/draft/UnicodeIntMap.java
+++ b/unicodetools/src/main/java/org/unicode/draft/UnicodeIntMap.java
@@ -891,7 +891,7 @@ public final class UnicodeIntMap
                 break;
             }
             for (int cp = entry.codepoint; cp <= entry.codepointEnd; ++cp) {
-                map.put(UTF16.valueOf(cp), entry.value);
+                map.put(Character.toString(cp), entry.value);
             }
         }
         map.putAll(stringMap);

--- a/unicodetools/src/main/java/org/unicode/draft/UnicodeIntMap.java
+++ b/unicodetools/src/main/java/org/unicode/draft/UnicodeIntMap.java
@@ -652,7 +652,7 @@ public final class UnicodeIntMap
             }
             return stringMap.get(value);
         }
-        return getValue(UTF16.charAt(value, 0));
+        return getValue(value.codePointAt(0));
     }
 
     /**
@@ -667,7 +667,7 @@ public final class UnicodeIntMap
         StringBuffer result = new StringBuffer();
         int cp;
         for (int i = 0; i < source.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(source, i);
+            cp = source.codePointAt(i);
             int mResult = getValue(cp);
             if (mResult != UNASSIGNED) {
                 result.append(mResult);

--- a/unicodetools/src/main/java/org/unicode/idna/GenerateIdna.java
+++ b/unicodetools/src/main/java/org/unicode/idna/GenerateIdna.java
@@ -6,7 +6,6 @@ import com.ibm.icu.impl.Row.R3;
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.text.DateFormat;
 import com.ibm.icu.text.SimpleDateFormat;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.TimeZone;
 import com.ibm.icu.util.ULocale;
@@ -387,7 +386,7 @@ public class GenerateIdna {
         final R2<IdnaType, String> validResult = Row.of(IdnaType.valid, (String) null);
 
         for (int cp = 0; cp <= 0x10FFFF; ++cp) {
-            final String cpString = UTF16.valueOf(cp);
+            final String cpString = Character.toString(cp);
             Row.R2<IdnaType, String> result;
             String baseMappingValue = baseMapping.get(cp);
             if (baseMappingValue == null) {

--- a/unicodetools/src/main/java/org/unicode/idna/GenerateIdnaTest.java
+++ b/unicodetools/src/main/java/org/unicode/idna/GenerateIdnaTest.java
@@ -7,7 +7,6 @@ import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.DateFormat;
 import com.ibm.icu.text.SimpleDateFormat;
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ULocale;
 import java.io.IOException;
@@ -768,8 +767,8 @@ public class GenerateIdnaTest {
         // FB04 LATIN SMALL LIGATURE FFL
         "\u02E3\u034F\u2115\u200B\uFE63\u00AD\uFF0D\u180C"
                 + "\u212C\uFE00\u017F\u2064"
-                + UTF16.valueOf(0x1D530)
-                + UTF16.valueOf(0xE01EF)
+                + Character.toString(0x1D530)
+                + Character.toString(0xE01EF)
                 + "\uFB04",
         "123456789012345678901234567890123456789012345678901234567890123."
                 + "123456789012345678901234567890123456789012345678901234567890123."

--- a/unicodetools/src/main/java/org/unicode/idna/Idna2003.java
+++ b/unicodetools/src/main/java/org/unicode/idna/Idna2003.java
@@ -46,7 +46,7 @@ public class Idna2003 extends Idna {
     ////      return UnicodeUtilities.OUTPUT;
     ////    }
     //    inbuffer.setLength(0);
-    //    UTF16.append(Idna2003.inbuffer, cp);
+    //    Idna2003.inbuffer.appendCodePoint(cp);
     //    try {
     //      convertWithHack();
     //      // DEFAULT
@@ -88,7 +88,7 @@ public class Idna2003 extends Idna {
     //  //      return "-";
     //  //    }
     //  //    UnicodeUtilities.inbuffer.setLength(0);
-    //  //    UTF16.append(UnicodeUtilities.inbuffer, cp);
+    //  //    UnicodeUtilities.inbuffer.appendCodePoint(cp);
     //  //    try {
     //  //      UnicodeUtilities.intermediate = IDNA.convertToASCII(UnicodeUtilities.inbuffer,
     // IDNA.USE_STD3_RULES); // USE_STD3_RULES,

--- a/unicodetools/src/main/java/org/unicode/idna/Idna2008.java
+++ b/unicodetools/src/main/java/org/unicode/idna/Idna2008.java
@@ -1,7 +1,6 @@
 package org.unicode.idna;
 
 import com.ibm.icu.impl.UnicodeMap;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 
 public class Idna2008 extends Idna {
@@ -26,7 +25,7 @@ public class Idna2008 extends Idna {
         // B: toNFKC(toCaseFold(toNFKC(cp))) != cp
         final UnicodeSet Unstable = new UnicodeSet();
         for (int i = 0; i <= 0x10FFFF; ++i) {
-            final String s = UTF16.valueOf(i);
+            final String s = Character.toString(i);
             final String nfkc = NFKC.transform(s);
             final String cased = CASEFOLD.transform(nfkc);
             final String full = NFKC.transform(cased);

--- a/unicodetools/src/main/java/org/unicode/idna/Punycode.java
+++ b/unicodetools/src/main/java/org/unicode/idna/Punycode.java
@@ -430,7 +430,7 @@ public final class Punycode {
             }
 
             /* Insert n at position i of the output: */
-            cpLength = UTF16.getCharCount(n);
+            cpLength = Character.charCount(n);
             if ((destLength + cpLength) < destCapacity) {
                 int codeUnitIndex;
 

--- a/unicodetools/src/main/java/org/unicode/idna/Punycode.java
+++ b/unicodetools/src/main/java/org/unicode/idna/Punycode.java
@@ -8,7 +8,6 @@ package org.unicode.idna;
 
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.StringPrepParseException;
-import com.ibm.icu.text.UTF16;
 
 /**
  * Ported code from ICU punycode.c
@@ -158,11 +157,11 @@ public final class Punycode {
                 ++destLength;
             } else {
                 n = ((caseFlags != null && caseFlags[j]) ? 1 : 0) << 31L;
-                if (!UTF16.isSurrogate(c)) {
+                if (!Character.isSurrogate(c)) {
                     n |= c;
-                } else if (UTF16.isLeadSurrogate(c)
+                } else if (Character.isHighSurrogate(c)
                         && (j + 1) < srcLength
-                        && UTF16.isTrailSurrogate(c2 = src.charAt(j + 1))) {
+                        && Character.isLowSurrogate(c2 = src.charAt(j + 1))) {
                     ++j;
 
                     n |= UCharacter.getCodePoint(c, c2);
@@ -454,7 +453,7 @@ public final class Punycode {
                 } else {
                     codeUnitIndex = firstSupplementaryIndex;
                     codeUnitIndex =
-                            UTF16.moveCodePointOffset(
+                            Character.offsetByCodePoints(
                                     dest, 0, destLength, codeUnitIndex, i - codeUnitIndex);
                 }
 
@@ -480,8 +479,8 @@ public final class Punycode {
                     dest[codeUnitIndex] = (char) n;
                 } else {
                     /* supplementary character, insert two code units */
-                    dest[codeUnitIndex] = UTF16.getLeadSurrogate(n);
-                    dest[codeUnitIndex + 1] = UTF16.getTrailSurrogate(n);
+                    dest[codeUnitIndex] = Character.highSurrogate(n);
+                    dest[codeUnitIndex + 1] = Character.lowSurrogate(n);
                 }
                 if (caseFlags != null) {
                     /* Case of last character determines uppercase flag: */

--- a/unicodetools/src/main/java/org/unicode/idna/StringPrepData.java
+++ b/unicodetools/src/main/java/org/unicode/idna/StringPrepData.java
@@ -3,7 +3,6 @@ package org.unicode.idna;
 
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.impl.Utility;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import java.io.BufferedReader;
@@ -60,11 +59,11 @@ public class StringPrepData {
         mappings.putAll(IdnaTypes.OTHER_DOT_SET, ".");
         // special old exceptions
 
-        mappings.put(0x2F868, UTF16.valueOf(0x2136A));
-        mappings.put(0x2F874, UTF16.valueOf(0x5F33));
-        mappings.put(0x2F91F, UTF16.valueOf(0x43AB));
-        mappings.put(0x2F95F, UTF16.valueOf(0x7AAE));
-        mappings.put(0x2F9BF, UTF16.valueOf(0x4D57));
+        mappings.put(0x2F868, Character.toString(0x2136A));
+        mappings.put(0x2F874, Character.toString(0x5F33));
+        mappings.put(0x2F91F, Character.toString(0x43AB));
+        mappings.put(0x2F95F, Character.toString(0x7AAE));
+        mappings.put(0x2F9BF, Character.toString(0x4D57));
 
         types.putAll(IdnaTypes.OTHER_DOT_SET, IdnaType.mapped);
         types.put('.', IdnaType.valid);
@@ -273,7 +272,7 @@ public class StringPrepData {
             }
 
             for (int i = 'A'; i <= 'Z'; ++i) {
-                mappings.put(i, UTF16.valueOf(i - 'A' + 'a'));
+                mappings.put(i, Character.toString(i - 'A' + 'a'));
             }
             // fix up mappings
 

--- a/unicodetools/src/main/java/org/unicode/parse/Pick.java
+++ b/unicodetools/src/main/java/org/unicode/parse/Pick.java
@@ -260,7 +260,7 @@ public abstract class Pick {
         if (newIndex >= newValue.length()) return newIndex;
         int cp = UTF16.charAt(newValue, newIndex);
         if (copy) UTF16.append(mergeBuffer, cp);
-        return newIndex + UTF16.getCharCount(cp);
+        return newIndex + Character.charCount(cp);
     }
 
     /*

--- a/unicodetools/src/main/java/org/unicode/parse/Pick.java
+++ b/unicodetools/src/main/java/org/unicode/parse/Pick.java
@@ -6,7 +6,6 @@
  */
 package org.unicode.parse;
 
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.util.HashSet;
 import java.util.Set;
@@ -253,26 +252,6 @@ public abstract class Pick {
             return toString();
         }
     }
-
-    /* Add character if we can
-     */
-    static int getChar(String newValue, int newIndex, StringBuffer mergeBuffer, boolean copy) {
-        if (newIndex >= newValue.length()) return newIndex;
-        int cp = UTF16.charAt(newValue, newIndex);
-        if (copy) UTF16.append(mergeBuffer, cp);
-        return newIndex + Character.charCount(cp);
-    }
-
-    /*
-            // quoted add
-            appendQuoted(target, addBuffer.toString(), quoteBuffer);
-            // fix buffers
-            StringBuffer swapTemp = addBuffer;
-            addBuffer = source;
-            source = swapTemp;
-        }
-    }
-     */
 
     private static class Literal extends FinalPick {
         public String toString() {

--- a/unicodetools/src/main/java/org/unicode/parse/Tokenizer.java
+++ b/unicodetools/src/main/java/org/unicode/parse/Tokenizer.java
@@ -323,7 +323,7 @@ public class Tokenizer {
     }
 
     private int nextChar() {
-        int cp = UTF16.charAt(source, index);
+        int cp = source.codePointAt(index);
         index += Character.charCount(cp);
         return cp;
     }
@@ -399,7 +399,7 @@ public class Tokenizer {
             int start = pos.getIndex();
             int i;
             for (i = start; i < limit; i += Character.charCount(cp)) {
-                cp = UTF16.charAt(text, i);
+                cp = text.codePointAt(i);
                 if (!com.ibm.icu.lang.UCharacter.isUnicodeIdentifierPart(cp)) {
                     break;
                 }

--- a/unicodetools/src/main/java/org/unicode/parse/Tokenizer.java
+++ b/unicodetools/src/main/java/org/unicode/parse/Tokenizer.java
@@ -213,7 +213,7 @@ public class Tokenizer {
             while (index < source.length()) {
                 cp = nextChar();
                 if (UCharacter.getType(cp) != Character.DECIMAL_DIGIT_NUMBER) {
-                    index -= UTF16.getCharCount(cp); // BACKUP!
+                    index -= Character.charCount(cp); // BACKUP!
                     break;
                 }
                 number *= 10;
@@ -279,7 +279,7 @@ public class Tokenizer {
                 if (UCharacter.isUnicodeIdentifierPart(cp) || cp == '$') {
                     buffer.appendCodePoint(cp);
                 } else if (!UCharacter.isIdentifierIgnorable(cp)) {
-                    index -= UTF16.getCharCount(cp); // BACKUP!
+                    index -= Character.charCount(cp); // BACKUP!
                     break;
                 }
             }
@@ -324,7 +324,7 @@ public class Tokenizer {
 
     private int nextChar() {
         int cp = UTF16.charAt(source, index);
-        index += UTF16.getCharCount(cp);
+        index += Character.charCount(cp);
         return cp;
     }
 
@@ -398,7 +398,7 @@ public class Tokenizer {
             int cp;
             int start = pos.getIndex();
             int i;
-            for (i = start; i < limit; i += UTF16.getCharCount(cp)) {
+            for (i = start; i < limit; i += Character.charCount(cp)) {
                 cp = UTF16.charAt(text, i);
                 if (!com.ibm.icu.lang.UCharacter.isUnicodeIdentifierPart(cp)) {
                     break;

--- a/unicodetools/src/main/java/org/unicode/parse/Tokenizer.java
+++ b/unicodetools/src/main/java/org/unicode/parse/Tokenizer.java
@@ -8,7 +8,6 @@ package org.unicode.parse;
 
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.SymbolTable;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeMatcher;
 import com.ibm.icu.text.UnicodeSet;
 import java.text.ParsePosition;
@@ -241,7 +240,7 @@ public class Tokenizer {
                         } else if (cp == BSLASH) {
                             result = Result.INCOMPLETE_BACKSLASH;
                         } else {
-                            UTF16.append(buffer, cp);
+                            buffer.appendCodePoint(cp);
                         }
                         break;
                     case INCOMPLETE_BACKSLASH:
@@ -258,7 +257,7 @@ public class Tokenizer {
                             default:
                                 break;
                         }
-                        UTF16.append(buffer, cp);
+                        buffer.appendCodePoint(cp);
                         result = Result.UNTERMINATED_QUOTE;
                         break;
                     default:

--- a/unicodetools/src/main/java/org/unicode/props/BagFormatter.java
+++ b/unicodetools/src/main/java/org/unicode/props/BagFormatter.java
@@ -9,7 +9,6 @@ package org.unicode.props;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -773,8 +772,10 @@ public class BagFormatter {
                 return "";
             }
             return " \t("
-                    + showLiteral.transliterate(UTF16.valueOf(start))
-                    + (start == end ? "" : (".." + showLiteral.transliterate(UTF16.valueOf(end))))
+                    + showLiteral.transliterate(Character.toString(start))
+                    + (start == end
+                            ? ""
+                            : (".." + showLiteral.transliterate(Character.toString(end))))
                     + showValue(start, end);
         }
     }

--- a/unicodetools/src/main/java/org/unicode/props/NormalizationDataIUP.java
+++ b/unicodetools/src/main/java/org/unicode/props/NormalizationDataIUP.java
@@ -100,7 +100,7 @@ public class NormalizationDataIUP implements NormalizationData {
                 }
                 isFirst.set(a);
 
-                final int b = UTF16.charAt(s, UTF16.getCharCount(a));
+                final int b = UTF16.charAt(s, Character.charCount(a));
                 isSecond.set(b);
 
                 // have a recomposition, so set the bit
@@ -224,7 +224,7 @@ public class NormalizationDataIUP implements NormalizationData {
             if (s.equals("<code point>") || s.equals(UTF16.valueOf(cp))) {
                 throw new IllegalArgumentException("decomp, but no map, " + Utility.hex(cp));
             }
-            for (int i = 0; i < s.length(); i += UTF16.getCharCount(cp)) {
+            for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
                 cp = UTF16.charAt(s, i);
                 getRecursiveDecomposition(cp, buffer, compat);
             }

--- a/unicodetools/src/main/java/org/unicode/props/NormalizationDataIUP.java
+++ b/unicodetools/src/main/java/org/unicode/props/NormalizationDataIUP.java
@@ -100,7 +100,7 @@ public class NormalizationDataIUP implements NormalizationData {
                 }
                 isFirst.set(a);
 
-                final int b = UTF16.charAt(s, Character.charCount(a));
+                final int b = s.codePointAt(Character.charCount(a));
                 isSecond.set(b);
 
                 // have a recomposition, so set the bit

--- a/unicodetools/src/main/java/org/unicode/props/NormalizationDataIUP.java
+++ b/unicodetools/src/main/java/org/unicode/props/NormalizationDataIUP.java
@@ -221,7 +221,7 @@ public class NormalizationDataIUP implements NormalizationData {
         // if (dt == UCD_Types.CANONICAL || dt > UCD_Types.CANONICAL && compat) {
         if (dt == Decomposition_Type_Values.Canonical || isCompat(dt) && compat) {
             final String s = decompMap.get(cp);
-            if (s.equals("<code point>") || s.equals(UTF16.valueOf(cp))) {
+            if (s.equals("<code point>") || s.equals(Character.toString(cp))) {
                 throw new IllegalArgumentException("decomp, but no map, " + Utility.hex(cp));
             }
             for (int i = 0; i < s.length(); i += Character.charCount(cp)) {

--- a/unicodetools/src/main/java/org/unicode/props/NormalizationDataIUP.java
+++ b/unicodetools/src/main/java/org/unicode/props/NormalizationDataIUP.java
@@ -93,7 +93,7 @@ public class NormalizationDataIUP implements NormalizationData {
                     //                        }
                     continue;
                 }
-                final int a = UTF16.charAt(s, 0);
+                final int a = s.codePointAt(0);
                 // if (ucd.getCombiningClass(a) != 0) {
                 if (ccc.get(a) != 0) {
                     continue;
@@ -225,7 +225,7 @@ public class NormalizationDataIUP implements NormalizationData {
                 throw new IllegalArgumentException("decomp, but no map, " + Utility.hex(cp));
             }
             for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-                cp = UTF16.charAt(s, i);
+                cp = s.codePointAt(i);
                 getRecursiveDecomposition(cp, buffer, compat);
             }
         } else {

--- a/unicodetools/src/main/java/org/unicode/props/PropNormalizationData.java
+++ b/unicodetools/src/main/java/org/unicode/props/PropNormalizationData.java
@@ -107,7 +107,7 @@ public class PropNormalizationData implements org.unicode.text.UCD.Normalization
         String dt = dtp.getValue(cp);
         if (dt.equals("Canonical") || compat && !dt.equals("None")) {
             final String s = dmp.getValue(cp);
-            for (int i = 0; i < s.length(); i += UTF16.getCharCount(cp)) {
+            for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
                 cp = s.codePointAt(i);
                 getRecursiveDecomposition2(cp, compat, dtp, dmp, buffer);
             }
@@ -232,7 +232,7 @@ public class PropNormalizationData implements org.unicode.text.UCD.Normalization
      */
     private void internalDecompose(CharSequence source, StringBuilder target, boolean compat) {
         int ch32;
-        for (int i = 0; i < source.length(); i += UTF16.getCharCount(ch32)) {
+        for (int i = 0; i < source.length(); i += Character.charCount(ch32)) {
             ch32 = Character.codePointAt(source, i);
             String buffer = compat ? nfkd.get(ch32) : nfd.get(ch32);
             if (buffer == null) {
@@ -244,7 +244,7 @@ public class PropNormalizationData implements org.unicode.text.UCD.Normalization
             // no decomposition mapping)
 
             int ch;
-            for (int j = 0; j < buffer.length(); j += UTF16.getCharCount(ch)) {
+            for (int j = 0; j < buffer.length(); j += Character.charCount(ch)) {
                 ch = UTF16.charAt(buffer, j);
                 final int chClass = canonical.getValue(ch);
                 int k = target.length(); // insertion point
@@ -253,7 +253,7 @@ public class PropNormalizationData implements org.unicode.text.UCD.Normalization
                     // bubble-sort combining marks as necessary
 
                     int ch2;
-                    for (; k > 0; k -= UTF16.getCharCount(ch2)) {
+                    for (; k > 0; k -= Character.charCount(ch2)) {
                         ch2 = UTF16.charAt(target, k - 1);
                         if (canonical.getValue(ch2) <= chClass) {
                             break;
@@ -274,7 +274,7 @@ public class PropNormalizationData implements org.unicode.text.UCD.Normalization
     private void internalCompose(StringBuilder target) {
         int starterPos = 0;
         int starterCh = UTF16.charAt(target, 0);
-        int compPos = UTF16.getCharCount(starterCh); // length of last composition
+        int compPos = Character.charCount(starterCh); // length of last composition
         int lastClass = canonical.getValue(starterCh);
         if (lastClass != 0) {
             lastClass = 256; // fix for strings staring with a combining mark
@@ -286,7 +286,7 @@ public class PropNormalizationData implements org.unicode.text.UCD.Normalization
         int ch;
         for (int decompPos = compPos;
                 decompPos < target.length();
-                decompPos += UTF16.getCharCount(ch)) {
+                decompPos += Character.charCount(ch)) {
             ch = UTF16.charAt(target, decompPos);
             if (SHOW_PROGRESS) {
                 System.out.println(
@@ -327,7 +327,7 @@ public class PropNormalizationData implements org.unicode.text.UCD.Normalization
                     decompPos += target.length() - oldLen;
                     oldLen = target.length();
                 }
-                compPos += UTF16.getCharCount(ch);
+                compPos += Character.charCount(ch);
             }
         }
         target.setLength(compPos);

--- a/unicodetools/src/main/java/org/unicode/props/PropNormalizationData.java
+++ b/unicodetools/src/main/java/org/unicode/props/PropNormalizationData.java
@@ -255,7 +255,7 @@ public class PropNormalizationData implements org.unicode.text.UCD.Normalization
 
                     int ch2;
                     for (; k > 0; k -= Character.charCount(ch2)) {
-                        ch2 = UTF16.charAt(target, k - 1);
+                        ch2 = target.codePointBefore(k);
                         if (canonical.getValue(ch2) <= chClass) {
                             break;
                         }

--- a/unicodetools/src/main/java/org/unicode/props/PropNormalizationData.java
+++ b/unicodetools/src/main/java/org/unicode/props/PropNormalizationData.java
@@ -1,7 +1,6 @@
 package org.unicode.props;
 
 import com.ibm.icu.impl.UnicodeMap;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.util.BitSet;
 import java.util.HashMap;
@@ -234,7 +233,7 @@ public class PropNormalizationData implements org.unicode.text.UCD.Normalization
             ch32 = Character.codePointAt(source, i);
             String buffer = compat ? nfkd.get(ch32) : nfd.get(ch32);
             if (buffer == null) {
-                buffer = UTF16.valueOf(ch32);
+                buffer = Character.toString(ch32);
             }
 
             // add all of the characters in the decomposition.
@@ -358,6 +357,6 @@ public class PropNormalizationData implements org.unicode.text.UCD.Normalization
                 }
             }
         }
-        target.replace(offset16, offset16 + count, UTF16.valueOf(char32));
+        target.replace(offset16, offset16 + count, Character.toString(char32));
     }
 }

--- a/unicodetools/src/main/java/org/unicode/props/PropNormalizationData.java
+++ b/unicodetools/src/main/java/org/unicode/props/PropNormalizationData.java
@@ -7,6 +7,7 @@ import java.util.BitSet;
 import java.util.HashMap;
 import org.unicode.props.UcdPropertyValues.Canonical_Combining_Class_Values;
 import org.unicode.text.UCD.NormalizationData;
+import org.unicode.text.utility.UTF16Plus;
 import org.unicode.text.utility.Utility;
 
 public class PropNormalizationData implements org.unicode.text.UCD.NormalizationData {
@@ -63,7 +64,7 @@ public class PropNormalizationData implements org.unicode.text.UCD.Normalization
             } else {
                 final int first = dmpStr.codePointAt(0);
                 if (ce.getValue(cp).equals("Yes")
-                        || UTF16.countCodePoint(dmpStr) == 1
+                        || UTF16Plus.isSingleCodePoint(dmpStr)
                         || canonical.getValue(first) != 0) {
                     // skip
                 } else {

--- a/unicodetools/src/main/java/org/unicode/props/PropNormalizationData.java
+++ b/unicodetools/src/main/java/org/unicode/props/PropNormalizationData.java
@@ -225,9 +225,6 @@ public class PropNormalizationData implements org.unicode.text.UCD.Normalization
     /**
      * Decomposes text, either canonical or compatibility, replacing contents of the target buffer.
      *
-     * @param form the normalization form. If NF_COMPATIBILITY_MASK bit is on in this byte, then
-     *     selects the recursive compatibility decomposition, otherwise selects the recursive
-     *     canonical decomposition.
      * @param source the original text, unnormalized
      * @param target the resulting normalized text
      */
@@ -261,7 +258,7 @@ public class PropNormalizationData implements org.unicode.text.UCD.Normalization
                         }
                     }
                 }
-                target.insert(k, UTF16.valueOf(ch));
+                UTF16Plus.insertCodePoint(target, k, ch);
             }
         }
     }

--- a/unicodetools/src/main/java/org/unicode/props/PropNormalizationData.java
+++ b/unicodetools/src/main/java/org/unicode/props/PropNormalizationData.java
@@ -245,7 +245,7 @@ public class PropNormalizationData implements org.unicode.text.UCD.Normalization
 
             int ch;
             for (int j = 0; j < buffer.length(); j += Character.charCount(ch)) {
-                ch = UTF16.charAt(buffer, j);
+                ch = buffer.codePointAt(j);
                 final int chClass = canonical.getValue(ch);
                 int k = target.length(); // insertion point
                 if (chClass != 0) {
@@ -273,7 +273,7 @@ public class PropNormalizationData implements org.unicode.text.UCD.Normalization
      */
     private void internalCompose(StringBuilder target) {
         int starterPos = 0;
-        int starterCh = UTF16.charAt(target, 0);
+        int starterCh = target.codePointAt(0);
         int compPos = Character.charCount(starterCh); // length of last composition
         int lastClass = canonical.getValue(starterCh);
         if (lastClass != 0) {
@@ -287,7 +287,7 @@ public class PropNormalizationData implements org.unicode.text.UCD.Normalization
         for (int decompPos = compPos;
                 decompPos < target.length();
                 decompPos += Character.charCount(ch)) {
-            ch = UTF16.charAt(target, decompPos);
+            ch = target.codePointAt(decompPos);
             if (SHOW_PROGRESS) {
                 System.out.println(
                         Utility.hex(target)

--- a/unicodetools/src/main/java/org/unicode/props/PropertyLister.java
+++ b/unicodetools/src/main/java/org/unicode/props/PropertyLister.java
@@ -4,7 +4,6 @@ import com.google.common.base.Objects;
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.impl.UnicodeMap.EntryRange;
 import com.ibm.icu.impl.Utility;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ICUUncheckedIOException;
 import java.io.IOException;
@@ -76,16 +75,16 @@ public class PropertyLister {
                     lead = Utility.hex(entry.codepoint);
                     trail =
                             "("
-                                    + UTF16.valueOf(entry.codepoint)
+                                    + Character.toString(entry.codepoint)
                                     + ") "
                                     + iup.getName(entry.codepoint);
                 } else {
                     lead = Utility.hex(entry.codepoint) + ".." + Utility.hex(entry.codepointEnd);
                     trail =
                             "("
-                                    + UTF16.valueOf(entry.codepoint)
+                                    + Character.toString(entry.codepoint)
                                     + ".."
-                                    + UTF16.valueOf(entry.codepointEnd)
+                                    + Character.toString(entry.codepointEnd)
                                     + ") "
                                     + iup.getName(entry.codepoint)
                                     + ".."

--- a/unicodetools/src/main/java/org/unicode/props/RandomStringGenerator.java
+++ b/unicodetools/src/main/java/org/unicode/props/RandomStringGenerator.java
@@ -9,7 +9,6 @@
 package org.unicode.props;
 
 import com.ibm.icu.impl.UnicodeMap;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.util.ArrayList;
 import java.util.List;
@@ -109,7 +108,7 @@ public class RandomStringGenerator {
         for (int i = 0; i < len; ++i) {
             UnicodeSet us = sets[random.nextInt(sets.length)];
             int cp = us.charAt(random.nextInt(us.size()));
-            UTF16.append(result, cp);
+            result.appendCodePoint(cp);
         }
         return result.toString();
     }

--- a/unicodetools/src/main/java/org/unicode/props/ShimUnicodePropertyFactory.java
+++ b/unicodetools/src/main/java/org/unicode/props/ShimUnicodePropertyFactory.java
@@ -3,7 +3,6 @@ package org.unicode.props;
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.impl.locale.XCldrStub.Splitter;
 import com.ibm.icu.text.NumberFormat;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ULocale;
 import java.lang.reflect.Method;
@@ -64,7 +63,7 @@ public class ShimUnicodePropertyFactory extends UnicodeProperty.Factory {
                             replaceCpValues(
                                     prop,
                                     (cp, oldValue) ->
-                                            oldValue == null ? UTF16.valueOf(cp) : oldValue);
+                                            oldValue == null ? Character.toString(cp) : oldValue);
                     break;
                 case "Bidi_Paired_Bracket":
                     // The default is <none> in PropertyValueAliases.txt, but TUP incorrectly

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -1170,7 +1170,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
                 if (DEBUG) System.out.println("\tGetID <" + text.substring(start, limit) + ">");
                 int cp = 0;
                 int i;
-                for (i = start; i < limit; i += UTF16.getCharCount(cp)) {
+                for (i = start; i < limit; i += Character.charCount(cp)) {
                     cp = UTF16.charAt(text, i);
                     if (!com.ibm.icu.lang.UCharacter.isUnicodeIdentifierPart(cp) && cp != '.') {
                         break;

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -35,6 +35,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import org.unicode.cldr.util.Rational.RationalParser;
 import org.unicode.cldr.util.props.UnicodeLabel;
+import org.unicode.text.utility.UTF16Plus;
 
 public abstract class UnicodeProperty extends UnicodeLabel {
 
@@ -1170,8 +1171,10 @@ public abstract class UnicodeProperty extends UnicodeLabel {
                 if (DEBUG) System.out.println("\tGetID <" + text.substring(start, limit) + ">");
                 int cp = 0;
                 int i;
+                UTF16Plus.checkCodePointBoundary(text, start);
+                UTF16Plus.checkCodePointBoundary(text, limit);
                 for (i = start; i < limit; i += Character.charCount(cp)) {
-                    cp = UTF16.charAt(text, i);
+                    cp = text.codePointAt(i);
                     if (!com.ibm.icu.lang.UCharacter.isUnicodeIdentifierPart(cp) && cp != '.') {
                         break;
                     }

--- a/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UnicodeProperty.java
@@ -10,7 +10,6 @@ import com.google.common.base.Splitter;
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.text.SymbolTable;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeMatcher;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
@@ -919,7 +918,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
             return codepoint == other.charAt(0);
         }
         if (other.length() == 2) {
-            return other.equals(UTF16.valueOf(codepoint));
+            return other.equals(Character.toString(codepoint));
         }
         return false;
     }
@@ -1822,7 +1821,7 @@ public abstract class UnicodeProperty extends UnicodeLabel {
     //            setUniformUnassigned(hasUniformUnassigned);
     //        }
     //        protected String _getValue(int codepoint) {
-    //            return transform.transform(UTF16.valueOf(codepoint));
+    //            return transform.transform(Character.toString(codepoint));
     //        }
     //    }
     //

--- a/unicodetools/src/main/java/org/unicode/text/UCA/FractionalUCA.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/FractionalUCA.java
@@ -1221,7 +1221,7 @@ public class FractionalUCA {
 
         showRange("Last", output.summary, lastChr, lastNp);
         // output.summary.println("Last:  " + Utility.hex(lastNp) + ", " +
-        // WriteCollationData.ucd.getCodeAndName(UTF16.charAt(lastChr, 0)));
+        // WriteCollationData.ucd.getCodeAndName(lastChr.codePointAt(0)));
 
         /*
            String sample = "\u3400\u3401\u4DB4\u4DB5\u4E00\u4E01\u9FA4\u9FA5\uAC00\uAC01\uD7A2\uD7A3";

--- a/unicodetools/src/main/java/org/unicode/text/UCA/GenOverlap.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/GenOverlap.java
@@ -413,7 +413,7 @@ public class GenOverlap implements UCD_Types {
             CEList newList = CEList.EMPTY;
             int cp;
             for (int i = 0; i < str.length(); i += Character.charCount(cp)) {
-                cp = UTF16.charAt(str, i);
+                cp = str.codePointAt(i);
                 if (0xFF3F == cp) {
                     System.out.println("debug");
                 }
@@ -637,7 +637,7 @@ public class GenOverlap implements UCD_Types {
                 if (UTF16.countCodePoint(s) != 1) {
                     continue; // skip ligatures
                 }
-                final int cp = UTF16.charAt(s, 0);
+                final int cp = s.codePointAt(0);
                 if (!nfkd.isNormalized(cp)) {
                     continue;
                 }
@@ -735,7 +735,7 @@ public class GenOverlap implements UCD_Types {
             int cp2;
             log.println("<table>");
             for (int j = 0; j < element.length(); j += Character.charCount(cp2)) {
-                cp2 = UTF16.charAt(element, j);
+                cp2 = element.codePointAt(j);
                 final String scp2 = UTF16.valueOf(cp2);
                 final CEList clist = collator.getCEList(scp2, true);
                 log.println(

--- a/unicodetools/src/main/java/org/unicode/text/UCA/GenOverlap.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/GenOverlap.java
@@ -412,7 +412,7 @@ public class GenOverlap implements UCD_Types {
 
             CEList newList = CEList.EMPTY;
             int cp;
-            for (int i = 0; i < str.length(); i += UTF16.getCharCount(cp)) {
+            for (int i = 0; i < str.length(); i += Character.charCount(cp)) {
                 cp = UTF16.charAt(str, i);
                 if (0xFF3F == cp) {
                     System.out.println("debug");
@@ -734,7 +734,7 @@ public class GenOverlap implements UCD_Types {
             // if (UTF16.countCodePoint(latin[i]) < 2) continue;
             int cp2;
             log.println("<table>");
-            for (int j = 0; j < element.length(); j += UTF16.getCharCount(cp2)) {
+            for (int j = 0; j < element.length(); j += Character.charCount(cp2)) {
                 cp2 = UTF16.charAt(element, j);
                 final String scp2 = UTF16.valueOf(cp2);
                 final CEList clist = collator.getCEList(scp2, true);

--- a/unicodetools/src/main/java/org/unicode/text/UCA/GenOverlap.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/GenOverlap.java
@@ -9,7 +9,6 @@
  */
 package org.unicode.text.UCA;
 
-import com.ibm.icu.text.UTF16;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.BitSet;
@@ -53,7 +52,7 @@ public class GenOverlap implements UCD_Types {
             if (decompType >= UCD_Types.COMPATIBILITY) {
                 final String decomp = nfkd.normalize(cp);
                 final CEList celistDecomp = getCEList(cp, decomp, true, decompType);
-                final CEList celistNormal = getCEList(UTF16.valueOf(cp), false);
+                final CEList celistNormal = getCEList(Character.toString(cp), false);
                 if (!celistNormal.equals(celistDecomp)) {
                     Utility.fixDot();
                     System.out.println();
@@ -449,7 +448,7 @@ public class GenOverlap implements UCD_Types {
                         }
                     }
                 } else {
-                    len = collator.getCEs(UTF16.valueOf(cp), true, ces);
+                    len = collator.getCEs(Character.toString(cp), true, ces);
                 }
                 final CEList inc = new CEList(ces, 0, len);
 
@@ -681,7 +680,7 @@ public class GenOverlap implements UCD_Types {
                 continue; // don't count case
             }
 
-            final String scp = UTF16.valueOf(cp);
+            final String scp = Character.toString(cp);
             final int len = collator.getCEs(scp, true, ces);
             final int script = ucd.getScript(cp);
 
@@ -737,7 +736,7 @@ public class GenOverlap implements UCD_Types {
             log.println("<table>");
             for (int j = 0; j < element.length(); j += Character.charCount(cp2)) {
                 cp2 = element.codePointAt(j);
-                final String scp2 = UTF16.valueOf(cp2);
+                final String scp2 = Character.toString(cp2);
                 final CEList clist = collator.getCEList(scp2, true);
                 log.println(
                         "<tr><td>"

--- a/unicodetools/src/main/java/org/unicode/text/UCA/GenOverlap.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/GenOverlap.java
@@ -23,6 +23,7 @@ import org.unicode.text.UCD.Normalizer;
 import org.unicode.text.UCD.UCD;
 import org.unicode.text.UCD.UCD_Types;
 import org.unicode.text.utility.Pair;
+import org.unicode.text.utility.UTF16Plus;
 import org.unicode.text.utility.Utility;
 
 public class GenOverlap implements UCD_Types {
@@ -634,7 +635,7 @@ public class GenOverlap implements UCD_Types {
                     break;
                 }
 
-                if (UTF16.countCodePoint(s) != 1) {
+                if (!UTF16Plus.isSingleCodePoint(s)) {
                     continue; // skip ligatures
                 }
                 final int cp = s.codePointAt(0);

--- a/unicodetools/src/main/java/org/unicode/text/UCA/Main.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/Main.java
@@ -12,7 +12,6 @@ package org.unicode.text.UCA;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UCharacterEnums.ECharacterCategory;
 import com.ibm.icu.text.CanonicalIterator;
-import com.ibm.icu.text.UTF16;
 import org.unicode.text.UCA.UCA.CollatorType;
 import org.unicode.text.UCD.Default;
 import org.unicode.text.utility.Utility;
@@ -265,7 +264,7 @@ public class Main {
                     || cat == ECharacterCategory.SURROGATE) {
                 continue;
             }
-            final String s = UTF16.valueOf(i);
+            final String s = Character.toString(i);
             try {
                 it.setSource(s);
             } catch (final RuntimeException e) {

--- a/unicodetools/src/main/java/org/unicode/text/UCA/MakeNamesChart.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/MakeNamesChart.java
@@ -1,7 +1,6 @@
 package org.unicode.text.UCA;
 
 import com.ibm.icu.text.Collator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import com.ibm.icu.util.ULocale;
@@ -503,7 +502,7 @@ public class MakeNamesChart {
         if (lastDecompType != UCD_Types.NONE) {
             System.out.println("Alert: missing decomp for " + Utility.hex(lastCodePoint));
         }
-        final String str = UTF16.valueOf(lastCodePoint);
+        final String str = Character.toString(lastCodePoint);
         final String upper =
                 showForm(
                         out,
@@ -754,7 +753,7 @@ public class MakeNamesChart {
         if (type == UCD_Types.Cn || type == UCD_Types.Co || type == UCD_Types.Cs) {
             return "\u2588";
         }
-        String result = TransliteratorUtilities.toHTML.transliterate(UTF16.valueOf(cp));
+        String result = TransliteratorUtilities.toHTML.transliterate(Character.toString(cp));
         if (type == UCD_Types.Me || type == UCD_Types.Mn) {
             result = "\u25CC" + result;
         } else if (addRlmIfNeeded && rtl.contains(cp)) {
@@ -783,9 +782,9 @@ public class MakeNamesChart {
             hexed2 += " " + Default.ucd().getName(lastDecomp).toLowerCase();
         }
         if (hexed.equalsIgnoreCase(body)) {
-            hasNoNameCan.put(lastDecomp, UTF16.valueOf(codePoint));
+            hasNoNameCan.put(lastDecomp, Character.toString(codePoint));
         } else if (hexed2.equalsIgnoreCase(body)) {
-            hasNameCan.put(lastDecomp, UTF16.valueOf(codePoint));
+            hasNameCan.put(lastDecomp, Character.toString(codePoint));
         } else {
             System.out.println(
                     "Mismatching Decomposition: " + body + " in " + Utility.hex(codePoint));
@@ -812,9 +811,9 @@ public class MakeNamesChart {
             hexed2 += " " + Default.ucd().getName(lastDecomp).toLowerCase();
         }
         if (hexed.equalsIgnoreCase(body)) {
-            hasNoNameComp.put(lastDecomp, UTF16.valueOf(codePoint));
+            hasNoNameComp.put(lastDecomp, Character.toString(codePoint));
         } else if (hexed2.equalsIgnoreCase(body)) {
-            hasNameComp.put(lastDecomp, UTF16.valueOf(codePoint));
+            hasNameComp.put(lastDecomp, Character.toString(codePoint));
         } else {
             System.out.println(
                     "Mismatching Decomposition: " + body + " in " + Utility.hex(codePoint));

--- a/unicodetools/src/main/java/org/unicode/text/UCA/MakeNamesChart.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/MakeNamesChart.java
@@ -28,6 +28,7 @@ import org.unicode.text.UCD.ToolUnicodePropertySource;
 import org.unicode.text.UCD.UCD;
 import org.unicode.text.UCD.UCD_Types;
 import org.unicode.text.utility.Settings;
+import org.unicode.text.utility.UTF16Plus;
 import org.unicode.text.utility.Utility;
 import org.unicode.text.utility.UtilityBase;
 
@@ -582,7 +583,7 @@ public class MakeNamesChart {
                             + symbol
                             + "</td><td>"
                             + showTextConvertingHex(Utility.hex(transformed, 4, " + "), true)
-                            + (UTF16.countCodePoint(transformed) != 1
+                            + (!UTF16Plus.isSingleCodePoint(transformed)
                                     ? ""
                                     : " "
                                             + Default.ucd()
@@ -778,7 +779,7 @@ public class MakeNamesChart {
         final String lastDecomp = Default.ucd().getDecompositionMapping(lastCodePoint);
         final String hexed = Utility.hex(lastDecomp, 4, " ");
         String hexed2 = hexed;
-        if (UTF16.countCodePoint(lastDecomp) == 1) {
+        if (UTF16Plus.isSingleCodePoint(lastDecomp)) {
             hexed2 += " " + Default.ucd().getName(lastDecomp).toLowerCase();
         }
         if (hexed.equalsIgnoreCase(body)) {
@@ -807,7 +808,7 @@ public class MakeNamesChart {
             hexed = "<" + lastDecompID + "> " + hexed;
         }
         String hexed2 = hexed;
-        if (UTF16.countCodePoint(lastDecomp) == 1) {
+        if (UTF16Plus.isSingleCodePoint(lastDecomp)) {
             hexed2 += " " + Default.ucd().getName(lastDecomp).toLowerCase();
         }
         if (hexed.equalsIgnoreCase(body)) {

--- a/unicodetools/src/main/java/org/unicode/text/UCA/MappingsForFractionalUCA.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/MappingsForFractionalUCA.java
@@ -1,7 +1,6 @@
 package org.unicode.text.UCA;
 
 import com.ibm.icu.text.CanonicalIterator;
-import com.ibm.icu.text.UTF16;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -157,7 +156,7 @@ public final class MappingsForFractionalUCA {
      * <p>This method also adds canonical equivalents (canonical closure), if any are missing.
      */
     private SortedSet<MappingWithSortKey> getSortedUCAMappings() {
-        final String highCompat = UTF16.valueOf(0x2F805);
+        final String highCompat = Character.toString(0x2F805);
 
         System.out.println("Sorting");
         final SortedSet<MappingWithSortKey> ordered = new TreeSet<MappingWithSortKey>();
@@ -211,7 +210,7 @@ public final class MappingsForFractionalUCA {
             if (UCD.isHangulSyllable(i)) {
                 continue;
             }
-            final String s = UTF16.valueOf(i);
+            final String s = Character.toString(i);
             if (!contentsForCanonicalIteration.contains(s)) {
                 contentsForCanonicalIteration.add(s);
                 ordered.add(new MappingWithSortKey(uca, s));
@@ -289,7 +288,7 @@ public final class MappingsForFractionalUCA {
                if (type >= UCA.FIXED_CE && !nfd.hasDecomposition(ch))
                    continue;
                }
-               String s = org.unicode.text.UTF16.valueOf(ch);
+               String s = org.unicode.text.Character.toString(ch);
                ordered.put(collator.getSortKey(s, UCA.NON_IGNORABLE) + '\u0000' + s, s);
            }
 

--- a/unicodetools/src/main/java/org/unicode/text/UCA/PrimariesToFractional.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/PrimariesToFractional.java
@@ -1,6 +1,5 @@
 package org.unicode.text.UCA;
 
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import java.util.BitSet;
@@ -1360,7 +1359,7 @@ public final class PrimariesToFractional {
     }
 
     private void setTwoBytePrimaryFor(int minPrimary, int ch) {
-        final CEList ces = uca.getCEList(UTF16.valueOf(ch), true);
+        final CEList ces = uca.getCEList(Character.toString(ch), true);
         if (ces != null && ces.length() != 0) {
             final int firstPrimary = CEList.getPrimary(ces.at(0));
             if (minPrimary <= firstPrimary && firstPrimary < Implicit.CJK_BASE) {

--- a/unicodetools/src/main/java/org/unicode/text/UCA/TestCompatibilityCharacters.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/TestCompatibilityCharacters.java
@@ -1,6 +1,5 @@
 package org.unicode.text.UCA;
 
-import com.ibm.icu.text.UTF16;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -152,7 +151,7 @@ public final class TestCompatibilityCharacters {
             final String d = Default.nfd().normalize(cp); // TODO
             int cp1;
             for (int i = 0; i < d.length(); i += Character.charCount(cp1)) {
-                cp1 = UTF16.charAt(d, i);
+                cp1 = d.codePointAt(i);
                 final byte t = Default.ucd().getDecompositionType(cp1);
                 if (t > UCD_Types.CANONICAL) {
                     return t;
@@ -215,7 +214,7 @@ public final class TestCompatibilityCharacters {
 
     private static int fixCompatibilityCE(
             UCA uca, String s, boolean decompose, int[] output, boolean compress) {
-        final byte type = getDecompType(UTF16.charAt(s, 0));
+        final byte type = getDecompType(s.codePointAt(0));
         // char ch = s.charAt(0);
 
         final String decomp = Default.nfkd().normalize(s);

--- a/unicodetools/src/main/java/org/unicode/text/UCA/TestCompatibilityCharacters.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/TestCompatibilityCharacters.java
@@ -151,7 +151,7 @@ public final class TestCompatibilityCharacters {
         if (result == UCD_Types.CANONICAL) {
             final String d = Default.nfd().normalize(cp); // TODO
             int cp1;
-            for (int i = 0; i < d.length(); i += UTF16.getCharCount(cp1)) {
+            for (int i = 0; i < d.length(); i += Character.charCount(cp1)) {
                 cp1 = UTF16.charAt(d, i);
                 final byte t = Default.ucd().getDecompositionType(cp1);
                 if (t > UCD_Types.CANONICAL) {

--- a/unicodetools/src/main/java/org/unicode/text/UCA/UCA.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/UCA.java
@@ -625,7 +625,7 @@ public final class UCA implements Comparator<String> {
         StringBuilder target = new StringBuilder();
         int cp;
         for (int i = 0; i < source.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(source, i);
+            cp = Character.codePointAt(source, i);
             if (cp <= 2) {
                 // Avoid collision with level separator 0 and merge separator 1:
                 // 00 -> 02 02
@@ -1055,7 +1055,7 @@ public final class UCA implements Comparator<String> {
                         final String decomp = nfkd.normalize(i);
                         int cp2;
                         for (int j = 0; j < decomp.length(); j += Character.charCount(cp2)) {
-                            cp2 = UTF16.charAt(decomp, j);
+                            cp2 = decomp.codePointAt(j);
                             if (!getStatistics().unspecified.contains(cp2)) {
                                 temp.add(cp2);
                             }

--- a/unicodetools/src/main/java/org/unicode/text/UCA/UCA.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/UCA.java
@@ -624,7 +624,7 @@ public final class UCA implements Comparator<String> {
     public static String codePointOrder(CharSequence source) {
         StringBuilder target = new StringBuilder();
         int cp;
-        for (int i = 0; i < source.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < source.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(source, i);
             if (cp <= 2) {
                 // Avoid collision with level separator 0 and merge separator 1:
@@ -1054,7 +1054,7 @@ public final class UCA implements Comparator<String> {
                     if (!nfkd.isNormalized(i)) {
                         final String decomp = nfkd.normalize(i);
                         int cp2;
-                        for (int j = 0; j < decomp.length(); j += UTF16.getCharCount(cp2)) {
+                        for (int j = 0; j < decomp.length(); j += Character.charCount(cp2)) {
                             cp2 = UTF16.charAt(decomp, j);
                             if (!getStatistics().unspecified.contains(cp2)) {
                                 temp.add(cp2);

--- a/unicodetools/src/main/java/org/unicode/text/UCA/UCA.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/UCA.java
@@ -1079,7 +1079,7 @@ public final class UCA implements Comparator<String> {
                 if (usi.codepoint == UnicodeSetIterator.IS_STRING) {
                     result = usi.string;
                 } else {
-                    result = UTF16.valueOf(usi.codepoint);
+                    result = Character.toString(usi.codepoint);
                 }
                 if (DEBUG) {
                     System.out.println("Unspecified: " + ucd.getCodeAndName(result));
@@ -1100,7 +1100,7 @@ public final class UCA implements Comparator<String> {
             // extra samples
             if (currentRange < SAMPLE_RANGES.length) {
                 try {
-                    result = UTF16.valueOf(itemInRange);
+                    result = Character.toString(itemInRange);
                 } catch (final RuntimeException e) {
                     System.out.println(Utility.hex(itemInRange));
                     throw e;

--- a/unicodetools/src/main/java/org/unicode/text/UCA/UCA.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/UCA.java
@@ -9,7 +9,6 @@
  */
 package org.unicode.text.UCA;
 
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import java.io.BufferedReader;
@@ -1519,8 +1518,8 @@ public final class UCA implements Comparator<String> {
                 return (char) cp;
             }
             // DEBUGCHAR = true;
-            charBuffer = UTF16.getTrailSurrogate(cp);
-            return UTF16.getLeadSurrogate(cp);
+            charBuffer = Character.lowSurrogate(cp);
+            return Character.highSurrogate(cp);
         }
 
         return UCA_Types.NOT_A_CHAR;

--- a/unicodetools/src/main/java/org/unicode/text/UCA/Validity.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/Validity.java
@@ -473,7 +473,7 @@ final class Validity {
 
             String sortKey =
                     uca.getSortKey(
-                            UTF16.valueOf(ch),
+                            Character.toString(ch),
                             UCA_Types.Alternate.NON_IGNORABLE,
                             decomposition,
                             AppendToCe.none);
@@ -1525,9 +1525,9 @@ final class Validity {
                                     + typeAndString.getKey()
                                     + "</td>"
                                     + "<td>"
-                                    + UTF16.valueOf(it.codepoint)
+                                    + Character.toString(it.codepoint)
                                     + "…"
-                                    + UTF16.valueOf(it.codepointEnd)
+                                    + Character.toString(it.codepointEnd)
                                     + "</td>"
                                     + "<td>"
                                     + Utility.hex(it.codepoint)
@@ -1547,7 +1547,7 @@ final class Validity {
                                     + typeAndString.getKey()
                                     + "</td>"
                                     + "<td>"
-                                    + UTF16.valueOf(it.codepoint)
+                                    + Character.toString(it.codepoint)
                                     + "</td>"
                                     + "<td>"
                                     + Utility.hex(it.codepoint)

--- a/unicodetools/src/main/java/org/unicode/text/UCA/Validity.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/Validity.java
@@ -212,7 +212,7 @@ final class Validity {
         final String canDecomp = Default.nfd().normalize(cp);
         String result = "";
         int ch;
-        for (int j = 0; j < canDecomp.length(); j += UTF16.getCharCount(ch)) {
+        for (int j = 0; j < canDecomp.length(); j += Character.charCount(ch)) {
             ch = UTF16.charAt(canDecomp, j);
             System.out.println("* " + Default.ucd().getCodeAndName(ch));
             final String newSortKey = remapCanSortKey(ch, decomposition);

--- a/unicodetools/src/main/java/org/unicode/text/UCA/Validity.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/Validity.java
@@ -31,6 +31,7 @@ import org.unicode.text.UCD.ToolUnicodePropertySource;
 import org.unicode.text.UCD.UCD;
 import org.unicode.text.UCD.UCD_Types;
 import org.unicode.text.utility.Pair;
+import org.unicode.text.utility.UTF16Plus;
 import org.unicode.text.utility.Utility;
 
 final class Validity {
@@ -303,7 +304,7 @@ final class Validity {
             if (!Default.nfd().isNormalized(s)) {
                 continue; // only unnormalized stuff
             }
-            if (UTF16.countCodePoint(s) == 1) {
+            if (UTF16Plus.isSingleCodePoint(s)) {
                 final int cat = Default.ucd().getCategory(s.codePointAt(0));
                 if (cat == UCD_Types.Cn || cat == UCD_Types.Cc || cat == UCD_Types.Cs) {
                     continue;

--- a/unicodetools/src/main/java/org/unicode/text/UCA/Validity.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/Validity.java
@@ -213,7 +213,7 @@ final class Validity {
         String result = "";
         int ch;
         for (int j = 0; j < canDecomp.length(); j += Character.charCount(ch)) {
-            ch = UTF16.charAt(canDecomp, j);
+            ch = canDecomp.codePointAt(j);
             System.out.println("* " + Default.ucd().getCodeAndName(ch));
             final String newSortKey = remapCanSortKey(ch, decomposition);
             System.out.println("* " + UCA.toString(newSortKey));
@@ -304,7 +304,7 @@ final class Validity {
                 continue; // only unnormalized stuff
             }
             if (UTF16.countCodePoint(s) == 1) {
-                final int cat = Default.ucd().getCategory(UTF16.charAt(s, 0));
+                final int cat = Default.ucd().getCategory(s.codePointAt(0));
                 if (cat == UCD_Types.Cn || cat == UCD_Types.Cc || cat == UCD_Types.Cs) {
                     continue;
                 }

--- a/unicodetools/src/main/java/org/unicode/text/UCA/WriteCharts.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/WriteCharts.java
@@ -921,7 +921,7 @@ public class WriteCharts implements UCD_Types {
     static short getBestScript(String s) {
         int cp;
         short result = COMMON_SCRIPT;
-        for (int i = 0; i < s.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(s, i);
             result = Default.ucd().getScript(cp);
             if (result != COMMON_SCRIPT && result != INHERITED_SCRIPT) {
@@ -1259,7 +1259,7 @@ public class WriteCharts implements UCD_Types {
 
     static boolean containsCase(String s) {
         int cp;
-        for (int i = 0; i < s.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(s, i);
             // contains Lu, Lo, Lt, or Lowercase or Uppercase
             final byte cat = Default.ucd().getCategory(cp);
@@ -1364,7 +1364,7 @@ public class WriteCharts implements UCD_Types {
                     }
 
                     // pick up all decompositions
-                    int count = UTF16.getCharCount(UTF16.charAt(decomp, 0));
+                    int count = Character.charCount(UTF16.charAt(decomp, 0));
 
                     if (count == decomp.length()) {
                         notPrinted.add(source);

--- a/unicodetools/src/main/java/org/unicode/text/UCA/WriteCharts.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/WriteCharts.java
@@ -1423,7 +1423,7 @@ public class WriteCharts implements UCD_Types {
                             }
                             // skip unless single char or header
                             /*if (let.length() != 0
-                                && (UTF16.countCodePoint(comp) != 1 || comp.equals(merge))) {
+                                && (!UTF16Plus.isSingleCodePoint(comp) || comp.equals(merge))) {
                                     out.println("<td class='x'>&nbsp;</td>");
                                     continue;
                             }

--- a/unicodetools/src/main/java/org/unicode/text/UCA/WriteCharts.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/WriteCharts.java
@@ -854,7 +854,7 @@ public class WriteCharts implements UCD_Types {
         }
         final String name = Default.ucd().getName(s);
         String comp = Default.nfc().normalize(s);
-        final int cat = Default.ucd().getCategory(UTF16.charAt(comp, 0));
+        final int cat = Default.ucd().getCategory(comp.codePointAt(0));
         if (cat == Mn || cat == Mc || cat == Me) {
             comp = '\u25CC' + comp;
             if (s.equals("\u0300")) {
@@ -885,7 +885,7 @@ public class WriteCharts implements UCD_Types {
         //        }
 
         String comp = Default.nfc().normalize(s);
-        final int cat = Default.ucd().getCategory(UTF16.charAt(comp, 0));
+        final int cat = Default.ucd().getCategory(comp.codePointAt(0));
         if (cat == Mn || cat == Mc || cat == Me) {
             comp = '\u25CC' + comp;
             if (s.equals("\u0300")) {
@@ -922,7 +922,7 @@ public class WriteCharts implements UCD_Types {
         int cp;
         short result = COMMON_SCRIPT;
         for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(s, i);
+            cp = s.codePointAt(i);
             result = Default.ucd().getScript(cp);
             if (result != COMMON_SCRIPT && result != INHERITED_SCRIPT) {
                 return result;
@@ -1260,7 +1260,7 @@ public class WriteCharts implements UCD_Types {
     static boolean containsCase(String s) {
         int cp;
         for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(s, i);
+            cp = s.codePointAt(i);
             // contains Lu, Lo, Lt, or Lowercase or Uppercase
             final byte cat = Default.ucd().getCategory(cp);
             if (cat == Lu || cat == Ll || cat == Lt) {
@@ -1364,7 +1364,7 @@ public class WriteCharts implements UCD_Types {
                     }
 
                     // pick up all decompositions
-                    int count = Character.charCount(UTF16.charAt(decomp, 0));
+                    int count = Character.charCount(decomp.codePointAt(0));
 
                     if (count == decomp.length()) {
                         notPrinted.add(source);

--- a/unicodetools/src/main/java/org/unicode/text/UCA/WriteCharts.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/WriteCharts.java
@@ -382,7 +382,7 @@ public class WriteCharts implements UCD_Types {
             output.println("<tr>");
 
             String prefix;
-            final String code = UTF16.valueOf(cp);
+            final String code = Character.toString(cp);
             final String c = Default.nfc().normalize(cp);
             final String d = Default.nfd().normalize(cp);
             final String kc = Default.nfkc().normalize(cp);
@@ -424,7 +424,7 @@ public class WriteCharts implements UCD_Types {
                 continue;
             }
 
-            final String code = UTF16.valueOf(i);
+            final String code = Character.toString(i);
             final String lower = Default.ucd().getCase(i, FULL, LOWER);
             final String title = Default.ucd().getCase(i, FULL, TITLE);
             final String upper = Default.ucd().getCase(i, FULL, UPPER);
@@ -528,14 +528,14 @@ public class WriteCharts implements UCD_Types {
                     output.println("</tr><tr>");
                     columnCount = 0;
                 }
-                showCell(output, UTF16.valueOf(cp), "", "", false);
+                showCell(output, Character.toString(cp), "", "", false);
                 ++columnCount;
                 continue;
             }
 
             output.println("<tr>");
 
-            final String code = UTF16.valueOf(cp);
+            final String code = Character.toString(cp);
             final String lower = Default.ucd().getCase(cp, FULL, LOWER);
             final String title = Default.ucd().getCase(cp, FULL, TITLE);
             final String upper = Default.ucd().getCase(cp, FULL, UPPER);
@@ -653,7 +653,7 @@ public class WriteCharts implements UCD_Types {
                 output.println("</tr><tr>");
                 columnCount = 0;
             }
-            showCell(output, UTF16.valueOf(cp), "", "", false);
+            showCell(output, Character.toString(cp), "", "", false);
             ++columnCount;
         }
         output.println("</tr>");
@@ -719,7 +719,7 @@ public class WriteCharts implements UCD_Types {
             if (s.startsWith("<")) {
                 System.out.println("Weird character at " + Default.ucd().getCodeAndName(i));
             }
-            final String ch = UTF16.valueOf(i);
+            final String ch = Character.toString(i);
             int last = -1;
             int j;
             for (j = 0; j < s.length(); ++j) {
@@ -1357,7 +1357,7 @@ public class WriteCharts implements UCD_Types {
                         continue;
                     }
 
-                    final String source = UTF16.valueOf(cp);
+                    final String source = Character.toString(cp);
                     final String decomp = Default.nfd().normalize(source);
                     if (decomp.equals(source)) {
                         continue;
@@ -1464,7 +1464,7 @@ public class WriteCharts implements UCD_Types {
             it.reset(markSet);
             while (it.next()) {
                 final int cp = it.codepoint;
-                final String source = UTF16.valueOf(cp);
+                final String source = Character.toString(cp);
                 if (totalMarks.contains(source)) {
                     continue; // skip all that we have already
                 }

--- a/unicodetools/src/main/java/org/unicode/text/UCA/WriteCollationData.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/WriteCollationData.java
@@ -747,7 +747,7 @@ public class WriteCollationData {
             Utility.dot(i);
             final String decomp = Default.nfkd().normalize(i);
             int cp;
-            for (int j = 0; j < decomp.length(); j += UTF16.getCharCount(cp)) {
+            for (int j = 0; j < decomp.length(); j += Character.charCount(cp)) {
                 cp = UTF16.charAt(decomp, j);
                 final String s = UTF16.valueOf(cp);
                 if (alreadyDone.contains(s)) {
@@ -1679,7 +1679,7 @@ public class WriteCollationData {
         boolean noQuotes = true;
         boolean inQuote = false;
         int cp;
-        for (int i = 0; i < s.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(s, i);
             if (!needsQuoting.contains(cp)) {
                 if (inQuote) {

--- a/unicodetools/src/main/java/org/unicode/text/UCA/WriteCollationData.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/WriteCollationData.java
@@ -387,7 +387,7 @@ public class WriteCollationData {
 
             int ccc;
             for (int kk = 0; kk < s.length(); kk += Character.charCount(ccc)) {
-                ccc = UTF16.charAt(s, kk);
+                ccc = s.codePointAt(kk);
                 final byte cat = Default.ucd().getCategory(ccc);
                 if (cat == UCD_Types.Cf
                         || cat == UCD_Types.Cc
@@ -748,7 +748,7 @@ public class WriteCollationData {
             final String decomp = Default.nfkd().normalize(i);
             int cp;
             for (int j = 0; j < decomp.length(); j += Character.charCount(cp)) {
-                cp = UTF16.charAt(decomp, j);
+                cp = decomp.codePointAt(j);
                 final String s = UTF16.valueOf(cp);
                 if (alreadyDone.contains(s)) {
                     continue;
@@ -1680,7 +1680,7 @@ public class WriteCollationData {
         boolean inQuote = false;
         int cp;
         for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(s, i);
+            cp = s.codePointAt(i);
             if (!needsQuoting.contains(cp)) {
                 if (inQuote) {
                     quoteOperandBuffer.append('\'');

--- a/unicodetools/src/main/java/org/unicode/text/UCA/WriteCollationData.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/WriteCollationData.java
@@ -9,7 +9,6 @@
  */
 package org.unicode.text.UCA;
 
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.io.BufferedReader;
 import java.io.File;
@@ -749,7 +748,7 @@ public class WriteCollationData {
             int cp;
             for (int j = 0; j < decomp.length(); j += Character.charCount(cp)) {
                 cp = decomp.codePointAt(j);
-                final String s = UTF16.valueOf(cp);
+                final String s = Character.toString(cp);
                 if (alreadyDone.contains(s)) {
                     continue;
                 }
@@ -1002,10 +1001,10 @@ public class WriteCollationData {
                             uca.implicit.codePointForPrimaryPair(
                                     primary, CEList.getPrimary(ces.at(1)));
 
-                    final CEList ces2 = uca.getCEList(UTF16.valueOf(resetCp), true);
+                    final CEList ces2 = uca.getCEList(Character.toString(resetCp), true);
                     relation = getStrengthDifference(ces, ces.length(), ces2, ces2.length());
 
-                    reset = quoteOperand(UTF16.valueOf(resetCp));
+                    reset = quoteOperand(Character.toString(resetCp));
                     if (!shortPrint) {
                         resetComment = Default.ucd().getCodeAndName(resetCp);
                     }
@@ -1606,7 +1605,7 @@ public class WriteCollationData {
                         int c =
                                 ducet.implicit.codePointForPrimaryPair(
                                         CEList.getPrimary(probe), CEList.getPrimary(nextCE));
-                        s = UTF16.valueOf(c);
+                        s = Character.toString(c);
                         ++i; // skip over trail primary
                         break;
                     }
@@ -1686,7 +1685,7 @@ public class WriteCollationData {
                     quoteOperandBuffer.append('\'');
                     inQuote = false;
                 }
-                quoteOperandBuffer.append(UTF16.valueOf(cp));
+                quoteOperandBuffer.append(Character.toString(cp));
             } else {
                 noQuotes = false;
                 if (cp == '\'') {
@@ -1697,14 +1696,14 @@ public class WriteCollationData {
                         inQuote = true;
                     }
                     if (!needsUnicodeForm.contains(cp)) {
-                        quoteOperandBuffer.append(UTF16.valueOf(cp)); // cp !=
+                        quoteOperandBuffer.append(Character.toString(cp)); // cp !=
                         // 0x2028
                     } else if (cp > 0xFFFF) {
                         quoteOperandBuffer.append("\\U").append(Utility.hex(cp, 8));
                     } else if (cp <= 0x20 || cp > 0x7E) {
                         quoteOperandBuffer.append("\\u").append(Utility.hex(cp));
                     } else {
-                        quoteOperandBuffer.append(UTF16.valueOf(cp));
+                        quoteOperandBuffer.append(Character.toString(cp));
                     }
                 }
             }

--- a/unicodetools/src/main/java/org/unicode/text/UCA/WriteConformanceTest.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/WriteConformanceTest.java
@@ -326,7 +326,7 @@ public class WriteConformanceTest {
         }
         if (UTF16.hasMoreCodePointsThan(s, 1)) {
             for (int i = 1; i < s.length(); ++i) {
-                if (UTF16.isLeadSurrogate(s.charAt(i - 1))) {
+                if (Character.isHighSurrogate(s.charAt(i - 1))) {
                     continue; // skip if in middle of supplementary
                 }
 

--- a/unicodetools/src/main/java/org/unicode/text/UCA/WriteConformanceTest.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCA/WriteConformanceTest.java
@@ -27,7 +27,7 @@ public class WriteConformanceTest {
 
     private static final char LOW_ACCENT = '\u0334';
 
-    private static final String SUPPLEMENTARY_ACCENT = UTF16.valueOf(0x1D165);
+    private static final String SUPPLEMENTARY_ACCENT = Character.toString(0x1D165);
     private static final String COMPLETELY_IGNOREABLE = "\u0001";
     private static final String COMPLETELY_IGNOREABLE_ACCENT = "\u0591";
     private static final String[] CONTRACTION_TEST = {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/BuildNames.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/BuildNames.java
@@ -187,7 +187,7 @@ public class BuildNames implements UCD_Types {
             }
 
             int cp2;
-            for (int i = 0; i < str.length(); i += UTF16.getCharCount(cp2)) {
+            for (int i = 0; i < str.length(); i += Character.charCount(cp2)) {
                 cp2 = UTF16.charAt(str, i);
                 name = Default.ucd().getName(cp2, SHORT);
                 if (name == null) {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/BuildNames.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/BuildNames.java
@@ -188,7 +188,7 @@ public class BuildNames implements UCD_Types {
 
             int cp2;
             for (int i = 0; i < str.length(); i += Character.charCount(cp2)) {
-                cp2 = UTF16.charAt(str, i);
+                cp2 = str.codePointAt(i);
                 name = Default.ucd().getName(cp2, SHORT);
                 if (name == null) {
                     continue;

--- a/unicodetools/src/main/java/org/unicode/text/UCD/BuildNames.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/BuildNames.java
@@ -9,7 +9,6 @@
  */
 package org.unicode.text.UCD;
 
-import com.ibm.icu.text.UTF16;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.HashMap;
@@ -181,7 +180,7 @@ public class BuildNames implements UCD_Types {
 
             // check the string, and its decomposition. This is just to get a good count.
 
-            String str = UTF16.valueOf(cp);
+            String str = Character.toString(cp);
             if (false && !Default.nfkd().isNormalized(cp)) {
                 str += Default.nfkd().normalize(cp);
             }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/ChineseFrequency.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/ChineseFrequency.java
@@ -2,7 +2,6 @@ package org.unicode.text.UCD;
 
 import com.ibm.icu.text.DecimalFormat;
 import com.ibm.icu.text.NumberFormat;
-import com.ibm.icu.text.UTF16;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -80,7 +79,7 @@ public class ChineseFrequency {
                             + "\t"
                             + Integer.toHexString(cp.intValue()).toUpperCase()
                             + "\t"
-                            + UTF16.valueOf(cp.intValue()));
+                            + Character.toString(cp.intValue()));
         }
         // pw.println("Grand total: " + (long)grandTotal);
         pw.close();

--- a/unicodetools/src/main/java/org/unicode/text/UCD/ConvertUCD.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/ConvertUCD.java
@@ -9,7 +9,6 @@
  */
 package org.unicode.text.UCD;
 
-import com.ibm.icu.text.UTF16;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -529,15 +528,12 @@ public final class ConvertUCD implements UCD_Types {
                     int cpStart;
                     final int ddot = parts[0].indexOf(".");
                     if (ddot >= 0) {
-                        cpStart = UTF16.charAt(Utility.fromHex(parts[0].substring(0, ddot)), 0);
-                        cpTop = UTF16.charAt(Utility.fromHex(parts[0].substring(ddot + 2)), 0);
+                        cpStart = Utility.fromHex(parts[0].substring(0, ddot)).codePointAt(0);
+                        cpTop = Utility.fromHex(parts[0].substring(ddot + 2)).codePointAt(0);
                         // System.out.println(Utility.hex(cpStart) + " ... " + Utility.hex(cpTop));
                     } else {
-                        cpStart = UTF16.charAt(Utility.fromHex(parts[0]), 0);
+                        cpStart = Utility.fromHex(parts[0]).codePointAt(0);
                         cpTop = cpStart;
-                        if (labels[1].equals("RANGE")) {
-                            UTF16.charAt(Utility.fromHex(parts[1]), 0);
-                        }
                     }
 
                     // properties first
@@ -553,7 +549,7 @@ public final class ConvertUCD implements UCD_Types {
                         properties.add(prop);
                         if (Utility.find(prop, UCD_Names.DeletedProperties, true)
                                 == -1) { // only undeleted
-                            int end = UTF16.charAt(Utility.fromHex(parts[1]), 0);
+                            int end = Utility.fromHex(parts[1]).codePointAt(0);
                             if (end == 0) {
                                 end = cpStart;
                             }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/DerivedProperty.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/DerivedProperty.java
@@ -20,6 +20,7 @@ import org.unicode.props.IndexUnicodeProperties;
 import org.unicode.props.UcdProperty;
 import org.unicode.props.UcdPropertyValues.Binary;
 import org.unicode.text.utility.ChainException;
+import org.unicode.text.utility.UTF16Plus;
 import org.unicode.text.utility.Utility;
 
 public final class DerivedProperty implements UCD_Types {
@@ -124,7 +125,7 @@ public final class DerivedProperty implements UCD_Types {
                 return false;
             }
             final String norm = nfx.normalize(cp);
-            if (UTF16.countCodePoint(norm) != 1) {
+            if (!UTF16Plus.isSingleCodePoint(norm)) {
                 return true;
             }
             return false;
@@ -1126,7 +1127,7 @@ public final class DerivedProperty implements UCD_Types {
             return true;
         }
         final String decomp = ucdData.getDecompositionMapping(cp);
-        if (UTF16.countCodePoint(decomp) == 1) {
+        if (UTF16Plus.isSingleCodePoint(decomp)) {
             return true;
         }
         final int first = decomp.codePointAt(0);

--- a/unicodetools/src/main/java/org/unicode/text/UCD/DerivedProperty.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/DerivedProperty.java
@@ -953,8 +953,8 @@ public final class DerivedProperty implements UCD_Types {
                         }
                         final String decomp = nfd.normalize(cp);
                         boolean ok = false;
-                        for (int i = decomp.length() - 1; i >= 0; --i) {
-                            final int ch = UTF16.charAt(decomp, i);
+                        for (int i = decomp.length(); i > 0; ) {
+                            final int ch = decomp.codePointBefore(i);
                             final int cc = ucdData.getCombiningClass(ch);
                             if (cc == 230) {
                                 return false;
@@ -965,6 +965,7 @@ public final class DerivedProperty implements UCD_Types {
                                 }
                                 ok = true;
                             }
+                            i -= Character.charCount(ch);
                         }
                         return ok;
                     }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/DerivedProperty.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/DerivedProperty.java
@@ -10,7 +10,6 @@
 package org.unicode.text.UCD;
 
 import com.ibm.icu.impl.UnicodeMap;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.io.PrintWriter;
 import java.util.BitSet;
@@ -275,7 +274,7 @@ public final class DerivedProperty implements UCD_Types {
             cacheStr = "";
 
             if (ucdData.getDecompositionType(cp) != NONE) {
-                final String cps = UTF16.valueOf(cp);
+                final String cps = Character.toString(cp);
                 String comp = cps;
                 if (nfComp != null) {
                     comp = nfComp.normalize(comp);
@@ -449,7 +448,7 @@ public final class DerivedProperty implements UCD_Types {
                 // else it is nothing
                 int status2 = 0;
                 tempBuf.setLength(0);
-                nfkd.normalize(UTF16.valueOf(cp), tempBuf);
+                nfkd.normalize(Character.toString(cp), tempBuf);
                 int cp2;
                 for (int i = 0; i < tempBuf.length(); i += Character.charCount(cp2)) {
                     cp2 = tempBuf.codePointAt(i);
@@ -874,7 +873,7 @@ public final class DerivedProperty implements UCD_Types {
                                         continue;
                                     }
 
-                                    final String cps = UTF16.valueOf(c);
+                                    final String cps = Character.toString(c);
                                     addCase(cps, FULL, LOWER);
                                     addCase(cps, FULL, UPPER);
                                     addCase(cps, FULL, TITLE);

--- a/unicodetools/src/main/java/org/unicode/text/UCD/DerivedProperty.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/DerivedProperty.java
@@ -151,7 +151,7 @@ public final class DerivedProperty implements UCD_Types {
                 return false;
             }
             final String norm = nfx.normalize(cp);
-            final int first = UTF16.charAt(norm, 0);
+            final int first = norm.codePointAt(0);
             if (ucdData.getCombiningClass(first) != 0) {
                 return true;
             }
@@ -182,7 +182,7 @@ public final class DerivedProperty implements UCD_Types {
         public boolean hasValue(int cp) {
             if (ucdData.getCombiningClass(cp) != 0) return false;
             String norm = nfx.normalize(cp);
-            int first = UTF16.charAt(norm, 0);
+            int first = norm.codePointAt(0);
             if (ucdData.getCombiningClass(first) != 0) return true;
             if (nfx.isComposition()
                 && dprops[NFC_TrailingZero].hasValue(first)) return true; // 1,3 == composing
@@ -449,8 +449,9 @@ public final class DerivedProperty implements UCD_Types {
                 int status2 = 0;
                 tempBuf.setLength(0);
                 nfkd.normalize(UTF16.valueOf(cp), tempBuf);
-                for (int i = 0; i < tempBuf.length(); i += Character.charCount(cp)) {
-                    final int cp2 = UTF16.charAt(tempBuf, i);
+                int cp2;
+                for (int i = 0; i < tempBuf.length(); i += Character.charCount(cp2)) {
+                    cp2 = tempBuf.codePointAt(i);
                     if (i == 0) {
                         if (ucdData.isIdentifierStart(cp2)) {
                             status2 = 1;
@@ -1093,7 +1094,7 @@ public final class DerivedProperty implements UCD_Types {
         boolean gotLower = false;
         boolean gotTitle = false;
         for (int i = 0; i < norm.length(); i += Character.charCount(cp2)) {
-            cp2 = UTF16.charAt(norm, i);
+            cp2 = norm.codePointAt(i);
             final byte catx = ucdData.getCategory(cp2);
             final boolean upx = ucdData.getBinaryProperty(cp, Other_Uppercase);
             final boolean lowx = ucdData.getBinaryProperty(cp, Other_Lowercase);

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateBreakTest.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateBreakTest.java
@@ -111,7 +111,7 @@ public abstract class GenerateBreakTest implements UCD_Types {
     // finds the first base character, or the first character if there is no base
     public int findFirstBase(String source, int start, int limit) {
         int cp;
-        for (int i = start; i < limit; i += UTF16.getCharCount(cp)) {
+        for (int i = start; i < limit; i += Character.charCount(cp)) {
             cp = UTF16.charAt(source, i);
             final byte cat = ucd.getCategory(cp);
             if (((1 << cat) & MARK_MASK) != 0) {
@@ -179,7 +179,7 @@ public abstract class GenerateBreakTest implements UCD_Types {
     static String showData(UCD ucd, String source, UCDProperty[] props, String separator) {
         final StringBuffer result = new StringBuffer();
         int cp;
-        for (int i = 0; i < source.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < source.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(source, i);
             if (i != 0) {
                 result.append(separator);
@@ -204,7 +204,7 @@ public abstract class GenerateBreakTest implements UCD_Types {
     boolean isBaseNSMStar(String source) {
         int cp;
         int status = 0;
-        for (int i = 0; i < source.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < source.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(source, i);
             final byte cat = ucd.getCategory(cp);
             final int catMask = 1 << cat;
@@ -988,10 +988,10 @@ public abstract class GenerateBreakTest implements UCD_Types {
         }
         comment.append(' ').append(status).append(" [").append(getRule()).append(']');
 
-        for (int offset = 0; offset < source.length(); offset += UTF16.getCharCount(cp)) {
+        for (int offset = 0; offset < source.length(); offset += Character.charCount(cp)) {
 
             cp = UTF16.charAt(source, offset);
-            hasBreak = isBreak(source, offset + UTF16.getCharCount(cp));
+            hasBreak = isBreak(source, offset + Character.charCount(cp));
             addToRules(rulesFound, source, hasBreak);
 
             if (html) {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateBreakTest.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateBreakTest.java
@@ -32,6 +32,7 @@ import org.unicode.props.UcdProperty;
 import org.unicode.props.UcdPropertyValues.Age_Values;
 import org.unicode.props.UnicodeProperty;
 import org.unicode.text.utility.Settings;
+import org.unicode.text.utility.UTF16Plus;
 import org.unicode.text.utility.UnicodeDataFile;
 import org.unicode.text.utility.Utility;
 import org.unicode.text.utility.UtilityBase;
@@ -94,32 +95,20 @@ public abstract class GenerateBreakTest implements UCD_Types {
 
     Set<String> labels = new HashSet<String>();
 
-    public static boolean onCodepointBoundary(String s, int offset) {
-        if (offset < 0 || offset > s.length()) {
-            return false;
-        }
-        if (offset == 0 || offset == s.length()) {
-            return true;
-        }
-        if (UTF16.isLeadSurrogate(s.charAt(offset - 1))
-                && UTF16.isTrailSurrogate(s.charAt(offset))) {
-            return false;
-        }
-        return true;
-    }
-
     // finds the first base character, or the first character if there is no base
     public int findFirstBase(String source, int start, int limit) {
+        UTF16Plus.checkCodePointBoundary(source, start);
+        UTF16Plus.checkCodePointBoundary(source, limit);
         int cp;
         for (int i = start; i < limit; i += Character.charCount(cp)) {
-            cp = UTF16.charAt(source, i);
+            cp = source.codePointAt(i);
             final byte cat = ucd.getCategory(cp);
             if (((1 << cat) & MARK_MASK) != 0) {
                 continue;
             }
             return cp;
         }
-        return UTF16.charAt(source, start);
+        return source.codePointAt(start);
     }
 
     // quick & dirty routine
@@ -180,7 +169,7 @@ public abstract class GenerateBreakTest implements UCD_Types {
         final StringBuffer result = new StringBuffer();
         int cp;
         for (int i = 0; i < source.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(source, i);
+            cp = source.codePointAt(i);
             if (i != 0) {
                 result.append(separator);
             }
@@ -205,7 +194,7 @@ public abstract class GenerateBreakTest implements UCD_Types {
         int cp;
         int status = 0;
         for (int i = 0; i < source.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(source, i);
+            cp = source.codePointAt(i);
             final byte cat = ucd.getCategory(cp);
             final int catMask = 1 << cat;
             switch (status) {
@@ -666,7 +655,7 @@ public abstract class GenerateBreakTest implements UCD_Types {
         final StringBuffer result = new StringBuffer();
         int cp;
         for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(s, i);
+            cp = s.codePointAt(i);
             if (i > 0) {
                 result.append(" ");
             }
@@ -731,7 +720,7 @@ public abstract class GenerateBreakTest implements UCD_Types {
         final StringBuffer result = new StringBuffer();
         int cp;
         for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(s, i);
+            cp = s.codePointAt(i);
             if (i > 0) {
                 result.append(", ");
             }
@@ -990,7 +979,7 @@ public abstract class GenerateBreakTest implements UCD_Types {
 
         for (int offset = 0; offset < source.length(); offset += Character.charCount(cp)) {
 
-            cp = UTF16.charAt(source, offset);
+            cp = source.codePointAt(offset);
             hasBreak = isBreak(source, offset + Character.charCount(cp));
             addToRules(rulesFound, source, hasBreak);
 
@@ -1916,6 +1905,7 @@ public abstract class GenerateBreakTest implements UCD_Types {
 
         public MyBreakIterator set(String source, int offset) {
             // if (DEBUG_GRAPHEMES) System.out.println(Utility.hex(string) + "; " + offset);
+            UTF16Plus.checkCodePointBoundary(source, offset);
             string = source;
             this.offset = offset;
             return this;
@@ -1925,12 +1915,13 @@ public abstract class GenerateBreakTest implements UCD_Types {
             if (offset >= string.length()) {
                 return -1;
             }
-            final int result = UTF16.charAt(string, offset);
+            final int result = string.codePointAt(offset);
             for (++offset; offset < string.length(); ++offset) {
                 if (breaker.isBreak(string, offset)) {
                     break;
                 }
             }
+            UTF16Plus.checkCodePointBoundary(string, offset);
             // if (DEBUG_GRAPHEMES) System.out.println(Utility.hex(result));
             return result;
         }
@@ -1944,7 +1935,8 @@ public abstract class GenerateBreakTest implements UCD_Types {
                     break;
                 }
             }
-            final int result = UTF16.charAt(string, offset);
+            UTF16Plus.checkCodePointBoundary(string, offset);
+            final int result = string.codePointAt(offset);
             // if (DEBUG_GRAPHEMES) System.out.println(Utility.hex(result));
             return result;
         }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateBreakTest.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateBreakTest.java
@@ -11,7 +11,6 @@ package org.unicode.text.UCD;
 
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -154,7 +153,8 @@ public abstract class GenerateBreakTest implements UCD_Types {
                 for (int j = 1; j < test.length(); ++j) {
                     if (test2.isBreak(test, j)) {
                         if (!shown) {
-                            System.out.println(showData(ucd, UTF16.valueOf(i), INFOPROPS, "\n\t"));
+                            System.out.println(
+                                    showData(ucd, Character.toString(i), INFOPROPS, "\n\t"));
                             System.out.println(" => " + showData(ucd, decomp, INFOPROPS, "\n\t"));
                             shown = true;
                         }
@@ -813,7 +813,7 @@ public abstract class GenerateBreakTest implements UCD_Types {
             out.println("<p><b>Suppressed:</b> ");
             for (final int skippedSample : skippedSamples) {
                 if (skippedSample > 0) {
-                    final String tmp = UTF16.valueOf(skippedSample);
+                    final String tmp = Character.toString(skippedSample);
                     out.println("<span title='" + getInfo(tmp) + "'>" + getTypeID(tmp) + "</span>");
                 }
             }
@@ -1672,7 +1672,7 @@ public abstract class GenerateBreakTest implements UCD_Types {
             UnicodeSet extPict = propSource.getSet("ExtPict=yes");
             // [\p{Extended_Pictographic}&\p{Cn}]
             UnicodeSet extPictUnassigned = extPict.cloneAsThawed().retainAll(unassigned);
-            String firstExtPictUnassigned = UTF16.valueOf(extPictUnassigned.charAt(0));
+            String firstExtPictUnassigned = Character.toString(extPictUnassigned.charAt(0));
             // [\p{Extended_Pictographic}&\p{Cn}] × EM
             extraSingleSamples.add(firstExtPictUnassigned + sampleEMod);
 
@@ -1680,7 +1680,7 @@ public abstract class GenerateBreakTest implements UCD_Types {
             // [\p{Extended_Pictographic}-\p{Cn}-\p{lb=EB}]
             UnicodeSet extPictAssigned =
                     extPict.cloneAsThawed().removeAll(unassigned).removeAll(lb_EBase);
-            String firstExtPictAssigned = UTF16.valueOf(extPictAssigned.charAt(0));
+            String firstExtPictAssigned = Character.toString(extPictAssigned.charAt(0));
             // [\p{Extended_Pictographic}-\p{Cn}-\p{lb=EB}] ÷ EM
             extraSingleSamples.add(firstExtPictAssigned + sampleEMod);
         }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateCaseFolding.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateCaseFolding.java
@@ -102,10 +102,10 @@ public class GenerateCaseFolding implements UCD_Types {
                     continue;
                 }
 
-                final String rFull = fullData.get(UTF16.valueOf(ch));
-                final String rSimple = simpleData.get(UTF16.valueOf(ch));
-                final String rFullTurkish = fullDataTurkish.get(UTF16.valueOf(ch));
-                final String rSimpleTurkish = simpleDataTurkish.get(UTF16.valueOf(ch));
+                final String rFull = fullData.get(Character.toString(ch));
+                final String rSimple = simpleData.get(Character.toString(ch));
+                final String rFullTurkish = fullDataTurkish.get(Character.toString(ch));
+                final String rSimpleTurkish = simpleDataTurkish.get(Character.toString(ch));
                 if (rFull == null
                         && rSimple == null
                         && rFullTurkish == null
@@ -145,10 +145,10 @@ public class GenerateCaseFolding implements UCD_Types {
                 // Check that they are consistent. Eventually we should get rid of one of them, see
                 // https://github.com/unicode-org/unicodetools/issues/426.
                 if (normativeSCF.length() == 0) {
-                    normativeSCF.append(UTF16.valueOf(ch));
+                    normativeSCF.append(Character.toString(ch));
                 }
                 if (normativeCF.length() == 0) {
-                    normativeCF.append(UTF16.valueOf(ch));
+                    normativeCF.append(Character.toString(ch));
                 }
                 final String ucdSCF = Default.ucd().getCase(ch, UCD.SIMPLE, UCD.FOLD);
                 final String ucdCF = Default.ucd().getCase(ch, UCD.FULL, UCD.FOLD);
@@ -190,9 +190,9 @@ public class GenerateCaseFolding implements UCD_Types {
             StringBuilder normativeCF) {
         String comment = "";
         if (COMMENT_DIFFS) {
-            final String lower = Default.ucd().getCase(UTF16.valueOf(ch), FULL, LOWER);
+            final String lower = Default.ucd().getCase(Character.toString(ch), FULL, LOWER);
             if (!lower.equals(result)) {
-                final String lower2 = Default.ucd().getCase(UTF16.valueOf(ch), FULL, LOWER);
+                final String lower2 = Default.ucd().getCase(Character.toString(ch), FULL, LOWER);
                 if (lower.equals(lower2)) {
                     comment = "[Diff " + Utility.hex(lower, " ") + "] ";
                 } else {
@@ -235,7 +235,7 @@ public class GenerateCaseFolding implements UCD_Types {
     }
 
     static int probeCh = 0x01f0;
-    static String shower = UTF16.valueOf(probeCh);
+    static String shower = Character.toString(probeCh);
     // Public only for unicode.text.UCD.UData.
     // We have two independent definitions of the case foldings.
     // Eventually we should get rid of one of them, see
@@ -343,8 +343,8 @@ public class GenerateCaseFolding implements UCD_Types {
             for (int i = 0; i < simpleAdditions.length; i += 2) {
                 int c1 = simpleAdditions[i];
                 int c2 = simpleAdditions[i + 1];
-                String s1 = UTF16.valueOf(c1);
-                String s2 = UTF16.valueOf(c2);
+                String s1 = Character.toString(c1);
+                String s2 = Character.toString(c2);
                 String t = repChar.get(s1);
                 if (t != null) {
                     throw new IllegalArgumentException(
@@ -461,7 +461,7 @@ public class GenerateCaseFolding implements UCD_Types {
         if (ch == '\u023F') {
             System.out.println("???");
         }
-        final String charStr = UTF16.valueOf(ch);
+        final String charStr = Character.toString(ch);
         final String lowerStr = lower(charStr, full, condition);
         final String titleStr = title(charStr, full, condition);
         final String upperStr = upper(charStr, full, condition);
@@ -677,7 +677,7 @@ public class GenerateCaseFolding implements UCD_Types {
             final String upper = Default.nfc().normalize(Default.ucd().getCase(ch, SIMPLE, UPPER));
             final String title = Default.nfc().normalize(Default.ucd().getCase(ch, SIMPLE, TITLE));
 
-            final String chstr = UTF16.valueOf(ch);
+            final String chstr = Character.toString(ch);
 
             final String decomp = specialNormalization(chstr);
             String flower = Default.nfc().normalize(Default.ucd().getCase(decomp, SIMPLE, LOWER));

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateCaseFolding.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateCaseFolding.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import org.unicode.text.utility.Settings;
+import org.unicode.text.utility.UTF16Plus;
 import org.unicode.text.utility.UnicodeDataFile;
 import org.unicode.text.utility.UnicodeDataFile.FileInfix;
 import org.unicode.text.utility.Utility;
@@ -123,7 +124,7 @@ public class GenerateCaseFolding implements UCD_Types {
                     // do nothing
                     // drawLine(out, ch, "I", "i");
                 } else if (rFull != null && rFull.equals(rSimple)
-                        || (PICK_SHORT && UTF16.countCodePoint(rFull) == 1)) {
+                        || (PICK_SHORT && UTF16Plus.isSingleCodePoint(rFull))) {
                     drawLine(out, ch, "C", rFull, normativeSCF, normativeCF);
                 } else {
                     if (rFull != null) {
@@ -330,7 +331,7 @@ public class GenerateCaseFolding implements UCD_Types {
 
                 log.println(s2 + "\t#" + Default.ucd().getName(s2));
 
-                if (UTF16.countCodePoint(s2) == 1) {
+                if (UTF16Plus.isSingleCodePoint(s2)) {
                     repChar.put(s2, rep);
                     charsUsed.set(s2.codePointAt(0));
                 }
@@ -716,9 +717,9 @@ public class GenerateCaseFolding implements UCD_Types {
             // presumably if there is a single code point, it would already be in the simple
             // mappings
 
-            if (UTF16.countCodePoint(flower) == 1
-                    && UTF16.countCodePoint(fupper) == 1
-                    && UTF16.countCodePoint(title) == 1) {
+            if (UTF16Plus.isSingleCodePoint(flower)
+                    && UTF16Plus.isSingleCodePoint(fupper)
+                    && UTF16Plus.isSingleCodePoint(title)) {
                 if (ch == CHECK_CHAR) {
                     System.out.println(
                             "Skipping single code point: " + Default.ucd().getCodeAndName(ch));
@@ -770,7 +771,7 @@ public class GenerateCaseFolding implements UCD_Types {
                                                     ? 3
                                                     : name.indexOf("GEGRAMMENI") < 0
                                                             ? 5
-                                                            : UTF16.countCodePoint(ftitle) == 1
+                                                            : UTF16Plus.isSingleCodePoint(ftitle)
                                                                     ? 6
                                                                     : UTF16.countCodePoint(fupper)
                                                                                     == 2

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateCaseTest.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateCaseTest.java
@@ -9,7 +9,6 @@
  */
 package org.unicode.text.UCD;
 
-import com.ibm.icu.text.UTF16;
 import java.io.IOException;
 import java.io.PrintWriter;
 import org.unicode.text.utility.Utility;
@@ -49,7 +48,7 @@ public abstract class GenerateCaseTest implements UCD_Types {
                 continue;
             }
 
-            String s = UTF16.valueOf(cp);
+            String s = Character.toString(cp);
             write(out, s, true);
 
             // if (cp == '\u0345') continue; // don't add combining for this special case

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java
@@ -64,6 +64,7 @@ import org.unicode.props.UcdPropertyValues.NFKD_Quick_Check_Values;
 import org.unicode.props.UcdPropertyValues.Script_Values;
 import org.unicode.props.UnicodeProperty;
 import org.unicode.text.utility.Settings;
+import org.unicode.text.utility.UTF16Plus;
 import org.unicode.text.utility.UnicodeTransform;
 import org.unicode.text.utility.Utility;
 import org.unicode.tools.Confusables;
@@ -1118,7 +1119,7 @@ public class GenerateConfusables {
                         final String target = fromHexOld(targetString);
                         final String source = fromHexOld(sourceString);
                         final String nsource = NFKD.normalize(source);
-                        final String first = Character.toString(nsource.codePointAt(0));
+                        final String first = UTF16Plus.codePointSubstringAt(nsource, 0);
                         if (!first.equals(target)) {
                             add(source, target, type, count, line);
                         }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java
@@ -669,7 +669,7 @@ public class GenerateConfusables {
         int lastScript = UCD_Types.COMMON_SCRIPT; // temporary value
         int cp;
         for (int i = 0; i < source.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(source, i);
+            cp = source.codePointAt(i);
             final int script = DEFAULT_UCD.getScript(cp);
             if (script == UCD_Types.COMMON_SCRIPT || script == UCD_Types.INHERITED_SCRIPT) {
                 continue;
@@ -880,7 +880,7 @@ public class GenerateConfusables {
             final StringBuffer result = new StringBuffer();
             int cp;
             for (int i = 0; i < item.length(); i += Character.charCount(cp)) {
-                cp = UTF16.charAt(item, i);
+                cp = item.codePointAt(i);
                 final String cps = UTF16.valueOf(cp);
                 final String mapped = getParadigm(cps, onlyLowercase, onlySameScript);
                 if (mapped == null || mapped.indexOf(cps) >= 0) {
@@ -1037,9 +1037,9 @@ public class GenerateConfusables {
 
             // if it is base + combining sequence => base2 + same combining sequence, do just the
             // base
-            final int nsourceFirst = UTF16.charAt(nsource, 0);
+            final int nsourceFirst = nsource.codePointAt(0);
             final String nsourceRest = nsource.substring(Character.charCount(nsourceFirst));
-            final int ntargetFirst = UTF16.charAt(ntarget, 0);
+            final int ntargetFirst = ntarget.codePointAt(0);
             final String ntargetRest = ntarget.substring(Character.charCount(ntargetFirst));
 
             if (nsourceRest.length() != 0 && nsourceRest.equals(ntargetRest)) {
@@ -1118,7 +1118,7 @@ public class GenerateConfusables {
                         final String target = fromHexOld(targetString);
                         final String source = fromHexOld(sourceString);
                         final String nsource = NFKD.normalize(source);
-                        final String first = UTF16.valueOf(UTF16.charAt(nsource, 0));
+                        final String first = UTF16.valueOf(nsource.codePointAt(0));
                         if (!first.equals(target)) {
                             add(source, target, type, count, line);
                         }
@@ -1804,9 +1804,9 @@ public class GenerateConfusables {
                 }
 
                 if (true) {
-                    final int nsourceFirst = UTF16.charAt(nsource, 0);
+                    final int nsourceFirst = nsource.codePointAt(0);
                     final String nsourceRest = nsource.substring(Character.charCount(nsourceFirst));
-                    final int ntargetFirst = UTF16.charAt(ntarget, 0);
+                    final int ntargetFirst = ntarget.codePointAt(0);
                     final String ntargetRest = ntarget.substring(Character.charCount(ntargetFirst));
                     if (nsourceRest.equals(ntargetRest)) {
                         source = UTF16.valueOf(nsourceFirst);
@@ -1978,7 +1978,7 @@ public class GenerateConfusables {
             int cp;
             int lastValue = 0;
             for (int i = 0; i < a.length(); i += Character.charCount(cp)) {
-                cp = UTF16.charAt(a, i);
+                cp = a.codePointAt(i);
                 final Object objValue = info.lowerIsBetter.getValue(cp);
                 final int value = ((Integer) objValue).intValue();
                 if (value > lastValue) {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java
@@ -668,7 +668,7 @@ public class GenerateConfusables {
         }
         int lastScript = UCD_Types.COMMON_SCRIPT; // temporary value
         int cp;
-        for (int i = 0; i < source.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < source.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(source, i);
             final int script = DEFAULT_UCD.getScript(cp);
             if (script == UCD_Types.COMMON_SCRIPT || script == UCD_Types.INHERITED_SCRIPT) {
@@ -879,7 +879,7 @@ public class GenerateConfusables {
             }
             final StringBuffer result = new StringBuffer();
             int cp;
-            for (int i = 0; i < item.length(); i += UTF16.getCharCount(cp)) {
+            for (int i = 0; i < item.length(); i += Character.charCount(cp)) {
                 cp = UTF16.charAt(item, i);
                 final String cps = UTF16.valueOf(cp);
                 final String mapped = getParadigm(cps, onlyLowercase, onlySameScript);
@@ -1038,9 +1038,9 @@ public class GenerateConfusables {
             // if it is base + combining sequence => base2 + same combining sequence, do just the
             // base
             final int nsourceFirst = UTF16.charAt(nsource, 0);
-            final String nsourceRest = nsource.substring(UTF16.getCharCount(nsourceFirst));
+            final String nsourceRest = nsource.substring(Character.charCount(nsourceFirst));
             final int ntargetFirst = UTF16.charAt(ntarget, 0);
-            final String ntargetRest = ntarget.substring(UTF16.getCharCount(ntargetFirst));
+            final String ntargetRest = ntarget.substring(Character.charCount(ntargetFirst));
 
             if (nsourceRest.length() != 0 && nsourceRest.equals(ntargetRest)) {
                 source = UTF16.valueOf(nsourceFirst);
@@ -1805,9 +1805,9 @@ public class GenerateConfusables {
 
                 if (true) {
                     final int nsourceFirst = UTF16.charAt(nsource, 0);
-                    final String nsourceRest = nsource.substring(UTF16.getCharCount(nsourceFirst));
+                    final String nsourceRest = nsource.substring(Character.charCount(nsourceFirst));
                     final int ntargetFirst = UTF16.charAt(ntarget, 0);
-                    final String ntargetRest = ntarget.substring(UTF16.getCharCount(ntargetFirst));
+                    final String ntargetRest = ntarget.substring(Character.charCount(ntargetFirst));
                     if (nsourceRest.equals(ntargetRest)) {
                         source = UTF16.valueOf(nsourceFirst);
                         target = UTF16.valueOf(ntargetFirst);
@@ -1977,7 +1977,7 @@ public class GenerateConfusables {
         private int getValue(String a) { // lower is better
             int cp;
             int lastValue = 0;
-            for (int i = 0; i < a.length(); i += UTF16.getCharCount(cp)) {
+            for (int i = 0; i < a.length(); i += Character.charCount(cp)) {
                 cp = UTF16.charAt(a, i);
                 final Object objValue = info.lowerIsBetter.getValue(cp);
                 final int value = ((Integer) objValue).intValue();

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java
@@ -627,7 +627,7 @@ public class GenerateConfusables {
                     _skipNFKD.add(cp);
                     continue;
                 }
-                final String source = UTF16.valueOf(cp);
+                final String source = Character.toString(cp);
                 String kmapped = ModifiedNFKD.normalize(source);
                 if (!kmapped.equals(source) && !kmapped.equals(nfc)) {
                     if (kmapped.startsWith(" ") || kmapped.startsWith("\u0640")) {
@@ -881,7 +881,7 @@ public class GenerateConfusables {
             int cp;
             for (int i = 0; i < item.length(); i += Character.charCount(cp)) {
                 cp = item.codePointAt(i);
-                final String cps = UTF16.valueOf(cp);
+                final String cps = Character.toString(cp);
                 final String mapped = getParadigm(cps, onlyLowercase, onlySameScript);
                 if (mapped == null || mapped.indexOf(cps) >= 0) {
                     result.append(cps);
@@ -944,7 +944,7 @@ public class GenerateConfusables {
                 if (codePointArray.length == 1) {
                 } else {
                     for (int codepoint : codePointArray) {
-                        final String codePointString = UTF16.valueOf(codepoint);
+                        final String codePointString = Character.toString(codepoint);
                         String otherParadigm =
                                 getParadigm(codePointString, onlyLowercase, onlySameScript);
                         if (otherParadigm != null && !codePointString.equals(otherParadigm)) {
@@ -998,7 +998,7 @@ public class GenerateConfusables {
         MyEquivalenceClass dataMixedAnycase = new MyEquivalenceClass();
         RawData raw = new RawData();
 
-        private static String testChar = UTF16.valueOf(0x10A3A);
+        private static String testChar = Character.toString(0x10A3A);
 
         public DataSet add(
                 String source, String target, String type, int lineCount, String errorLine) {
@@ -1043,8 +1043,8 @@ public class GenerateConfusables {
             final String ntargetRest = ntarget.substring(Character.charCount(ntargetFirst));
 
             if (nsourceRest.length() != 0 && nsourceRest.equals(ntargetRest)) {
-                source = UTF16.valueOf(nsourceFirst);
-                target = UTF16.valueOf(ntargetFirst);
+                source = Character.toString(nsourceFirst);
+                target = Character.toString(ntargetFirst);
                 type += "-base";
             }
             // type += ":" + lineCount;
@@ -1118,7 +1118,7 @@ public class GenerateConfusables {
                         final String target = fromHexOld(targetString);
                         final String source = fromHexOld(sourceString);
                         final String nsource = NFKD.normalize(source);
-                        final String first = UTF16.valueOf(nsource.codePointAt(0));
+                        final String first = Character.toString(nsource.codePointAt(0));
                         if (!first.equals(target)) {
                             add(source, target, type, count, line);
                         }
@@ -1809,8 +1809,8 @@ public class GenerateConfusables {
                     final int ntargetFirst = ntarget.codePointAt(0);
                     final String ntargetRest = ntarget.substring(Character.charCount(ntargetFirst));
                     if (nsourceRest.equals(ntargetRest)) {
-                        source = UTF16.valueOf(nsourceFirst);
-                        target = UTF16.valueOf(ntargetFirst);
+                        source = Character.toString(nsourceFirst);
+                        target = Character.toString(ntargetFirst);
                     }
                 }
 

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateData.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateData.java
@@ -222,7 +222,7 @@ public class GenerateData implements UCD_Types {
             if (Default.ucd().getCombiningClass(c2) != 0) {
                 continue;
             }
-            prilist.add(UTF16.valueOf(c1) + '\u0334' + UTF16.valueOf(c2));
+            prilist.add(Character.toString(c1) + '\u0334' + Character.toString(c2));
         }
         Utility.fixDot();
 

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateData.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateData.java
@@ -215,7 +215,7 @@ public class GenerateData implements UCD_Types {
                 continue;
             }
             final int c1 = s.codePointAt(0);
-            final int c2 = UTF16.charAt(s, Character.charCount(c1));
+            final int c2 = s.codePointAt(Character.charCount(c1));
             if (Default.ucd().getCombiningClass(c1) != 0) {
                 continue;
             }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateData.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateData.java
@@ -548,7 +548,7 @@ public class GenerateData implements UCD_Types {
             if (Default.ucd().getCategory(cp) == Mn) {
                 commaResult.append('\u25CC');
             }
-            UTF16.append(commaResult, cp);
+            commaResult.appendCodePoint(cp);
         }
         return commaResult.toString();
     }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateData.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateData.java
@@ -214,7 +214,7 @@ public class GenerateData implements UCD_Types {
             if (!UTF16.hasMoreCodePointsThan(s, 1)) {
                 continue;
             }
-            final int c1 = UTF16.charAt(s, 0);
+            final int c1 = s.codePointAt(0);
             final int c2 = UTF16.charAt(s, Character.charCount(c1));
             if (Default.ucd().getCombiningClass(c1) != 0) {
                 continue;
@@ -544,7 +544,7 @@ public class GenerateData implements UCD_Types {
         commaResult.setLength(0);
         int cp;
         for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(s, i);
+            cp = s.codePointAt(i);
             if (Default.ucd().getCategory(cp) == Mn) {
                 commaResult.append('\u25CC');
             }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateData.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateData.java
@@ -215,7 +215,7 @@ public class GenerateData implements UCD_Types {
                 continue;
             }
             final int c1 = UTF16.charAt(s, 0);
-            final int c2 = UTF16.charAt(s, UTF16.getCharCount(c1));
+            final int c2 = UTF16.charAt(s, Character.charCount(c1));
             if (Default.ucd().getCombiningClass(c1) != 0) {
                 continue;
             }
@@ -302,7 +302,7 @@ public class GenerateData implements UCD_Types {
             int second;
             for (int i = Character.charCount(first);
                     i < decomposition.length();
-                    first = second, i += UTF16.getCharCount(first)) {
+                    first = second, i += Character.charCount(first)) {
                 second = decomposition.codePointAt(i);
                 links.add(Character.toString(first) + Character.toString(second));
             }
@@ -543,7 +543,7 @@ public class GenerateData implements UCD_Types {
         // if (true) return s;
         commaResult.setLength(0);
         int cp;
-        for (int i = 0; i < s.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(s, i);
             if (Default.ucd().getCategory(cp) == Mn) {
                 commaResult.append('\u25CC');

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateHanTransliterator.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateHanTransliterator.java
@@ -277,7 +277,7 @@ public final class GenerateHanTransliterator implements UCD_Types {
         StringBuffer result = new StringBuffer();
         while (pos1 < other.length()) {
             int end = getHexEnd(s, pos1);
-            result.append(UTF16.valueOf(Integer.parseInt(other.substring(pos1, end), 16)));
+            result.append(Character.toString(Integer.parseInt(other.substring(pos1, end), 16)));
             pos1 = other.indexOf("U+", pos1);
             if (pos2 < 0) pos2 = other.length();
             pos1 = pos2;
@@ -317,7 +317,7 @@ public final class GenerateHanTransliterator implements UCD_Types {
         final UnicodeSet gotAtLeastOne = new UnicodeSet(gotMandarin).addAll(gotHanyu);
         final Map outmap = new TreeMap(Collator.getInstance(new ULocale("zh")));
         for (final UnicodeSetIterator it = new UnicodeSetIterator(gotAtLeastOne); it.next(); ) {
-            // String code = UTF16.valueOf(it.codepoint);
+            // String code = Character.toString(it.codepoint);
             final String hanyu = (String) kHanyuPinlu.getValue(it.codepoint);
             final String mandarin = (String) kMandarin.getValue(it.codepoint);
             final String hPinyin =
@@ -345,7 +345,7 @@ public final class GenerateHanTransliterator implements UCD_Types {
             if (uset.size() == 1) {
                 final UnicodeSetIterator usi = new UnicodeSetIterator(uset);
                 usi.next();
-                out.println(UTF16.valueOf(usi.codepoint) + ">" + pinyin + ";");
+                out.println(Character.toString(usi.codepoint) + ">" + pinyin + ";");
             } else {
                 out.println(uset.toPattern(false) + ">" + pinyin + ";");
             }
@@ -391,7 +391,7 @@ public final class GenerateHanTransliterator implements UCD_Types {
         log.println("N\tCode\tChar\tUnihan\tICU\tGCL\tkHanyuPinlu / kMandarin");
         final UnicodeMap reformed = new UnicodeMap();
         for (final UnicodeSetIterator it = new UnicodeSetIterator(gotAtLeastOne); it.next(); ) {
-            final String code = UTF16.valueOf(it.codepoint);
+            final String code = Character.toString(it.codepoint);
             final String hanyu = (String) kHanyuPinlu.getValue(it.codepoint);
             final String mandarin = (String) kMandarin.getValue(it.codepoint);
             final String hPinyin =
@@ -559,7 +559,7 @@ public final class GenerateHanTransliterator implements UCD_Types {
         final Set set = new TreeSet(col);
         final PrintWriter pw = Utility.openPrintWriterGenDir("log/" + file, Utility.UTF8_WINDOWS);
         for (final UnicodeSetIterator it = new UnicodeSetIterator(tailored); it.next(); ) {
-            set.add(UTF16.valueOf(it.codepoint));
+            set.add(Character.toString(it.codepoint));
         }
         String lastm = "";
         String lasts = "";
@@ -1599,7 +1599,7 @@ public final class GenerateHanTransliterator implements UCD_Types {
                     final int rank = Integer.parseInt(line.substring(0, tabPos));
                     final int cp = line.charAt(tabPos + 1);
                     // if ((rank % 100) == 0) System.out.println(rank + ", " + Utility.hex(cp));
-                    combinedRank.add(new Pair(new Integer(rank), UTF16.valueOf(cp)));
+                    combinedRank.add(new Pair(new Integer(rank), Character.toString(cp)));
                 }
                 br.close();
             }
@@ -1639,7 +1639,7 @@ public final class GenerateHanTransliterator implements UCD_Types {
                             continue;
                         }
                         // if ((rank % 100) == 0) System.out.println(rank + ", " + Utility.hex(cp));
-                        Utility.addCount(japaneseMap, UTF16.valueOf(cp), -freq);
+                        Utility.addCount(japaneseMap, Character.toString(cp), -freq);
                     }
                 }
                 br.close();
@@ -1718,7 +1718,7 @@ public final class GenerateHanTransliterator implements UCD_Types {
             }
             Utility.dot(i);
 
-            final String ch = UTF16.valueOf(i);
+            final String ch = Character.toString(i);
 
             String pinyin = (String) unihanMap.get(ch);
             if (pinyin == null) {
@@ -2440,11 +2440,11 @@ public final class GenerateHanTransliterator implements UCD_Types {
 
             // gather traditional mapping
             if (property.equals("kTraditionalVariant")) {
-                simplifiedToTraditional.put(UTF16.valueOf(code), propertyValue);
+                simplifiedToTraditional.put(Character.toString(code), propertyValue);
             }
 
             if (property.equals("kSimplifiedVariant")) {
-                traditionalToSimplified.put(UTF16.valueOf(code), propertyValue);
+                traditionalToSimplified.put(Character.toString(code), propertyValue);
             }
 
             if (key.equals("kMandarin") && property.equals("kHanyuPinlu")) {
@@ -2511,9 +2511,9 @@ public final class GenerateHanTransliterator implements UCD_Types {
             if (end3 == 0) {
                 log.println(
                         "Bad pinyin data: "
-                                + hex.transliterate(UTF16.valueOf(cp))
+                                + hex.transliterate(Character.toString(cp))
                                 + "\t"
-                                + UTF16.valueOf(cp)
+                                + Character.toString(cp)
                                 + "\t"
                                 + definition);
                 end3 = definition.length();
@@ -2522,7 +2522,11 @@ public final class GenerateHanTransliterator implements UCD_Types {
 
             definition = digitToPinyin(definition, line);
             out2.println(
-                    Utility.hex(cp) + '\t' + UTF16.valueOf(cp) + "\t" + definition.toLowerCase());
+                    Utility.hex(cp)
+                            + '\t'
+                            + Character.toString(cp)
+                            + "\t"
+                            + definition.toLowerCase());
         }
         if (type == DEFINITION) {
             definition = removeMatched(definition, '(', ')', line);
@@ -2540,7 +2544,7 @@ public final class GenerateHanTransliterator implements UCD_Types {
                             + " on: "
                             + hex.transliterate(line));
         } else {
-            addCheck(UTF16.valueOf(cp), definition, line);
+            addCheck(Character.toString(cp), definition, line);
         }
         /*
         String key = (String) unihanMap.get(definition);

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateHanTransliterator.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateHanTransliterator.java
@@ -2279,7 +2279,7 @@ public final class GenerateHanTransliterator implements UCD_Types {
     static void addCheck2(String word, String definition, String line) {
         definition = Default.nfc().normalize(definition);
         word = Default.nfc().normalize(word);
-        if (DO_SIMPLE && UTF16.countCodePoint(word) > 1) {
+        if (DO_SIMPLE && UTF16.hasMoreCodePointsThan(word, 1)) {
             return;
         }
 
@@ -2298,7 +2298,7 @@ public final class GenerateHanTransliterator implements UCD_Types {
                 Utility.addToList(duplicates, word, definition, true);
             }
         }
-        if (UTF16.countCodePoint(word) > 1) {
+        if (UTF16.hasMoreCodePointsThan(word, 1)) {
             unihanNonSingular = true;
         }
     }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateHanTransliterator.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateHanTransliterator.java
@@ -503,8 +503,8 @@ public final class GenerateHanTransliterator implements UCD_Types {
 
         @Override
         public int compare(Object o1, Object o2) {
-            final int c1 = UTF16.charAt((String) o1, 0);
-            final int c2 = UTF16.charAt((String) o2, 0);
+            final int c1 = ((String) o1).codePointAt(0);
+            final int c2 = ((String) o2).codePointAt(0);
             final Object v1 = map.getValue(c1);
             final Object v2 = map.getValue(c2);
             if (v1 == null) {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateHanTransliterator.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateHanTransliterator.java
@@ -565,7 +565,7 @@ public final class GenerateHanTransliterator implements UCD_Types {
         String lasts = "";
         for (final Iterator it2 = set.iterator(); it2.hasNext(); ) {
             final String s = (String) it2.next();
-            String m = map == null ? null : (String) map.getValue(UTF16.charAt(s, 0));
+            String m = map == null ? null : (String) map.getValue(s.codePointAt(0));
             if (m == null) {
                 m = "";
             }
@@ -573,20 +573,20 @@ public final class GenerateHanTransliterator implements UCD_Types {
             if (p2.compare(lastm, m) > 0) {
                 info = info + "\t" + lastm + " > " + m + "\t";
                 Object temp;
-                temp = hanyu.getValue(UTF16.charAt(lasts, 0));
+                temp = hanyu.getValue(lasts.codePointAt(0));
                 if (temp != null) {
                     info += "[" + temp + "]";
                 }
-                temp = mand.getValue(UTF16.charAt(lasts, 0));
+                temp = mand.getValue(lasts.codePointAt(0));
                 if (temp != null) {
                     info += "[" + temp + "]";
                 }
                 info += " > ";
-                temp = hanyu.getValue(UTF16.charAt(s, 0));
+                temp = hanyu.getValue(s.codePointAt(0));
                 if (temp != null) {
                     info += "[" + temp + "]";
                 }
-                temp = mand.getValue(UTF16.charAt(s, 0));
+                temp = mand.getValue(s.codePointAt(0));
                 if (temp != null) {
                     info += "[" + temp + "]";
                 }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateNamedSequences.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateNamedSequences.java
@@ -10,7 +10,6 @@
 package org.unicode.text.UCD;
 
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.text.UTF16;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -89,7 +88,7 @@ public final class GenerateNamedSequences implements UCD_Types {
                 if (codes[i].length() == 0) {
                     continue;
                 }
-                UTF16.append(codeBuffer, Integer.parseInt(codes[i], 16));
+                codeBuffer.appendCodePoint(Integer.parseInt(codes[i], 16));
             }
             final String codeWithHyphens = splits[1].replaceAll("\\s+", "-");
             final String codeAlt = "U+" + splits[1].replaceAll("\\s", " U+");

--- a/unicodetools/src/main/java/org/unicode/text/UCD/IdentifierInfo.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/IdentifierInfo.java
@@ -6,7 +6,6 @@ import com.google.common.collect.Multimap;
 import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.impl.locale.XCldrStub.ImmutableSet;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import com.ibm.icu.util.ICUException;
@@ -158,7 +157,7 @@ public class IdentifierInfo {
             if (cat == UCD_Types.Cn || cat == UCD_Types.Co || cat == UCD_Types.Cs) {
                 continue;
             }
-            final String source = UTF16.valueOf(cp);
+            final String source = Character.toString(cp);
             final String cf = DEFAULT_UCD.getCase(source, UCD_Types.FULL, UCD_Types.FOLD);
             if (cf.equals(source)) {
                 isCaseFolded.add(cp);
@@ -655,7 +654,7 @@ public class IdentifierInfo {
         //          String[] pieces = Utility.split(line, ';');
         //          int code = Integer.parseInt(pieces[0].trim(), 16);
         //          if (pieces[1].trim().equals("remap-to")) {
-        //            remap.put(code, UTF16.valueOf(Integer.parseInt(
+        //            remap.put(code, Character.toString(Integer.parseInt(
         //                    pieces[2].trim(), 16)));
         //          } else {
         //            if (XIDContinueSet.contains(code)) {
@@ -976,7 +975,7 @@ public class IdentifierInfo {
                         if (GenerateConfusables.GC_LOWERCASE.contains(codePoint)) {
                             final String upper =
                                     DEFAULT_UCD.getCase(codePoint, UCD_Types.FULL, UCD_Types.UPPER);
-                            if (upper.equals(UTF16.valueOf(codePoint))
+                            if (upper.equals(Character.toString(codePoint))
                                     && x.equals("technical symbol (phonetic)")) {
                                 x = "technical symbol (phonetic with no uppercase)";
                             }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
@@ -2679,7 +2679,7 @@ public class MakeUnicodeFiles {
      int cp = 0;
      int i;
      for (i = start; i < limit; i += Character.charCount(cp)) {
-     cp = UTF16.charAt(text, i);
+     cp = text.codePointAt(i);
      if (!com.ibm.icu.lang.UCharacter.isUnicodeIdentifierPart(cp)) {
      break;
      }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
@@ -2678,7 +2678,7 @@ public class MakeUnicodeFiles {
      if (DEBUG) System.out.println("\tGetID <" + text.substring(start,limit) + ">");
      int cp = 0;
      int i;
-     for (i = start; i < limit; i += UTF16.getCharCount(cp)) {
+     for (i = start; i < limit; i += Character.charCount(cp)) {
      cp = UTF16.charAt(text, i);
      if (!com.ibm.icu.lang.UCharacter.isUnicodeIdentifierPart(cp)) {
      break;

--- a/unicodetools/src/main/java/org/unicode/text/UCD/NamesList.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/NamesList.java
@@ -4,7 +4,6 @@ import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.Transform;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ULocale;
 import com.ibm.icu.util.VersionInfo;
@@ -105,7 +104,7 @@ public class NamesList {
                             + (TO_SUPPRESS.contains(cp)
                                     ? DOTTED_BOX
                                     : (COMBINING.contains(cp) ? DOTTED_CIRCLE : "")
-                                            + UTF16.valueOf(cp));
+                                            + Character.toString(cp));
                 }
             };
 
@@ -165,7 +164,7 @@ public class NamesList {
             if (comment == Comment.xref) {
                 Matcher m = match(trim, XREF1, XREF2, XREF3);
                 int cp = Integer.parseInt(m.group(1), 16);
-                trim = UTF16.valueOf(cp);
+                trim = Character.toString(cp);
                 if (discardXref(trim)) {
                     return;
                 }
@@ -186,7 +185,7 @@ public class NamesList {
             for (byte width = 0; width < 2; ++width) {
                 for (byte caseType = 0; caseType < UCD_Types.LIMIT_CASE; ++caseType) {
                     String changed =
-                            UCharacter.toUpperCase(ULocale.ENGLISH, UTF16.valueOf(codePoint));
+                            UCharacter.toUpperCase(ULocale.ENGLISH, Character.toString(codePoint));
                     // TODO Support case folding with UnicodeProperty directly, instead of
                     // Default.ucd().getCase(codePoint, UCD_Types.FULL, UCD_Types.UPPER);
                     if (changed.equals(trim)) {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/NormalizationDataStandard.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/NormalizationDataStandard.java
@@ -46,7 +46,7 @@ class NormalizationDataStandard implements NormalizationData {
                         }
                         continue;
                     }
-                    final int a = UTF16.charAt(s, 0);
+                    final int a = s.codePointAt(0);
                     if (ucd.getCombiningClass(a) != 0) {
                         continue;
                     }
@@ -152,7 +152,7 @@ class NormalizationDataStandard implements NormalizationData {
                 System.out.println("fix");
             }
             for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-                cp = UTF16.charAt(s, i);
+                cp = s.codePointAt(i);
                 getRecursiveDecomposition(cp, buffer, compat);
             }
         } else {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/NormalizationDataStandard.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/NormalizationDataStandard.java
@@ -52,7 +52,7 @@ class NormalizationDataStandard implements NormalizationData {
                     }
                     isFirst.set(a);
 
-                    final int b = UTF16.charAt(s, Character.charCount(a));
+                    final int b = s.codePointAt(Character.charCount(a));
                     isSecond.set(b);
 
                     // have a recomposition, so set the bit

--- a/unicodetools/src/main/java/org/unicode/text/UCD/NormalizationDataStandard.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/NormalizationDataStandard.java
@@ -148,7 +148,7 @@ class NormalizationDataStandard implements NormalizationData {
         // we know we decompose all CANONICAL, plus > CANONICAL if compat is TRUE.
         if (dt == UCD_Types.CANONICAL || dt > UCD_Types.CANONICAL && compat) {
             final String s = ucd.getDecompositionMapping(cp);
-            if (s.equals(UTF16.valueOf(cp))) {
+            if (s.equals(Character.toString(cp))) {
                 System.out.println("fix");
             }
             for (int i = 0; i < s.length(); i += Character.charCount(cp)) {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/NormalizationDataStandard.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/NormalizationDataStandard.java
@@ -52,7 +52,7 @@ class NormalizationDataStandard implements NormalizationData {
                     }
                     isFirst.set(a);
 
-                    final int b = UTF16.charAt(s, UTF16.getCharCount(a));
+                    final int b = UTF16.charAt(s, Character.charCount(a));
                     isSecond.set(b);
 
                     // have a recomposition, so set the bit
@@ -151,7 +151,7 @@ class NormalizationDataStandard implements NormalizationData {
             if (s.equals(UTF16.valueOf(cp))) {
                 System.out.println("fix");
             }
-            for (int i = 0; i < s.length(); i += UTF16.getCharCount(cp)) {
+            for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
                 cp = UTF16.charAt(s, i);
                 getRecursiveDecomposition(cp, buffer, compat);
             }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/Normalizer.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/Normalizer.java
@@ -11,7 +11,6 @@ package org.unicode.text.UCD;
 
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.text.Transform;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.util.BitSet;
 import java.util.HashMap;
@@ -163,15 +162,16 @@ public final class Normalizer implements Transform<String, String>, UCD_Types {
      * @return target the resulting normalized text
      */
     public String normalize(int cp) {
-        return normalize(UTF16.valueOf(cp));
+        return normalize(Character.toString(cp));
     }
 
     /**
      * private StringBuilder hasDecompositionBuffer = new StringBuilder();
      *
      * <p>public boolean hasDecomposition(int cp) { hasDecompositionBuffer.setLength(0);
-     * normalize(UTF16.valueOf(cp), hasDecompositionBuffer); if (hasDecompositionBuffer.length() !=
-     * 1) return true; return cp != hasDecompositionBuffer.charAt(0); }
+     * normalize(Character.toString(cp), hasDecompositionBuffer); if
+     * (hasDecompositionBuffer.length() != 1) return true; return cp !=
+     * hasDecompositionBuffer.charAt(0); }
      */
 
     /*
@@ -512,7 +512,7 @@ public final class Normalizer implements Transform<String, String>, UCD_Types {
                     continue main;
                 }
             }
-            spacingMap.put(i, UTF16.valueOf(i));
+            spacingMap.put(i, Character.toString(i));
         }
         final String[][] specials = {
             {"[\\u0384\\u1FFD]", "\u00B4"},

--- a/unicodetools/src/main/java/org/unicode/text/UCD/Normalizer.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/Normalizer.java
@@ -248,7 +248,8 @@ public final class Normalizer implements Transform<String, String>, UCD_Types {
 
     public boolean isNormalized(CharSequence s) {
         if (Character.codePointCount(s, 0, s.length()) == 1) {
-            return !data.normalizationDiffers(UTF16.charAt(s, 0), composition, compatibility);
+            return !data.normalizationDiffers(
+                    Character.codePointAt(s, 0), composition, compatibility);
         }
         return s.equals(normalize(s)); // TODO: OPTIMIZE LATER
     }
@@ -313,7 +314,7 @@ public final class Normalizer implements Transform<String, String>, UCD_Types {
         int ch32;
         for (int i = 0; i < source.length(); i += Character.charCount(ch32)) {
             buffer.setLength(0);
-            ch32 = UTF16.charAt(source, i);
+            ch32 = Character.codePointAt(source, i);
             final String sub =
                     substituteMapping == null ? null : (String) substituteMapping.getValue(ch32);
             if (sub != null) {
@@ -328,7 +329,7 @@ public final class Normalizer implements Transform<String, String>, UCD_Types {
 
             int ch;
             for (int j = 0; j < buffer.length(); j += Character.charCount(ch)) {
-                ch = UTF16.charAt(buffer, j);
+                ch = buffer.codePointAt(j);
                 final int chClass = data.getCanonicalClass(ch);
                 int k = target.length(); // insertion point
                 if (chClass != 0 && reorder) {
@@ -371,7 +372,7 @@ public final class Normalizer implements Transform<String, String>, UCD_Types {
      */
     private void internalCompose(StringBuilder target) {
         int starterPos = 0;
-        int starterCh = UTF16.charAt(target, 0);
+        int starterCh = target.codePointAt(0);
         int compPos = Character.charCount(starterCh); // length of last composition
         int lastClass = data.getCanonicalClass(starterCh);
         if (lastClass != 0) {
@@ -385,7 +386,7 @@ public final class Normalizer implements Transform<String, String>, UCD_Types {
         for (int decompPos = compPos;
                 decompPos < target.length();
                 decompPos += Character.charCount(ch)) {
-            ch = UTF16.charAt(target, decompPos);
+            ch = target.codePointAt(decompPos);
             if (SHOW_PROGRESS) {
                 System.out.println(
                         Utility.hex(target)
@@ -496,7 +497,7 @@ public final class Normalizer implements Transform<String, String>, UCD_Types {
             }
             b.setLength(0);
             data.getRecursiveDecomposition(i, b, true);
-            if (b.length() == 1) {
+            if (b.length() == 1) { // TODO: isSingleCodePoint(b)?
                 continue;
             }
             final char firstChar = b.charAt(0);
@@ -505,6 +506,7 @@ public final class Normalizer implements Transform<String, String>, UCD_Types {
             }
             // if rest are just Mn or Me marks, then add to substitute mapping
             int cp;
+            // TODO: Start after first code point which could be j=2?
             for (int j = 1; j < b.length(); j += Character.charCount(cp)) {
                 cp = UTF16.charAt(b, j);
                 if (data.isNonSpacing(cp)) {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/Normalizer.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/Normalizer.java
@@ -311,7 +311,7 @@ public final class Normalizer implements Transform<String, String>, UCD_Types {
             CharSequence source, StringBuilder target, boolean reorder, boolean compat) {
         final StringBuilder buffer = new StringBuilder();
         int ch32;
-        for (int i = 0; i < source.length(); i += UTF16.getCharCount(ch32)) {
+        for (int i = 0; i < source.length(); i += Character.charCount(ch32)) {
             buffer.setLength(0);
             ch32 = UTF16.charAt(source, i);
             final String sub =
@@ -327,7 +327,7 @@ public final class Normalizer implements Transform<String, String>, UCD_Types {
             // no decomposition mapping)
 
             int ch;
-            for (int j = 0; j < buffer.length(); j += UTF16.getCharCount(ch)) {
+            for (int j = 0; j < buffer.length(); j += Character.charCount(ch)) {
                 ch = UTF16.charAt(buffer, j);
                 final int chClass = data.getCanonicalClass(ch);
                 int k = target.length(); // insertion point
@@ -336,7 +336,7 @@ public final class Normalizer implements Transform<String, String>, UCD_Types {
                     // bubble-sort combining marks as necessary
 
                     int ch2;
-                    for (; k > 0; k -= UTF16.getCharCount(ch2)) {
+                    for (; k > 0; k -= Character.charCount(ch2)) {
                         ch2 = UTF16.charAt(target, k - 1);
                         if (data.getCanonicalClass(ch2) <= chClass) {
                             break;
@@ -372,7 +372,7 @@ public final class Normalizer implements Transform<String, String>, UCD_Types {
     private void internalCompose(StringBuilder target) {
         int starterPos = 0;
         int starterCh = UTF16.charAt(target, 0);
-        int compPos = UTF16.getCharCount(starterCh); // length of last composition
+        int compPos = Character.charCount(starterCh); // length of last composition
         int lastClass = data.getCanonicalClass(starterCh);
         if (lastClass != 0) {
             lastClass = 256; // fix for strings staring with a combining mark
@@ -384,7 +384,7 @@ public final class Normalizer implements Transform<String, String>, UCD_Types {
         int ch;
         for (int decompPos = compPos;
                 decompPos < target.length();
-                decompPos += UTF16.getCharCount(ch)) {
+                decompPos += Character.charCount(ch)) {
             ch = UTF16.charAt(target, decompPos);
             if (SHOW_PROGRESS) {
                 System.out.println(
@@ -418,7 +418,7 @@ public final class Normalizer implements Transform<String, String>, UCD_Types {
                     decompPos += target.length() - oldLen;
                     oldLen = target.length();
                 }
-                compPos += UTF16.getCharCount(ch);
+                compPos += Character.charCount(ch);
             }
         }
         target.setLength(compPos);
@@ -505,7 +505,7 @@ public final class Normalizer implements Transform<String, String>, UCD_Types {
             }
             // if rest are just Mn or Me marks, then add to substitute mapping
             int cp;
-            for (int j = 1; j < b.length(); j += UTF16.getCharCount(cp)) {
+            for (int j = 1; j < b.length(); j += Character.charCount(cp)) {
                 cp = UTF16.charAt(b, j);
                 if (data.isNonSpacing(cp)) {
                     continue main;

--- a/unicodetools/src/main/java/org/unicode/text/UCD/Normalizer.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/Normalizer.java
@@ -343,7 +343,7 @@ public final class Normalizer implements Transform<String, String>, UCD_Types {
                         }
                     }
                 }
-                target.insert(k, UTF16.valueOf(ch));
+                UTF16Plus.insertCodePoint(target, k, ch);
             }
         }
     }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/Normalizer.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/Normalizer.java
@@ -334,12 +334,10 @@ public final class Normalizer implements Transform<String, String>, UCD_Types {
                 final int chClass = data.getCanonicalClass(ch);
                 int k = target.length(); // insertion point
                 if (chClass != 0 && reorder) {
-
                     // bubble-sort combining marks as necessary
-
                     int ch2;
                     for (; k > 0; k -= Character.charCount(ch2)) {
-                        ch2 = UTF16.charAt(target, k - 1);
+                        ch2 = target.codePointBefore(k);
                         if (data.getCanonicalClass(ch2) <= chClass) {
                             break;
                         }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/Normalizer.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/Normalizer.java
@@ -19,6 +19,7 @@ import org.unicode.cldr.util.Pair;
 import org.unicode.props.IndexUnicodeProperties;
 import org.unicode.props.NormalizationDataIUP;
 import org.unicode.text.utility.Settings;
+import org.unicode.text.utility.UTF16Plus;
 import org.unicode.text.utility.Utility;
 
 /**
@@ -497,18 +498,18 @@ public final class Normalizer implements Transform<String, String>, UCD_Types {
             }
             b.setLength(0);
             data.getRecursiveDecomposition(i, b, true);
-            if (b.length() == 1) { // TODO: isSingleCodePoint(b)?
+            if (UTF16Plus.isSingleCodePoint(b)) {
                 continue;
             }
-            final char firstChar = b.charAt(0);
+            final int firstChar = b.codePointAt(0);
             if (firstChar != 0x20 && firstChar != '\u0640') {
                 continue;
             }
             // if rest are just Mn or Me marks, then add to substitute mapping
             int cp;
-            // TODO: Start after first code point which could be j=2?
-            for (int j = 1; j < b.length(); j += Character.charCount(cp)) {
-                cp = UTF16.charAt(b, j);
+            int j = Character.charCount(firstChar);
+            for (; j < b.length(); j += Character.charCount(cp)) {
+                cp = b.codePointAt(j);
                 if (data.isNonSpacing(cp)) {
                     continue main;
                 }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/NormalizerSample.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/NormalizerSample.java
@@ -159,7 +159,7 @@ public class NormalizerSample implements UCD_Types {
 
                     int ch2;
                     for (; k > 0; k -= Character.charCount(ch2)) {
-                        ch2 = UTF16.charAt(target, k - 1);
+                        ch2 = target.codePointBefore(k);
                         if (data.getCanonicalClass(ch2) <= chClass) {
                             break;
                         }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/NormalizerSample.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/NormalizerSample.java
@@ -81,7 +81,7 @@ public class NormalizerSample implements UCD_Types {
      * @return target the resulting normalized text
      */
     public String normalize(int cp) {
-        return normalize(UTF16.valueOf(cp));
+        return normalize(Character.toString(cp));
     }
 
     /** */
@@ -89,7 +89,7 @@ public class NormalizerSample implements UCD_Types {
 
     public boolean hasDecomposition(int cp) {
         hasDecompositionBuffer.setLength(0);
-        normalize(UTF16.valueOf(cp), hasDecompositionBuffer);
+        normalize(Character.toString(cp), hasDecompositionBuffer);
         if (hasDecompositionBuffer.length() != 1) {
             return true;
         }
@@ -165,7 +165,7 @@ public class NormalizerSample implements UCD_Types {
                         }
                     }
                 }
-                target.insert(k, UTF16.valueOf(ch));
+                target.insert(k, Character.toString(ch));
             }
         }
     }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/NormalizerSample.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/NormalizerSample.java
@@ -139,7 +139,7 @@ public class NormalizerSample implements UCD_Types {
     private void internalDecompose(String source, StringBuffer target) {
         final StringBuffer buffer = new StringBuffer();
         int ch32;
-        for (int i = 0; i < source.length(); i += UTF16.getCharCount(ch32)) {
+        for (int i = 0; i < source.length(); i += Character.charCount(ch32)) {
             buffer.setLength(0);
             ch32 = UTF16.charAt(source, i);
             data.getRecursiveDecomposition(ch32, buffer, compatibility);
@@ -149,7 +149,7 @@ public class NormalizerSample implements UCD_Types {
             // no decomposition mapping)
 
             int ch;
-            for (int j = 0; j < buffer.length(); j += UTF16.getCharCount(ch)) {
+            for (int j = 0; j < buffer.length(); j += Character.charCount(ch)) {
                 ch = UTF16.charAt(buffer, j);
                 final int chClass = data.getCanonicalClass(ch);
                 int k = target.length(); // insertion point
@@ -158,7 +158,7 @@ public class NormalizerSample implements UCD_Types {
                     // bubble-sort combining marks as necessary
 
                     int ch2;
-                    for (; k > 0; k -= UTF16.getCharCount(ch2)) {
+                    for (; k > 0; k -= Character.charCount(ch2)) {
                         ch2 = UTF16.charAt(target, k - 1);
                         if (data.getCanonicalClass(ch2) <= chClass) {
                             break;
@@ -179,7 +179,7 @@ public class NormalizerSample implements UCD_Types {
     private void internalCompose(StringBuffer target) {
         int starterPos = 0;
         int starterCh = UTF16.charAt(target, 0);
-        int compPos = UTF16.getCharCount(starterCh); // length of last composition
+        int compPos = Character.charCount(starterCh); // length of last composition
         int lastClass = data.getCanonicalClass(starterCh);
         if (lastClass != 0) {
             lastClass = 256; // fix for strings staring with a combining mark
@@ -191,7 +191,7 @@ public class NormalizerSample implements UCD_Types {
         int ch;
         for (int decompPos = compPos;
                 decompPos < target.length();
-                decompPos += UTF16.getCharCount(ch)) {
+                decompPos += Character.charCount(ch)) {
             ch = UTF16.charAt(target, decompPos);
             if (SHOW_PROGRESS) {
                 System.out.println(
@@ -224,7 +224,7 @@ public class NormalizerSample implements UCD_Types {
                     decompPos += target.length() - oldLen;
                     oldLen = target.length();
                 }
-                compPos += UTF16.getCharCount(ch);
+                compPos += Character.charCount(ch);
             }
         }
         target.setLength(compPos);
@@ -273,7 +273,7 @@ public class NormalizerSample implements UCD_Types {
                             continue;
                         }
 
-                        final int b = UTF16.charAt(s, UTF16.getCharCount(a));
+                        final int b = UTF16.charAt(s, Character.charCount(a));
                         isSecond.set(b);
 
                         // have a recomposition, so set the bit
@@ -329,7 +329,7 @@ public class NormalizerSample implements UCD_Types {
             // we know we decompose all CANONICAL, plus > CANONICAL if compatibility is TRUE.
             if (dt == CANONICAL || dt > CANONICAL && compatibility) {
                 final String s = ucd.getDecompositionMapping(cp);
-                for (int i = 0; i < s.length(); i += UTF16.getCharCount(cp)) {
+                for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
                     cp = UTF16.charAt(s, i);
                     getRecursiveDecomposition(cp, buffer, compatibility);
                 }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/NormalizerSample.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/NormalizerSample.java
@@ -141,7 +141,7 @@ public class NormalizerSample implements UCD_Types {
         int ch32;
         for (int i = 0; i < source.length(); i += Character.charCount(ch32)) {
             buffer.setLength(0);
-            ch32 = UTF16.charAt(source, i);
+            ch32 = source.codePointAt(i);
             data.getRecursiveDecomposition(ch32, buffer, compatibility);
 
             // add all of the characters in the decomposition.
@@ -150,7 +150,7 @@ public class NormalizerSample implements UCD_Types {
 
             int ch;
             for (int j = 0; j < buffer.length(); j += Character.charCount(ch)) {
-                ch = UTF16.charAt(buffer, j);
+                ch = buffer.codePointAt(j);
                 final int chClass = data.getCanonicalClass(ch);
                 int k = target.length(); // insertion point
                 if (chClass != 0) {
@@ -178,7 +178,7 @@ public class NormalizerSample implements UCD_Types {
      */
     private void internalCompose(StringBuffer target) {
         int starterPos = 0;
-        int starterCh = UTF16.charAt(target, 0);
+        int starterCh = target.codePointAt(0);
         int compPos = Character.charCount(starterCh); // length of last composition
         int lastClass = data.getCanonicalClass(starterCh);
         if (lastClass != 0) {
@@ -192,7 +192,7 @@ public class NormalizerSample implements UCD_Types {
         for (int decompPos = compPos;
                 decompPos < target.length();
                 decompPos += Character.charCount(ch)) {
-            ch = UTF16.charAt(target, decompPos);
+            ch = target.codePointAt(decompPos);
             if (SHOW_PROGRESS) {
                 System.out.println(
                         Utility.hex(target)
@@ -268,7 +268,7 @@ public class NormalizerSample implements UCD_Types {
                             }
                             continue;
                         }
-                        final int a = UTF16.charAt(s, 0);
+                        final int a = s.codePointAt(0);
                         if (ucd.getCombiningClass(a) != 0) {
                             continue;
                         }
@@ -330,7 +330,7 @@ public class NormalizerSample implements UCD_Types {
             if (dt == CANONICAL || dt > CANONICAL && compatibility) {
                 final String s = ucd.getDecompositionMapping(cp);
                 for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-                    cp = UTF16.charAt(s, i);
+                    cp = s.codePointAt(i);
                     getRecursiveDecomposition(cp, buffer, compatibility);
                 }
             } else {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/NormalizerSample.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/NormalizerSample.java
@@ -334,7 +334,7 @@ public class NormalizerSample implements UCD_Types {
                     getRecursiveDecomposition(cp, buffer, compatibility);
                 }
             } else {
-                UTF16.append(buffer, cp);
+                buffer.appendCodePoint(cp);
             }
         }
 

--- a/unicodetools/src/main/java/org/unicode/text/UCD/NormalizerSample.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/NormalizerSample.java
@@ -273,7 +273,7 @@ public class NormalizerSample implements UCD_Types {
                             continue;
                         }
 
-                        final int b = UTF16.charAt(s, Character.charCount(a));
+                        final int b = s.codePointAt(Character.charCount(a));
                         isSecond.set(b);
 
                         // have a recomposition, so set the bit

--- a/unicodetools/src/main/java/org/unicode/text/UCD/TestData.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/TestData.java
@@ -17,7 +17,6 @@ import com.ibm.icu.text.DecimalFormatSymbols;
 import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.text.RuleBasedCollator;
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import com.ibm.icu.util.Currency;
@@ -291,7 +290,7 @@ public class TestData implements UCD_Types {
             final UnicodeSet base = new UnicodeSet("[:" + script + ":]");
             final UnicodeSetIterator it = new UnicodeSetIterator(base);
             while (it.next()) {
-                final String s2 = UTF16.valueOf(it.codepoint);
+                final String s2 = Character.toString(it.codepoint);
                 final String norm = Default.nfd().normalize(s2);
                 if (s2.equals(norm) && Default.nfkd().isNormalized(norm)) {
                     log.println("# " + s2 + " <> XXX # " + Default.ucd().getName(it.codepoint));
@@ -324,7 +323,7 @@ public class TestData implements UCD_Types {
                 continue;
             }
             // if (compat == (ucd.getDecompositionType(i) > UCD.CANONICAL)) continue;
-            final String str = UTF16.valueOf(i);
+            final String str = Character.toString(i);
             final String simpleLower = ucd.getCase(str, SIMPLE, LOWER);
             final String fullFold = ucd.getCase(str, FULL, FOLD);
 
@@ -527,7 +526,7 @@ public class TestData implements UCD_Types {
             if (gc == Cn || gc == PRIVATE_USE) {
                 continue;
             }
-            final String str = UTF16.valueOf(i);
+            final String str = Character.toString(i);
             if (!str.equals(ucd.getCase(str, FULL, FOLD))) {
                 hasFold.add(i);
                 scripts.set(ucd.getScript(i));

--- a/unicodetools/src/main/java/org/unicode/text/UCD/TestData.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/TestData.java
@@ -720,7 +720,7 @@ public class TestData implements UCD_Types {
             // if (nfd.equals(it.getString())) continue;
             int cp;
             for (int i = 0; i < nfd.length(); i += Character.charCount(cp)) {
-                cp = UTF16.charAt(nfd, i);
+                cp = nfd.codePointAt(i);
                 boolean shown = false;
                 final String newValue = up.getValue(cp);
                 final String possIgnValue = ignProp.getValue(cp);

--- a/unicodetools/src/main/java/org/unicode/text/UCD/TestData.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/TestData.java
@@ -719,7 +719,7 @@ public class TestData implements UCD_Types {
             }
             // if (nfd.equals(it.getString())) continue;
             int cp;
-            for (int i = 0; i < nfd.length(); i += UTF16.getCharCount(cp)) {
+            for (int i = 0; i < nfd.length(); i += Character.charCount(cp)) {
                 cp = UTF16.charAt(nfd, i);
                 boolean shown = false;
                 final String newValue = up.getValue(cp);

--- a/unicodetools/src/main/java/org/unicode/text/UCD/TestIdentifiers.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/TestIdentifiers.java
@@ -374,7 +374,7 @@ public class TestIdentifiers {
     public static int getSingleScript(String source) {
         int lastScript = UScript.INVALID_CODE;
         int cp;
-        for (int i = 0; i < source.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < source.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(source, i);
             int script = UScript.getScript(cp);
             if (script == UScript.COMMON || script == UScript.INHERITED) {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/TestIdentifiers.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/TestIdentifiers.java
@@ -4,7 +4,6 @@ import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UScript;
 import com.ibm.icu.text.Normalizer;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import java.io.BufferedReader;
@@ -222,7 +221,7 @@ public class TestIdentifiers {
             return null;
         }
         final XEquivalenceClass ec = (XEquivalenceClass) type_equivalences.get(type);
-        return ec.getEquivalences(UTF16.valueOf(cp));
+        return ec.getEquivalences(Character.toString(cp));
     }
 
     void loadWholeScriptConfusables(String filterType) throws IOException {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/TestIdentifiers.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/TestIdentifiers.java
@@ -375,7 +375,7 @@ public class TestIdentifiers {
         int lastScript = UScript.INVALID_CODE;
         int cp;
         for (int i = 0; i < source.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(source, i);
+            cp = source.codePointAt(i);
             int script = UScript.getScript(cp);
             if (script == UScript.COMMON || script == UScript.INHERITED) {
                 if (XIDContinueSet.contains(cp)) {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/TestNormalization.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/TestNormalization.java
@@ -9,7 +9,6 @@
  */
 package org.unicode.text.UCD;
 
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import java.io.BufferedReader;
@@ -25,6 +24,7 @@ import java.util.TreeMap;
 import org.unicode.props.BagFormatter;
 import org.unicode.text.utility.ChainException;
 import org.unicode.text.utility.Settings;
+import org.unicode.text.utility.UTF16Plus;
 import org.unicode.text.utility.UTF32;
 import org.unicode.text.utility.Utility;
 
@@ -96,7 +96,7 @@ public final class TestNormalization {
                 for (int i = 0; i < splitCount; ++i) {
                     parts[i] = Utility.fromHex(parts[i]);
                 }
-                if (UTF16.countCodePoint(parts[0]) == 1) {
+                if (UTF16Plus.isSingleCodePoint(parts[0])) {
                     final int code = parts[0].codePointAt(0);
                     charsListed.set(code);
                     if ((code & 0x3FF) == 0) {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/TestUnicodeInvariants.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/TestUnicodeInvariants.java
@@ -1347,7 +1347,7 @@ public class TestUnicodeInvariants {
                                             + values);
                         }
                         buffer.setLength(0);
-                        for (int j = 0; j < value.length(); j += UTF16.getCharCount(cp)) {
+                        for (int j = 0; j < value.length(); j += Character.charCount(cp)) {
                             cp = UTF16.charAt(value, j);
                             if (!propOrFilter.filter.contains(cp)) {
                                 continue;
@@ -1365,7 +1365,7 @@ public class TestUnicodeInvariants {
                                             + values);
                         }
                         buffer.setLength(0);
-                        for (int j = 0; j < value.length(); j += UTF16.getCharCount(cp)) {
+                        for (int j = 0; j < value.length(); j += Character.charCount(cp)) {
                             cp = UTF16.charAt(value, j);
                             final String value2 = propOrFilter.prop.getValue(cp);
                             buffer.append(value2);
@@ -1381,7 +1381,7 @@ public class TestUnicodeInvariants {
                                             + values);
                         }
                         values = new ArrayList<>();
-                        for (int j = 0; j < value.length(); j += UTF16.getCharCount(cp)) {
+                        for (int j = 0; j < value.length(); j += Character.charCount(cp)) {
                             cp = UTF16.charAt(value, j);
                             final String value2 = propOrFilter.prop.getValue(cp);
                             values.add(value2);
@@ -1976,7 +1976,7 @@ public class TestUnicodeInvariants {
     private static int scan(UnicodeSet allowed, CharSequence line, int start, boolean in) {
         int cp = 0;
         int i;
-        for (i = start; i < line.length(); i += UTF16.getCharCount(cp)) {
+        for (i = start; i < line.length(); i += Character.charCount(cp)) {
             cp = Character.codePointAt(line, i);
             if (allowed.contains(cp) != in) {
                 break;

--- a/unicodetools/src/main/java/org/unicode/text/UCD/TestUnicodeInvariants.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/TestUnicodeInvariants.java
@@ -1070,8 +1070,9 @@ public class TestUnicodeInvariants {
                 return null;
             }
             int start = next.getIndex();
-            if (PATTERN_SYNTAX.contains(text.codePointAt(start))) {
-                final String syntax = Character.toString(text.codePointAt(start));
+            int startCp = text.codePointAt(start);
+            if (PATTERN_SYNTAX.contains(startCp)) {
+                final String syntax = Character.toString(startCp);
                 next.setIndex(start + syntax.length());
                 final String marks = scan(NONSPACING_MARK, text, next, true);
                 return new Lookahead(syntax + marks, pp, next);

--- a/unicodetools/src/main/java/org/unicode/text/UCD/TestUnicodeInvariants.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/TestUnicodeInvariants.java
@@ -5,7 +5,6 @@ import com.ibm.icu.dev.tool.UOption;
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import java.io.BufferedReader;
@@ -1348,7 +1347,7 @@ public class TestUnicodeInvariants {
                         }
                         buffer.setLength(0);
                         for (int j = 0; j < value.length(); j += Character.charCount(cp)) {
-                            cp = UTF16.charAt(value, j);
+                            cp = value.codePointAt(j);
                             if (!propOrFilter.filter.contains(cp)) {
                                 continue;
                             }
@@ -1366,7 +1365,7 @@ public class TestUnicodeInvariants {
                         }
                         buffer.setLength(0);
                         for (int j = 0; j < value.length(); j += Character.charCount(cp)) {
-                            cp = UTF16.charAt(value, j);
+                            cp = value.codePointAt(j);
                             final String value2 = propOrFilter.prop.getValue(cp);
                             buffer.append(value2);
                         }
@@ -1382,7 +1381,7 @@ public class TestUnicodeInvariants {
                         }
                         values = new ArrayList<>();
                         for (int j = 0; j < value.length(); j += Character.charCount(cp)) {
-                            cp = UTF16.charAt(value, j);
+                            cp = value.codePointAt(j);
                             final String value2 = propOrFilter.prop.getValue(cp);
                             values.add(value2);
                         }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/ToolIdna2008.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/ToolIdna2008.java
@@ -30,7 +30,7 @@ public class ToolIdna2008 {
     //        UnicodeSet Unstable = new UnicodeSet();
     //        Normalizer toNfkc = Default.nfkc();
     //        for (int i = 0; i <= 0x10FFFF; ++i) {
-    //            String s = UTF16.valueOf(i);
+    //            String s = Character.toString(i);
     //            String nfkc = toNfkc.normalize(s);
     //            String cased = Default.ucd().getCase(s, UCD_Types.FULL, UCD_Types.FOLD);
     //            String full = toNfkc.normalize(cased);

--- a/unicodetools/src/main/java/org/unicode/text/UCD/ToolUnicodePropertySource.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/ToolUnicodePropertySource.java
@@ -7,7 +7,6 @@ import com.ibm.icu.text.IDNA;
 import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.text.StringPrep;
 import com.ibm.icu.text.StringPrepParseException;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ULocale;
 import com.ibm.icu.util.VersionInfo;
@@ -547,7 +546,7 @@ public class ToolUnicodePropertySource extends UnicodeProperty.Factory {
                 new UnicodeProperty.SimpleProperty() {
                     @Override
                     public String _getValue(int codepoint) {
-                        return UTF16.valueOf(ucd.getBidi_Paired_Bracket(codepoint));
+                        return Character.toString(ucd.getBidi_Paired_Bracket(codepoint));
                     }
                 }.setValues("<string>")
                         .setMain(
@@ -2343,7 +2342,7 @@ public class ToolUnicodePropertySource extends UnicodeProperty.Factory {
     }
 
     public static boolean equals(int codepoint, String string) {
-        return UTF16.valueOf(codepoint).equals(string);
+        return Character.toString(codepoint).equals(string);
     }
 
     static List<String> lookup(
@@ -2418,7 +2417,7 @@ public class ToolUnicodePropertySource extends UnicodeProperty.Factory {
             if (cp == '-') {
                 return IdnaType.OK;
             }
-            final String source = UTF16.valueOf(cp);
+            final String source = Character.toString(cp);
             try {
                 String result = namePrep.prepare(source, IDNA.DEFAULT);
                 if (!source.equals(result)) {

--- a/unicodetools/src/main/java/org/unicode/text/UCD/UCD.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/UCD.java
@@ -172,7 +172,7 @@ public final class UCD implements UCD_Types {
         }
         final StringBuffer result = new StringBuffer();
         int cp;
-        for (int i = 0; i < s.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(s, i);
             if (i > 0) {
                 result.append(separator);

--- a/unicodetools/src/main/java/org/unicode/text/UCD/UCD.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/UCD.java
@@ -33,6 +33,7 @@ import org.unicode.props.UcdPropertyValues.Bidi_Class_Values;
 import org.unicode.props.UnicodeProperty;
 import org.unicode.text.utility.ChainException;
 import org.unicode.text.utility.Settings;
+import org.unicode.text.utility.UTF16Plus;
 import org.unicode.text.utility.UTF32;
 import org.unicode.text.utility.Utility;
 
@@ -652,7 +653,7 @@ public final class UCD implements UCD_Types {
     static final char APOSTROPHE = '\u2019';
 
     public String getCase(String s, byte simpleVsFull, byte caseType, String condition) {
-        if (UTF16.countCodePoint(s) == 1) {
+        if (UTF16Plus.isSingleCodePoint(s)) {
             return getCase(s.codePointAt(0), simpleVsFull, caseType);
         }
         final StringBuffer result = new StringBuffer();

--- a/unicodetools/src/main/java/org/unicode/text/UCD/UCD.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/UCD.java
@@ -11,7 +11,6 @@ package org.unicode.text.UCD;
 
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.VersionInfo;
 import java.io.BufferedInputStream;
@@ -214,7 +213,7 @@ public final class UCD implements UCD_Types {
         return getCode(codePoint)
                 + (charTrans == null
                         ? " "
-                        : " ( " + charTrans.transliterate(UTF16.valueOf(codePoint)) + " ) ")
+                        : " ( " + charTrans.transliterate(Character.toString(codePoint)) + " ) ")
                 + getName(codePoint, type);
     }
 

--- a/unicodetools/src/main/java/org/unicode/text/UCD/UCD.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/UCD.java
@@ -173,7 +173,7 @@ public final class UCD implements UCD_Types {
         final StringBuffer result = new StringBuffer();
         int cp;
         for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(s, i);
+            cp = s.codePointAt(i);
             if (i > 0) {
                 result.append(separator);
             }
@@ -195,7 +195,7 @@ public final class UCD implements UCD_Types {
         final StringBuffer result = new StringBuffer();
         int cp;
         for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(s, i);
+            cp = s.codePointAt(i);
             if (i > 0) {
                 result.append(", ");
             }
@@ -232,7 +232,7 @@ public final class UCD implements UCD_Types {
         final StringBuffer result = new StringBuffer();
         int cp;
         for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(s, i);
+            cp = s.codePointAt(i);
             if (i > 0) {
                 result.append(", ");
             }
@@ -661,7 +661,7 @@ public final class UCD implements UCD_Types {
         final UCDProperty defaultIgnorable = DerivedProperty.make(UCD_Types.DefaultIgnorable, this);
 
         for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(s, i);
+            cp = s.codePointAt(i);
             final String mappedVersion = getCase(cp, simpleVsFull, currentCaseType, condition);
             result.append(mappedVersion);
             if (caseType == TITLE) { // set the case type for the next character
@@ -826,7 +826,7 @@ public final class UCD implements UCD_Types {
         }
         int cp;
         for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(s, i);
+            cp = s.codePointAt(i);
             final short script = getScript(cp);
             if (script == INHERITED_SCRIPT) {
                 continue;
@@ -1508,7 +1508,7 @@ public final class UCD implements UCD_Types {
         }
         int cp;
         for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(s, i);
+            cp = s.codePointAt(i);
             if (i == 0) {
                 if (!isIdentifierStart(cp)) {
                     return false;

--- a/unicodetools/src/main/java/org/unicode/text/UCD/UData.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/UData.java
@@ -10,7 +10,6 @@
  */
 package org.unicode.text.UCD;
 
-import com.ibm.icu.text.UTF16;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -186,7 +185,7 @@ class UData implements UCD_Types {
     }
 
     public void fleshOut() {
-        final String codeValue = codePoint >= 0 ? UTF16.valueOf(codePoint) : "\uFFFD";
+        final String codeValue = codePoint >= 0 ? Character.toString(codePoint) : "\uFFFD";
         if (codePoint == 0x13A0) {
             int debug = 0;
         }
@@ -239,12 +238,12 @@ class UData implements UCD_Types {
                 continue;
             }
             int c2 = GenerateCaseFolding.simpleAdditions[i + 1];
-            String s2 = UTF16.valueOf(c2);
+            String s2 = Character.toString(c2);
             if (simpleCaseFolding != null) {
                 if (simpleCaseFolding.equals(s2)) {
                     break;
                 }
-                String s1 = UTF16.valueOf(c1);
+                String s1 = Character.toString(c1);
                 throw new IllegalArgumentException(
                         String.format(
                                 "UData: Trying to add scf(U+%04X)→U+%04X (%s→%s) "

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VerifyUCD.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VerifyUCD.java
@@ -471,7 +471,7 @@ public class VerifyUCD implements UCD_Types {
         byte lastBidi = -1;
         int cp;
         for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(s, i);
+            cp = s.codePointAt(i);
             byte bidi = Default.ucd().getBidiClass(cp);
             if (compact) {
                 if (bidi == BIDI_NSM) {
@@ -1141,7 +1141,7 @@ public class VerifyUCD implements UCD_Types {
         int cp;
         if (!doEnd) {
             for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-                cp = UTF16.charAt(s, i);
+                cp = s.codePointAt(i);
                 final int cc = Default.ucd().getCombiningClass(cp);
                 if (cc == 0) {
                     return s.substring(0, i);
@@ -1215,7 +1215,7 @@ public class VerifyUCD implements UCD_Types {
 
             int cp2;
             for (int i = 0; i < full.length(); i += Character.charCount(cp2)) {
-                cp2 = UTF16.charAt(full, i);
+                cp2 = full.codePointAt(i);
                 int ccc2 = Default.ucd.getCombiningClass(cp2);
                 if (ccc2 != ccc) {
                     System.out.println("Case fold CCC fails at " + Default.ucd.getCodeAndName(cp));
@@ -1382,7 +1382,7 @@ public class VerifyUCD implements UCD_Types {
                 int cp2;
                 boolean excluded = false;
                 for (int j = 0; j < kc.length(); j += Character.charCount(cp2)) {
-                    cp2 = UTF16.charAt(kc, j);
+                    cp2 = kc.codePointAt(j);
                     if (prohibited.get(cp2)) {
                         showError("Prohibited with NFKC, but output with NFC", cp, "");
                         excluded = true;
@@ -2079,7 +2079,7 @@ public class VerifyUCD implements UCD_Types {
                 if (UTF16.countCodePoint(key) != 1) {
                     throw new ChainException("First IDN field not single character: " + line, null);
                 }
-                final int cp = UTF16.charAt(key, 0);
+                final int cp = key.codePointAt(0);
                 if (!Default.ucd().isAssigned(cp) || Default.ucd().isPUA(cp)) {
                     throw new ChainException("IDN character unassigned or PUA: " + line, null);
                 }
@@ -2317,7 +2317,7 @@ public class VerifyUCD implements UCD_Types {
         final StringBuffer result = new StringBuffer();
         int cp;
         for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(s, i);
+            cp = s.codePointAt(i);
             if (i != 0) {
                 result.append(' ');
             }
@@ -2585,7 +2585,7 @@ public class VerifyUCD implements UCD_Types {
     public static boolean noneHaveCategory(String s, byte cat, UCD ucd) {
         int cp;
         for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(s, i);
+            cp = s.codePointAt(i);
             final byte cat2 = ucd.getCategory(i);
             if (cat == cat2) {
                 return false;

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VerifyUCD.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VerifyUCD.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import org.unicode.text.utility.ChainException;
 import org.unicode.text.utility.Settings;
+import org.unicode.text.utility.UTF16Plus;
 import org.unicode.text.utility.UTF32;
 import org.unicode.text.utility.Utility;
 
@@ -2076,7 +2077,7 @@ public class VerifyUCD implements UCD_Types {
                 }
 
                 final String key = Utility.fromHex(parts[0]);
-                if (UTF16.countCodePoint(key) != 1) {
+                if (!UTF16Plus.isSingleCodePoint(key)) {
                     throw new ChainException("First IDN field not single character: " + line, null);
                 }
                 final int cp = key.codePointAt(0);
@@ -2311,7 +2312,7 @@ public class VerifyUCD implements UCD_Types {
     }
 
     static String getCategoryID(String s) {
-        if (UTF16.countCodePoint(s) == 1) {
+        if (UTF16Plus.isSingleCodePoint(s)) {
             return Default.ucd().getCategoryID(s.codePointAt(0));
         }
         final StringBuffer result = new StringBuffer();

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VerifyUCD.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VerifyUCD.java
@@ -421,7 +421,7 @@ public class VerifyUCD implements UCD_Types {
         final boolean result = !x.isNormalized(cp);
         if (false) {
             final String s = x.normalize(cp);
-            final boolean sResult = !s.equals(UTF16.valueOf(cp));
+            final boolean sResult = !s.equals(Character.toString(cp));
             if (result != sResult) {
                 System.out.println("Failure with " + x + " at " + Default.ucd().getCodeAndName(cp));
             }
@@ -443,7 +443,7 @@ public class VerifyUCD implements UCD_Types {
 
             final String decomp = Default.nfd().normalize(cp);
             final String comp = Default.nfc().normalize(cp);
-            final String source = UTF16.valueOf(cp);
+            final String source = Character.toString(cp);
 
             final String bidiDecomp = getBidi(decomp, true);
             final String bidiComp = getBidi(comp, true);
@@ -559,7 +559,7 @@ public class VerifyUCD implements UCD_Types {
             final byte cat = Default.ucd().getCategory(cp);
             // check if canonical equivalents are case-mapped to canonical equivalents
             if (cat != PRIVATE_USE && cat != SURROGATE) {
-                String str = UTF16.valueOf(cp);
+                String str = Character.toString(cp);
                 if (!checkNF_AndCase(str, false)) {
                     badChars.add(cp);
                 }
@@ -1183,7 +1183,7 @@ public class VerifyUCD implements UCD_Types {
             final String full = Default.ucd().getCase(cp, FULL, FOLD);
             final String simple = Default.ucd().getCase(cp, SIMPLE, FOLD);
 
-            final String realTest = "\u0360" + UTF16.valueOf(cp) + "\u0334";
+            final String realTest = "\u0360" + Character.toString(cp) + "\u0334";
 
             final int ccc = Default.ucd().getCombiningClass(cp);
 
@@ -1716,7 +1716,7 @@ public class VerifyUCD implements UCD_Types {
             // if (Default.ucd.hasComputableName(i)) continue;
             tempInteger = null;
 
-            final String original = UTF16.valueOf(i);
+            final String original = Character.toString(i);
             final String caseFold = Default.ucd().getCase(i, FULL, FOLD);
             if (!original.equals(caseFold)) {
                 tempInteger = new Integer(i);
@@ -2568,7 +2568,7 @@ public class VerifyUCD implements UCD_Types {
                     final String decomp = Default.nfd().normalize(i);
                     if (noneHaveCategory(decomp, Cn, older)) {
                         final String recomp = Default.nfc().normalize(decomp);
-                        if (recomp.equals(UTF16.valueOf(i))) {
+                        if (recomp.equals(Character.toString(i))) {
                             Utility.fixDot();
                             System.out.println(
                                     "FAILS COMP STABILITY: " + Default.ucd().getCodeAndName(i));

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VerifyUCD.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VerifyUCD.java
@@ -1149,7 +1149,7 @@ public class VerifyUCD implements UCD_Types {
             }
         } else {
             for (int i = s.length(); i > 0; i -= Character.charCount(cp)) {
-                cp = UTF16.charAt(s, i - 1); // will go 2 before if necessary
+                cp = s.codePointBefore(i);
                 final int cc = Default.ucd().getCombiningClass(cp);
                 if (cc == 0) {
                     return s.substring(i);

--- a/unicodetools/src/main/java/org/unicode/text/UCD/VerifyUCD.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/VerifyUCD.java
@@ -470,7 +470,7 @@ public class VerifyUCD implements UCD_Types {
         String result = "";
         byte lastBidi = -1;
         int cp;
-        for (int i = 0; i < s.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(s, i);
             byte bidi = Default.ucd().getBidiClass(cp);
             if (compact) {
@@ -1140,7 +1140,7 @@ public class VerifyUCD implements UCD_Types {
     public static String getMarks(String s, boolean doEnd) {
         int cp;
         if (!doEnd) {
-            for (int i = 0; i < s.length(); i += UTF16.getCharCount(cp)) {
+            for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
                 cp = UTF16.charAt(s, i);
                 final int cc = Default.ucd().getCombiningClass(cp);
                 if (cc == 0) {
@@ -1148,7 +1148,7 @@ public class VerifyUCD implements UCD_Types {
                 }
             }
         } else {
-            for (int i = s.length(); i > 0; i -= UTF16.getCharCount(cp)) {
+            for (int i = s.length(); i > 0; i -= Character.charCount(cp)) {
                 cp = UTF16.charAt(s, i - 1); // will go 2 before if necessary
                 final int cc = Default.ucd().getCombiningClass(cp);
                 if (cc == 0) {
@@ -1214,7 +1214,7 @@ public class VerifyUCD implements UCD_Types {
             int ccc = Default.ucd.getCombiningClass(cp);
 
             int cp2;
-            for (int i = 0; i < full.length(); i += UTF16.getCharCount(cp2)) {
+            for (int i = 0; i < full.length(); i += Character.charCount(cp2)) {
                 cp2 = UTF16.charAt(full, i);
                 int ccc2 = Default.ucd.getCombiningClass(cp2);
                 if (ccc2 != ccc) {
@@ -1381,7 +1381,7 @@ public class VerifyUCD implements UCD_Types {
                 }
                 int cp2;
                 boolean excluded = false;
-                for (int j = 0; j < kc.length(); j += UTF16.getCharCount(cp2)) {
+                for (int j = 0; j < kc.length(); j += Character.charCount(cp2)) {
                     cp2 = UTF16.charAt(kc, j);
                     if (prohibited.get(cp2)) {
                         showError("Prohibited with NFKC, but output with NFC", cp, "");
@@ -2584,7 +2584,7 @@ public class VerifyUCD implements UCD_Types {
 
     public static boolean noneHaveCategory(String s, byte cat, UCD ucd) {
         int cp;
-        for (int i = 0; i < s.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(s, i);
             final byte cat2 = ucd.getCategory(i);
             if (cat == cat2) {

--- a/unicodetools/src/main/java/org/unicode/text/tools/GenerateLabels.java
+++ b/unicodetools/src/main/java/org/unicode/text/tools/GenerateLabels.java
@@ -10,7 +10,6 @@ import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.CurrencyMetaInfo;
 import com.ibm.icu.text.CurrencyMetaInfo.CurrencyFilter;
 import com.ibm.icu.text.Normalizer2;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.Currency;
 import com.ibm.icu.util.Output;
@@ -94,7 +93,7 @@ public class GenerateLabels {
                         continue;
                     }
                     for (String label : lastLabel.value) {
-                        characterToRelation.put(label, UTF16.valueOf(cp));
+                        characterToRelation.put(label, Character.toString(cp));
                     }
                     missingPunctuation.remove(cp);
                     missingSymbols.remove(cp);

--- a/unicodetools/src/main/java/org/unicode/text/tools/IcannMsr.java
+++ b/unicodetools/src/main/java/org/unicode/text/tools/IcannMsr.java
@@ -4,7 +4,6 @@ import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UProperty;
 import com.ibm.icu.text.Collator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSet.EntryRange;
 import com.ibm.icu.util.ULocale;
@@ -299,8 +298,8 @@ public class IcannMsr {
                         + "\t # "
                         + (_type == null ? "" : "according to MSR 5 ")
                         + "( "
-                        + UTF16.valueOf(cpStart)
-                        + (cpStart == cpEnd ? "" : ".." + UTF16.valueOf(cpEnd))
+                        + Character.toString(cpStart)
+                        + (cpStart == cpEnd ? "" : ".." + Character.toString(cpEnd))
                         + " ) ["
                         + getGc(cpStart)
                         + (cpStart == cpEnd ? "" : "..")

--- a/unicodetools/src/main/java/org/unicode/text/tools/MakeEmojiTable.java
+++ b/unicodetools/src/main/java/org/unicode/text/tools/MakeEmojiTable.java
@@ -1,7 +1,6 @@
 package org.unicode.text.tools;
 
 import com.ibm.icu.impl.Utility;
-import com.ibm.icu.text.UTF16;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Locale;
@@ -38,7 +37,7 @@ public class MakeEmojiTable {
                     first = false;
                     out.println("</td></tr>");
                 }
-                String chars = UTF16.valueOf(hex);
+                String chars = Character.toString(hex);
                 String hexUpper = Utility.hex(hex);
                 String hexLower = hexUpper.toLowerCase(Locale.ROOT);
                 out.println(

--- a/unicodetools/src/main/java/org/unicode/text/tools/RenameFiles.java
+++ b/unicodetools/src/main/java/org/unicode/text/tools/RenameFiles.java
@@ -1,6 +1,5 @@
 package org.unicode.text.tools;
 
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.Output;
 import java.io.File;
@@ -211,11 +210,11 @@ public class RenameFiles {
                         //                    }
                         //                    // 1F469 1F3FB 200D 1F9B1 = woman, light skin, zwj
                         // curly
-                        //                    oldHex = UTF16.valueOf(first) + oldHex +
-                        // UTF16.valueOf(0x200d) + UTF16.valueOf(last);
+                        //                    oldHex = Character.toString(first) + oldHex +
+                        // Character.toString(0x200d) + Character.toString(last);
                         //                }
                         if (HEX_ADDITION != 0) {
-                            oldHex = UTF16.valueOf(HEX_ADDITION + oldHex.codePointAt(0));
+                            oldHex = Character.toString(HEX_ADDITION + oldHex.codePointAt(0));
                         }
                     }
             }

--- a/unicodetools/src/main/java/org/unicode/text/tools/ScriptPopulation.java
+++ b/unicodetools/src/main/java/org/unicode/text/tools/ScriptPopulation.java
@@ -22,6 +22,7 @@ import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.draft.CharacterFrequency;
 import org.unicode.text.tools.ScriptPopulation.Category.Extra;
+import org.unicode.text.utility.UTF16Plus;
 import org.unicode.tools.emoji.EmojiData;
 
 /** See CharacterFrequency for the base data */
@@ -82,7 +83,7 @@ class ScriptPopulation {
             // quick approximate normalization
             int i = UCharacter.foldCase(cp, true);
             String str = NFC.normalize(UTF16.valueOf(i));
-            if (1 == UTF16.countCodePoint(str)) {
+            if (UTF16Plus.isSingleCodePoint(str)) {
                 i = str.codePointAt(0);
             }
 
@@ -682,7 +683,7 @@ class ScriptPopulation {
             buffer.setLength(0);
             buffer.appendCodePoint(cp);
             String nfkcForm = nfkc.normalize(buffer);
-            if (UTF16.countCodePoint(nfkcForm) == 1) {
+            if (UTF16Plus.isSingleCodePoint(nfkcForm)) {
                 script = getBestScript(nfkcForm.codePointAt(0));
                 if (script != UScript.UNKNOWN
                         && script != UScript.COMMON

--- a/unicodetools/src/main/java/org/unicode/text/tools/ScriptPopulation.java
+++ b/unicodetools/src/main/java/org/unicode/text/tools/ScriptPopulation.java
@@ -8,7 +8,6 @@ import com.ibm.icu.lang.UScript.ScriptUsage;
 import com.ibm.icu.text.DecimalFormat;
 import com.ibm.icu.text.Normalizer2;
 import com.ibm.icu.text.NumberFormat;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ULocale;
 import java.util.BitSet;
@@ -82,7 +81,7 @@ class ScriptPopulation {
 
             // quick approximate normalization
             int i = UCharacter.foldCase(cp, true);
-            String str = NFC.normalize(UTF16.valueOf(i));
+            String str = NFC.normalize(Character.toString(i));
             if (UTF16Plus.isSingleCodePoint(str)) {
                 i = str.codePointAt(0);
             }
@@ -500,7 +499,7 @@ class ScriptPopulation {
                 break;
             }
             Double cFreq = topItems.getCount(codePoint);
-            String str = UTF16.valueOf(codePoint);
+            String str = Character.toString(codePoint);
             if (codePoint == '=' || codePoint == '"' || codePoint == '\'' || codePoint == '+') {
                 str = '\'' + str;
             }

--- a/unicodetools/src/main/java/org/unicode/text/tools/ShowCharacterFrequency.java
+++ b/unicodetools/src/main/java/org/unicode/text/tools/ShowCharacterFrequency.java
@@ -2,7 +2,6 @@ package org.unicode.text.tools;
 
 import com.ibm.icu.impl.Row.R2;
 import com.ibm.icu.impl.UnicodeMap;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.util.Locale;
 import org.unicode.cldr.util.Counter;
@@ -60,7 +59,7 @@ public class ShowCharacterFrequency {
             }
             double count = s.get0() * factor;
             System.out.println(
-                    UTF16.valueOf(cp)
+                    Character.toString(cp)
                             + "\t"
                             + count
                             + "%"

--- a/unicodetools/src/main/java/org/unicode/text/tools/ShowCharacters.java
+++ b/unicodetools/src/main/java/org/unicode/text/tools/ShowCharacters.java
@@ -4,7 +4,6 @@ import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R3;
 import com.ibm.icu.impl.Row.R5;
 import com.ibm.icu.impl.UnicodeMap;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import java.io.PrintWriter;
@@ -281,13 +280,13 @@ public class ShowCharacters {
         if (it.codepoint == it.codepointEnd) {
             return Row.of(
                     Utility.hex(it.codepoint),
-                    UTF16.valueOf(it.codepoint),
+                    Character.toString(it.codepoint),
                     Default.ucd().getName(it.codepoint));
         } else {
             final String sep = it.codepointEnd == it.codepoint + 1 ? "," : "…";
             return Row.of(
                     Utility.hex(it.codepoint) + sep + Utility.hex(it.codepointEnd),
-                    UTF16.valueOf(it.codepoint) + sep + UTF16.valueOf(it.codepointEnd),
+                    Character.toString(it.codepoint) + sep + Character.toString(it.codepointEnd),
                     Default.ucd().getName(it.codepoint)
                             + sep
                             + Default.ucd().getName(it.codepointEnd));

--- a/unicodetools/src/main/java/org/unicode/text/tools/VerifyUCD.java
+++ b/unicodetools/src/main/java/org/unicode/text/tools/VerifyUCD.java
@@ -236,7 +236,7 @@ public class VerifyUCD {
                     if (isStringProp) {
                         Object value2 = getValue(up, newCodepoint);
                         if (value2 == null) {
-                            value2 = UTF16.valueOf(newCodepoint);
+                            value2 = Character.toString(newCodepoint);
                         }
                         nfcStringPropertyValue += value2;
                         continue;
@@ -371,7 +371,7 @@ public class VerifyUCD {
         Object value1 = up.getValue(codepoint);
         if (value1 == null) {
             if ((type & UnicodeProperty.STRING_OR_MISC_MASK) != 0) {
-                value1 = UTF16.valueOf(codepoint);
+                value1 = Character.toString(codepoint);
             } else if ((type & UnicodeProperty.BINARY_MASK) != 0) {
                 value1 = UCD_Names.NO;
             }

--- a/unicodetools/src/main/java/org/unicode/text/tools/VerifyUCD.java
+++ b/unicodetools/src/main/java/org/unicode/text/tools/VerifyUCD.java
@@ -229,7 +229,7 @@ public class VerifyUCD {
                 final Object value1 = getValue(up, codepoint);
                 int newCodepoint;
                 String nfcStringPropertyValue = "";
-                for (int i = 0; i < normalized.length(); i += UTF16.getCharCount(newCodepoint)) {
+                for (int i = 0; i < normalized.length(); i += Character.charCount(newCodepoint)) {
                     newCodepoint = UTF16.charAt(normalized, i);
                     final int catMask = Default.ucd().getCategoryMask(newCodepoint);
                     // special case strings

--- a/unicodetools/src/main/java/org/unicode/text/tools/VerifyUCD.java
+++ b/unicodetools/src/main/java/org/unicode/text/tools/VerifyUCD.java
@@ -230,7 +230,7 @@ public class VerifyUCD {
                 int newCodepoint;
                 String nfcStringPropertyValue = "";
                 for (int i = 0; i < normalized.length(); i += Character.charCount(newCodepoint)) {
-                    newCodepoint = UTF16.charAt(normalized, i);
+                    newCodepoint = normalized.codePointAt(i);
                     final int catMask = Default.ucd().getCategoryMask(newCodepoint);
                     // special case strings
                     if (isStringProp) {

--- a/unicodetools/src/main/java/org/unicode/text/tools/VerifyXmlUcd.java
+++ b/unicodetools/src/main/java/org/unicode/text/tools/VerifyXmlUcd.java
@@ -1,7 +1,6 @@
 package org.unicode.text.tools;
 
 import com.ibm.icu.impl.Utility;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.io.File;
 import java.io.IOException;
@@ -358,7 +357,7 @@ public class VerifyXmlUcd {
             // if (type == UnicodeProperty.STRING) {
             // UCD marks no change with "". I reflect the full value, Eric doesn't.
             // however, this is tricky, so I'm still playing with it to get them to match up.
-            // if (UTF16.valueOf(cp).equals(toolValue)) {
+            // if (Character.toString(cp).equals(toolValue)) {
             // toolValue = "#";
             //        } else if (property.equals("lc") || property.equals("uc") ||
             // property.equals("tc")) {
@@ -399,7 +398,7 @@ public class VerifyXmlUcd {
 
             if (type == UnicodeProperty.STRING) {
                 // Eric is using hex strings, no disagreement
-                final String cpString = UTF16.valueOf(cp);
+                final String cpString = Character.toString(cp);
                 if (cpString.equals(toolValue) && property.equals("bmg")) {
                     toolValue = "";
                 } else {

--- a/unicodetools/src/main/java/org/unicode/text/utility/TestUtility.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/TestUtility.java
@@ -173,7 +173,7 @@ public class TestUtility {
         if (i <= 0xFFFF) {
             return false;
         }
-        return i == UTF16.charAt(value, 0);
+        return i == value.codePointAt(0);
     }
 
     /** */

--- a/unicodetools/src/main/java/org/unicode/text/utility/TestUtility.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/TestUtility.java
@@ -11,7 +11,6 @@ package org.unicode.text.utility;
 
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.impl.UnicodeMapIterator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import java.io.ByteArrayInputStream;
@@ -325,7 +324,7 @@ public class TestUtility {
     /** */
     private static void testStreamCompressor() throws IOException {
         final Object[] tests = {
-            UTF16.valueOf(0x10FFFF),
+            Character.toString(0x10FFFF),
             "\u1234",
             "abc",
             new Long(-3),

--- a/unicodetools/src/main/java/org/unicode/text/utility/UTF16Plus.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/UTF16Plus.java
@@ -10,8 +10,26 @@
 package org.unicode.text.utility;
 
 public final class UTF16Plus {
-    public static boolean isSingleCodePoint(CharSequence seq) {
-        final int length = seq.length();
-        return length > 0 && Character.offsetByCodePoints(seq, 0, 1) == length;
+    public static boolean isSingleCodePoint(CharSequence s) {
+        return s.length() == 1
+                || (s.length() == 2 && Character.isSurrogatePair(s.charAt(0), s.charAt(1)));
+    }
+
+    public static boolean isCodePointBoundary(CharSequence s, int offset) {
+        if (offset < 0 || offset > s.length()) {
+            return false;
+        }
+        if (offset == 0 || offset == s.length()) {
+            return true;
+        }
+        return !Character.isSurrogatePair(s.charAt(offset - 1), s.charAt(offset));
+    }
+
+    /** Throws an IllegalArgumentException if !isCodePointBoundary(). */
+    public static void checkCodePointBoundary(CharSequence s, int offset) {
+        if (!isCodePointBoundary(s, offset)) {
+            throw new IllegalArgumentException(
+                    "not a code point boundary:\n" + s.toString() + "\nat offset " + offset);
+        }
     }
 }

--- a/unicodetools/src/main/java/org/unicode/text/utility/UTF16Plus.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/UTF16Plus.java
@@ -33,6 +33,12 @@ public final class UTF16Plus {
         }
     }
 
+    /** Equivalent to Character.toString(s.codePointAt(offset)). */
+    public static String codePointSubstringAt(String s, int offset) {
+        int limit = Character.offsetByCodePoints(s, offset, 1);
+        return s.substring(offset, limit);
+    }
+
     public static StringBuilder insertCodePoint(StringBuilder sb, int offset, int c) {
         if (Character.isBmpCodePoint(c)) {
             sb.insert(offset, (char) c);

--- a/unicodetools/src/main/java/org/unicode/text/utility/UTF16Plus.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/UTF16Plus.java
@@ -32,4 +32,14 @@ public final class UTF16Plus {
                     "not a code point boundary:\n" + s.toString() + "\nat offset " + offset);
         }
     }
+
+    public static StringBuilder insertCodePoint(StringBuilder sb, int offset, int c) {
+        if (Character.isBmpCodePoint(c)) {
+            sb.insert(offset, (char) c);
+        } else {
+            sb.insert(offset++, Character.highSurrogate(c));
+            sb.insert(offset, Character.lowSurrogate(c));
+        }
+        return sb;
+    }
 }

--- a/unicodetools/src/main/java/org/unicode/text/utility/UTF32.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/UTF32.java
@@ -15,18 +15,6 @@ package org.unicode.text.utility;
  */
 public final class UTF32 {
     /**
-     * Determines whether the code point is a surrogate. TODO: Propose again to widen
-     * UTF16.isSurrogate(char) to take an int. Or maybe add UTF16.isSurrogateCodePoint(int) or
-     * isCodePointSurrogate(int).
-     *
-     * @return true iff the input character is a surrogate.
-     * @param ch the input character.
-     */
-    public static boolean isSurrogate(int char32) {
-        return Character.MIN_SURROGATE <= char32 && char32 <= Character.MAX_SURROGATE;
-    }
-
-    /**
      * Convenience method corresponding to String.valueOf(char). It returns a one or two char string
      * containing the UTF-32 value. If the input value can't be converted, it substitutes the
      * replacement character U+FFFD.

--- a/unicodetools/src/main/java/org/unicode/text/utility/UTF32.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/UTF32.java
@@ -9,8 +9,6 @@
  */
 package org.unicode.text.utility;
 
-import com.ibm.icu.text.UTF16;
-
 /**
  * Utility class for dealing with UTF-16 strings and code points. Provides only methods that are not
  * available in Java itself, nor in ICU.
@@ -35,13 +33,13 @@ public final class UTF32 {
      *
      * @return string value of char32
      * @param ch the input character.
-     * @deprecated Try to use UTF16.valueOf(char32), but that throws an exception for illegal code
-     *     points.
+     * @deprecated Try to use Character.toString(char32), but that throws an exception for illegal
+     *     code points.
      */
     @Deprecated
     public static String valueOf32(int char32) {
         try {
-            return UTF16.valueOf(char32);
+            return Character.toString(char32);
         } catch (IllegalArgumentException e) {
             return "\uFFFD";
         }

--- a/unicodetools/src/main/java/org/unicode/text/utility/UnicodeTransform.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/UnicodeTransform.java
@@ -7,7 +7,6 @@
 package org.unicode.text.utility;
 
 import com.ibm.icu.text.Transform;
-import com.ibm.icu.text.UTF16;
 
 /**
  * Simple wrapping for normalizer that allows for both the standard ICU normalizer, and one built
@@ -49,11 +48,11 @@ public abstract class UnicodeTransform implements Transform<String, String> {
 
     /** Can be overridden for performance. */
     public String transform(int source) {
-        return transform(UTF16.valueOf(source));
+        return transform(Character.toString(source));
     }
 
     /** Can be overridden for performance. */
     public boolean isTransformed(int source) {
-        return isTransformed(UTF16.valueOf(source));
+        return isTransformed(Character.toString(source));
     }
 }

--- a/unicodetools/src/main/java/org/unicode/text/utility/Utility.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/Utility.java
@@ -14,6 +14,7 @@ import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.Replaceable;
 import com.ibm.icu.text.Transliterator;
+import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeMatcher;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.VersionInfo;
@@ -784,7 +785,7 @@ public final class Utility implements UCD_Types { // COMMON UTILITIES
         }
 
         // fix surrogates, since XML can't handle
-        if (UTF32.isSurrogate(c)) {
+        if (UTF16.isSurrogate(c)) {
             return HTML ? '#' + hex(c, 4) : "<codepoint hex=\"" + hex(c, 1) + "\"/>";
         }
 

--- a/unicodetools/src/main/java/org/unicode/text/utility/Utility.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/Utility.java
@@ -420,7 +420,7 @@ public final class Utility implements UCD_Types { // COMMON UTILITIES
 
     public static int codePointFromHex(String p) {
         final String temp = Utility.fromHex(p);
-        if (UTF16.countCodePoint(temp) != 1) {
+        if (!UTF16Plus.isSingleCodePoint(temp)) {
             throw new ChainException("String is not single (UTF32) character: " + p, null);
         }
         return temp.codePointAt(0);

--- a/unicodetools/src/main/java/org/unicode/text/utility/Utility.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/Utility.java
@@ -318,7 +318,7 @@ public final class Utility implements UCD_Types { // COMMON UTILITIES
             if (i != 0) {
                 result.append(separator);
             }
-            ch = UTF16.charAt(s, i);
+            ch = s.codePointAt(i);
             result.append(hex(ch, places));
         }
         return result.toString();
@@ -808,7 +808,7 @@ public final class Utility implements UCD_Types { // COMMON UTILITIES
         }
         final StringBuffer result = new StringBuffer();
         for (int i = 0; i < source.length(); ++i) {
-            final int c = UTF16.charAt(source, i);
+            final int c = source.codePointAt(i);
             if (Character.isSupplementaryCodePoint(c)) {
                 ++i;
             }

--- a/unicodetools/src/main/java/org/unicode/text/utility/Utility.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/Utility.java
@@ -14,7 +14,6 @@ import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.Replaceable;
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeMatcher;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.VersionInfo;
@@ -1889,7 +1888,7 @@ public final class Utility implements UCD_Types { // COMMON UTILITIES
                                         + "\t# "
                                         + (useHTML ? "(" + getUnicodeImage(cp) + ") " : "")
                                         + (withChar && (cp >= 0x20)
-                                                ? "(" + UTF16.valueOf(cp) + ") "
+                                                ? "(" + Character.toString(cp) + ") "
                                                 : "")
                                         + (names != null ? names.getValue(cp) + " " : "")
                                         + ucd.getName(cp)
@@ -1907,9 +1906,9 @@ public final class Utility implements UCD_Types { // COMMON UTILITIES
                                     + "\t# "
                                     + (withChar && (start >= 0x20)
                                             ? " ("
-                                                    + UTF16.valueOf(start)
+                                                    + Character.toString(start)
                                                     + ((start != end)
-                                                            ? (".." + UTF16.valueOf(end))
+                                                            ? (".." + Character.toString(end))
                                                             : "")
                                                     + ") "
                                             : "")

--- a/unicodetools/src/main/java/org/unicode/text/utility/UtilityBase.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/UtilityBase.java
@@ -1,6 +1,5 @@
 package org.unicode.text.utility;
 
-import com.ibm.icu.text.UTF16;
 import org.unicode.text.UCD.Default;
 import org.unicode.text.UCD.DerivedProperty;
 import org.unicode.text.UCD.UCDProperty;
@@ -9,7 +8,7 @@ import org.unicode.text.UCD.UCD_Types;
 public class UtilityBase implements UCD_Types {
 
     public static String getDisplay(int cp) {
-        String result = UTF16.valueOf(cp);
+        String result = Character.toString(cp);
         final byte cat = Default.ucd().getCategory(cp);
         if (cat == Mn || cat == Me) {
             result = String.valueOf(DOTTED_CIRCLE) + result;

--- a/unicodetools/src/main/java/org/unicode/tools/AacOrder.java
+++ b/unicodetools/src/main/java/org/unicode/tools/AacOrder.java
@@ -3,7 +3,6 @@ package org.unicode.tools;
 import com.google.common.collect.ImmutableSet;
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.lang.UCharacter;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSet.EntryRange;
 import com.ibm.icu.util.VersionInfo;
@@ -164,13 +163,13 @@ public class AacOrder {
                 separator = ",";
                 out.println(
                         "\n// ("
-                                + UTF16.valueOf(entry.codepoint)
+                                + Character.toString(entry.codepoint)
                                 + ") "
                                 + getName(entry.codepoint)
                                 + (entry.codepointEnd == entry.codepoint
                                         ? ""
                                         : "\t..\t("
-                                                + UTF16.valueOf(entry.codepointEnd)
+                                                + Character.toString(entry.codepointEnd)
                                                 + ") "
                                                 + getName(entry.codepointEnd)));
                 out.print(
@@ -199,7 +198,7 @@ public class AacOrder {
 
     private static String getName(int codepoint) {
         try {
-            return getName(UTF16.valueOf(codepoint));
+            return getName(Character.toString(codepoint));
         } catch (Exception e) {
             return UCharacter.getExtendedName(codepoint);
         }
@@ -253,7 +252,7 @@ public class AacOrder {
         private String getName(int s) {
             String name = null;
             try {
-                name = EMOJI_DATA.getName(UTF16.valueOf(s));
+                name = EMOJI_DATA.getName(Character.toString(s));
             } catch (Exception e) {
             }
             return name != null ? name : UCharacter.getName(s);

--- a/unicodetools/src/main/java/org/unicode/tools/CollatorEquivalences.java
+++ b/unicodetools/src/main/java/org/unicode/tools/CollatorEquivalences.java
@@ -9,7 +9,6 @@ import com.ibm.icu.text.CollationElementIterator;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.Normalizer2;
 import com.ibm.icu.text.RuleBasedCollator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UTF16.StringComparator;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ULocale;
@@ -200,7 +199,7 @@ public class CollatorEquivalences {
                     || gc == UCharacter.SURROGATE) {
                 continue;
             }
-            String s = UTF16.valueOf(i);
+            String s = Character.toString(i);
             equiv.put(new RawKey(UCA_SECONDARY_ONLY, s), s);
             String t = nfkccf.normalize(s);
             equiv.put(new RawKey(UCA_SECONDARY_ONLY, t), t);

--- a/unicodetools/src/main/java/org/unicode/tools/CollatorEquivalencesNew.java
+++ b/unicodetools/src/main/java/org/unicode/tools/CollatorEquivalencesNew.java
@@ -3,7 +3,6 @@ package org.unicode.tools;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.impl.Utility;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UTF16.StringComparator;
 import com.ibm.icu.text.UnicodeSet;
 import java.io.IOException;
@@ -230,7 +229,7 @@ public class CollatorEquivalencesNew {
             if (CN_CS_CO.contains(i)) {
                 continue;
             }
-            String s = UTF16.valueOf(i);
+            String s = Character.toString(i);
             equiv.put(MyCollator.getSortKey(s), s);
             String t = nfkccf.normalize(s);
             equiv.put(MyCollator.getSortKey(t), t);

--- a/unicodetools/src/main/java/org/unicode/tools/Confusables.java
+++ b/unicodetools/src/main/java/org/unicode/tools/Confusables.java
@@ -2,7 +2,6 @@ package org.unicode.tools;
 
 import com.google.common.base.Splitter;
 import com.ibm.icu.impl.UnicodeMap;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.Freezable;
 import com.ibm.icu.util.ICUException;
@@ -379,7 +378,7 @@ public class Confusables {
                                             + "; A; "
                                             + values.toPattern(false)
                                             + "\t# ( "
-                                            + UTF16.valueOf(range.codepoint)
+                                            + Character.toString(range.codepoint)
                                             + " ) "
                                             + CODEPOINT_TO_NAME.get(range.codepoint)
                                             + (single ? "" : "...")

--- a/unicodetools/src/main/java/org/unicode/tools/ExtendedPictographic.java
+++ b/unicodetools/src/main/java/org/unicode/tools/ExtendedPictographic.java
@@ -1,7 +1,6 @@
 package org.unicode.tools;
 
 import com.ibm.icu.impl.UnicodeMap;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSet.EntryRange;
 import java.io.File;
@@ -296,9 +295,9 @@ class ExtendedPictographic {
                 + Utility.hex(cpEnd)
                 + (v == null ? "" : "; " + v.getShortName())
                 + " # "
-                + UTF16.valueOf(cpStart)
+                + Character.toString(cpStart)
                 + ".."
-                + UTF16.valueOf(cpEnd)
+                + Character.toString(cpEnd)
                 + "; "
                 + iup.getName(cpStart)
                 + ".."
@@ -309,7 +308,7 @@ class ExtendedPictographic {
         return Utility.hex(cp)
                 + (v == null ? "" : "; " + v.getShortName())
                 + " # "
-                + UTF16.valueOf(cp)
+                + Character.toString(cp)
                 + "; "
                 + iup.getName(cp);
     }

--- a/unicodetools/src/main/java/org/unicode/tools/FixedProps.java
+++ b/unicodetools/src/main/java/org/unicode/tools/FixedProps.java
@@ -3,7 +3,6 @@ package org.unicode.tools;
 import com.google.common.base.Splitter;
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.lang.CharSequences;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSet.EntryRange;
 import java.io.IOException;
@@ -636,7 +635,7 @@ public class FixedProps {
                                         + " ;\t"
                                         + value
                                         + "\t # ("
-                                        + UTF16.valueOf(range.codepoint)
+                                        + Character.toString(range.codepoint)
                                         + ") "
                                         + name.get(range.codepoint)));
             } else {
@@ -649,9 +648,9 @@ public class FixedProps {
                                         + " ;\t"
                                         + value
                                         + "\t # ("
-                                        + UTF16.valueOf(range.codepoint)
+                                        + Character.toString(range.codepoint)
                                         + ".."
-                                        + UTF16.valueOf(range.codepointEnd)
+                                        + Character.toString(range.codepointEnd)
                                         + ") "
                                         + name.get(range.codepoint)
                                         + ".."

--- a/unicodetools/src/main/java/org/unicode/tools/GenerateNormalizeForMatch.java
+++ b/unicodetools/src/main/java/org/unicode/tools/GenerateNormalizeForMatch.java
@@ -9,7 +9,6 @@ import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.lang.CharSequences;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSet.EntryRange;
 import java.io.IOException;
@@ -169,8 +168,8 @@ public class GenerateNormalizeForMatch {
         Builder<String, String> builder = ImmutableMap.builder();
         for (EntryRange entry : NO_NAME.ranges()) {
             for (int cp = entry.codepoint; cp < entry.codepointEnd; ++cp) {
-                final String name = iup.getName(UTF16.valueOf(cp), " + ");
-                final String decomp = UTF16.valueOf(cp);
+                final String name = iup.getName(Character.toString(cp), " + ");
+                final String decomp = Character.toString(cp);
                 builder.put(name, decomp);
                 if (name.startsWith("CIRCLED NUMBER ")) {
                     final String decompHack = Normalizer3.NFKCCF.normalize(decomp);
@@ -283,7 +282,7 @@ public class GenerateNormalizeForMatch {
                 UnicodeSet other = nameToCp.get(lowName);
                 if (other != null) {
                     int otherFirst = other.getRangeStart(0);
-                    final String otherCp = UTF16.valueOf(otherFirst);
+                    final String otherCp = Character.toString(otherFirst);
                     final String cpNkfccf = CldrUtility.ifNull(cpToNFKCCF.get(cp), cp);
                     final String otherCpNfkccf =
                             CldrUtility.ifNull(cpToNFKCCF.get(otherCp), otherCp);
@@ -654,7 +653,7 @@ public class GenerateNormalizeForMatch {
                 int debug = 0;
             }
 
-            String source = UTF16.valueOf(cp);
+            String source = Character.toString(cp);
             String nfkccf = normalizer3.normalize(source);
             String target = source;
             Set<SpecialReason> reason = new LinkedHashSet<>();
@@ -898,7 +897,7 @@ public class GenerateNormalizeForMatch {
             if (b.length() > 0) {
                 b.append(separator);
             }
-            b.append(iup.getName(UTF16.valueOf(cp), " + "));
+            b.append(iup.getName(Character.toString(cp), " + "));
         }
         return b.toString();
     }
@@ -949,7 +948,7 @@ public class GenerateNormalizeForMatch {
     //                    + SEP + hex(trialValue)
     //                    + SEP + (Objects.equal(nfkccfValue,trialValue) ? "≣" : hex(nfkccfValue))
     //                    + SEP + (reason == null ? "" : reason)
-    //                    + SEP + iup.getName(UTF16.valueOf(sourceCodePoint), " + ")
+    //                    + SEP + iup.getName(Character.toString(sourceCodePoint), " + ")
     //                    );
     //            sorted.add(row);
     //            counter.add(Row.of(age,difference), 1);

--- a/unicodetools/src/main/java/org/unicode/tools/GeneratePickerData.java
+++ b/unicodetools/src/main/java/org/unicode/tools/GeneratePickerData.java
@@ -2704,7 +2704,7 @@ class GeneratePickerData {
         int cp;
         int len = 0;
         for (int i = 0; i < x.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(x, i);
+            cp = x.codePointAt(i);
             len += cp < 0x80 ? 1 : cp < 0x800 ? 2 : cp < 0x10000 ? 3 : 4;
         }
         return len;

--- a/unicodetools/src/main/java/org/unicode/tools/GeneratePickerData.java
+++ b/unicodetools/src/main/java/org/unicode/tools/GeneratePickerData.java
@@ -1017,7 +1017,7 @@ class GeneratePickerData {
                 Separation separateOld,
                 String values) {
             int cp;
-            for (int i = 0; i < values.length(); i += UTF16.getCharCount(cp)) {
+            for (int i = 0; i < values.length(); i += Character.charCount(cp)) {
                 add(
                         category,
                         sortSubcategory,
@@ -2703,7 +2703,7 @@ class GeneratePickerData {
     public static int utf8Length(String x) {
         int cp;
         int len = 0;
-        for (int i = 0; i < x.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < x.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(x, i);
             len += cp < 0x80 ? 1 : cp < 0x800 ? 2 : cp < 0x10000 ? 3 : 4;
         }

--- a/unicodetools/src/main/java/org/unicode/tools/GeneratePickerData.java
+++ b/unicodetools/src/main/java/org/unicode/tools/GeneratePickerData.java
@@ -408,7 +408,7 @@ class GeneratePickerData {
                                             ? "11..17"
                                             : String.valueOf(radicalStrokes))
                                     + "-Stroke Radicals";
-                    String subCat = UTF16.valueOf(radicalChar);
+                    String subCat = Character.toString(radicalChar);
                     // if (DEBUG) System.out.println(radical + " => " + radicalToChar.get(radical));
                     // String radChar = getRadicalName(radicalToChar, radical);
                     // String subCat = radChar + " Han";
@@ -584,7 +584,7 @@ class GeneratePickerData {
     private static UnicodeSet closeOver(UnicodeSet closed) {
         for (int i = 0; i < 0x10FFFF; ++i) {
             if (closed.contains(i)) continue;
-            final String str = UTF16.valueOf(i);
+            final String str = Character.toString(i);
             String s = UCharacter.foldCase(str, true);
             if (s.equals(str)) continue;
             if (closed.contains(s)) {
@@ -878,7 +878,7 @@ class GeneratePickerData {
             CATEGORYTABLE.add(
                     "Hangul",
                     true,
-                    UTF16.valueOf(decompCodePoint1)
+                    Character.toString(decompCodePoint1)
                             + " "
                             + UCharacter.getExtendedName(decompCodePoint1),
                     buttonComparator,
@@ -1100,7 +1100,7 @@ class GeneratePickerData {
             GeneratePickerData.USet oldValue =
                     getValues(category, sortSubcategory, subcategory, sortValues);
             if (!SKIP.contains(codePoint)) {
-                oldValue.strings.add(UTF16.valueOf(codePoint));
+                oldValue.strings.add(Character.toString(codePoint));
             }
         }
 

--- a/unicodetools/src/main/java/org/unicode/tools/Ids.java
+++ b/unicodetools/src/main/java/org/unicode/tools/Ids.java
@@ -10,7 +10,6 @@ import com.ibm.icu.impl.UnicodeMap.EntryRange;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.lang.CharSequences;
 import com.ibm.icu.lang.UCharacter;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ICUException;
 import com.ibm.icu.util.Output;
@@ -408,7 +407,7 @@ public class Ids {
             int codepoint, String sample, String sampleDecomp, Positioning... part) {
         final IdsData value = new IdsData(sample, sampleDecomp, Arrays.asList(part));
         IDS_INFO.put(codepoint, value);
-        System.out.println(UTF16.valueOf(codepoint) + ", " + value);
+        System.out.println(Character.toString(codepoint) + ", " + value);
     }
 
     private static final UnicodeMap<IdsData> IDS_INFO = new UnicodeMap<>();
@@ -622,13 +621,16 @@ public class Ids {
             }
             if (DEBUG)
                 System.out.println(
-                        Utility.repeat("\t", depth) + UTF16.valueOf(lead) + " => " + ids.part);
+                        Utility.repeat("\t", depth) + Character.toString(lead) + " => " + ids.part);
             for (final Positioning subpart : ids.part) {
                 final Positioning combo = position.times(subpart);
                 int codePoint = codePoints[pos++];
                 if (DEBUG)
                     System.out.println(
-                            Utility.repeat("\t", depth) + UTF16.valueOf(codePoint) + " & " + combo);
+                            Utility.repeat("\t", depth)
+                                    + Character.toString(codePoint)
+                                    + " & "
+                                    + combo);
 
                 IdsData partData = IDS_INFO.get(codePoint);
                 while (partData == null && codePoint == '？') {
@@ -644,7 +646,7 @@ public class Ids {
                                 if (IDS_HACK.contains(codePoint)) {
                                     codePoint =
                                             Special.addSpecialX(
-                                                    sourceChar, UTF16.valueOf(codePoint));
+                                                    sourceChar, Character.toString(codePoint));
                                     partData = IDS_INFO.get(codePoint);
                                 }
                                 break;
@@ -711,7 +713,7 @@ public class Ids {
                                     Special.addSpecial(
                                             0xE040 + mirrored,
                                             sourceChar,
-                                            "mirrored " + UTF16.valueOf(codePoint));
+                                            "mirrored " + Character.toString(codePoint));
                                 }
                                 break;
                             }
@@ -724,7 +726,7 @@ public class Ids {
                                     Special.addSpecial(
                                             0xE050 + mirrored,
                                             sourceChar,
-                                            "rotated " + UTF16.valueOf(codePoint));
+                                            "rotated " + Character.toString(codePoint));
                                 }
                                 break;
                             }
@@ -755,7 +757,7 @@ public class Ids {
 
         @Override
         public String toString() {
-            return UTF16.valueOf(codepoint) + part;
+            return Character.toString(codepoint) + part;
         }
 
         public String svgRect(String color, boolean showRect) {
@@ -788,7 +790,7 @@ public class Ids {
                     + (part.y2 - part.y1)
                     + ")'"
                     + ">"
-                    + UTF16.valueOf(codepoint)
+                    + Character.toString(codepoint)
                     + "</text></g>\n";
         }
 
@@ -912,11 +914,13 @@ public class Ids {
         Special.listSpecials();
 
         //        for (int i : CharSequences.codePoints(FLIPPED)) {
-        //            System.out.println("FLIPPED:\t" + UTF16.valueOf(i) + "\t" + IDS_DATA.get(i) +
+        //            System.out.println("FLIPPED:\t" + Character.toString(i) + "\t" +
+        // IDS_DATA.get(i) +
         // "\t" + radicalStroke.get(i));
         //        }
         //        for (int i : CharSequences.codePoints(MIRRORED)) {
-        //            System.out.println("MIRRORED:\t" + UTF16.valueOf(i) + "\t" + IDS_DATA.get(i) +
+        //            System.out.println("MIRRORED:\t" + Character.toString(i) + "\t" +
+        // IDS_DATA.get(i) +
         // "\t" + radicalStroke.get(i));
         //        }
         //        for (Entry<String, CharacterIds> entry : IDS_DATA.entrySet()) {
@@ -1413,7 +1417,7 @@ public class Ids {
                     invert.put(entry.value.getComponents(), entry.string);
                 } else {
                     for (int i = entry.codepoint; i <= entry.codepointEnd; ++i) {
-                        invert.put(entry.value.getComponents(), UTF16.valueOf(i));
+                        invert.put(entry.value.getComponents(), Character.toString(i));
                     }
                 }
             }
@@ -1557,7 +1561,7 @@ public class Ids {
                 // CDP-854B &CDP-854B;  ⿻冂从
                 continue;
                 //                int cp = Special.addSpecialX("?", source);
-                //                source = UTF16.valueOf(cp);
+                //                source = Character.toString(cp);
             }
             try {
                 if (ids.equals(source)) {
@@ -1746,7 +1750,7 @@ public class Ids {
 
     private static void show(
             int count, PrintWriter out, int codepoint, String source, List<CpPart> breakdown) {
-        if (DEBUG) System.out.println(UTF16.valueOf(codepoint) + "\t" + source);
+        if (DEBUG) System.out.println(Character.toString(codepoint) + "\t" + source);
         out.println(
                 "<tr>"
                         + "<td style='text-align:right'>"
@@ -1755,7 +1759,7 @@ public class Ids {
                         + "<td style='font-size:"
                         + LARGE
                         + "px'>"
-                        + UTF16.valueOf(codepoint)
+                        + Character.toString(codepoint)
                         + "</td>\n"
                         + "<td height='"
                         + LARGE

--- a/unicodetools/src/main/java/org/unicode/tools/Ids.java
+++ b/unicodetools/src/main/java/org/unicode/tools/Ids.java
@@ -42,6 +42,7 @@ import org.unicode.props.UcdPropertyValues;
 import org.unicode.props.UcdPropertyValues.Block_Values;
 import org.unicode.props.UcdPropertyValues.General_Category_Values;
 import org.unicode.text.utility.Settings;
+import org.unicode.text.utility.UTF16Plus;
 
 public class Ids {
 
@@ -1246,7 +1247,7 @@ public class Ids {
                     throw new ICUException(target);
                 }
                 String cp = target.substring(equals + 1, paren).trim();
-                if (UTF16.countCodePoint(cp) != 1) {
+                if (!UTF16Plus.isSingleCodePoint(cp)) {
                     throw new ICUException(target);
                 }
                 cjkRadSupToIdeo.put(cjkRadSup, cp);

--- a/unicodetools/src/main/java/org/unicode/tools/IdsFileData.java
+++ b/unicodetools/src/main/java/org/unicode/tools/IdsFileData.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.UnicodeMap;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ICUException;
 import java.util.List;
@@ -71,7 +70,7 @@ public class IdsFileData {
             int cjkRad = Integer.parseInt(parts.get(0), 16);
             final String radString = parts.get(1);
             int radNumber = Integer.parseInt(radString);
-            radToCjkRad.put(radNumber, UTF16.valueOf(cjkRad));
+            radToCjkRad.put(radNumber, Character.toString(cjkRad));
         }
         radToCjkRad.freeze();
         cjkRadToRad.addAllInverted(radToCjkRad);

--- a/unicodetools/src/main/java/org/unicode/tools/RadicalStroke.java
+++ b/unicodetools/src/main/java/org/unicode/tools/RadicalStroke.java
@@ -126,14 +126,16 @@ public class RadicalStroke {
             // temp.add(it.codepoint);
             // if (temp.size() >= 800) {
             // int code = temp.charAt(0);
-            // CATEGORYTABLE.add("Han (CJK)", false, UTF16.valueOf(code) + " Han " + toHex(code,
+            // CATEGORYTABLE.add("Han (CJK)", false, Character.toString(code) + " Han " +
+            // toHex(code,
             // false), false, temp);
             // temp.clear();
             // }
             // }
             // if (temp.size() > 0) {
             // int code = temp.charAt(0);
-            // CATEGORYTABLE.add("Han (CJK)", false, UTF16.valueOf(code) + " Han " + toHex(code,
+            // CATEGORYTABLE.add("Han (CJK)", false, Character.toString(code) + " Han " +
+            // toHex(code,
             // false), false, temp);
             // }
         } catch (IOException e) {

--- a/unicodetools/src/main/java/org/unicode/tools/Segmenter.java
+++ b/unicodetools/src/main/java/org/unicode/tools/Segmenter.java
@@ -36,6 +36,7 @@ import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.util.TransliteratorUtilities;
 import org.unicode.props.UnicodeProperty;
 import org.unicode.text.UCD.VersionedSymbolTable;
+import org.unicode.text.utility.UTF16Plus;
 import org.unicode.tools.Segmenter.Builder.NamedRefinedSet;
 import org.unicode.tools.Segmenter.SegmentationRule.Breaks;
 
@@ -162,8 +163,7 @@ public class Segmenter {
             return true;
         }
         // don't break in middle of surrogate
-        if (Character.isHighSurrogate(text.charAt(position - 1))
-                && Character.isLowSurrogate(text.charAt(position))) {
+        if (!UTF16Plus.isCodePointBoundary(text, position)) {
             breakRule = NOBREAK_SUPPLEMENTARY;
             return false;
         }

--- a/unicodetools/src/main/java/org/unicode/tools/Segmenter.java
+++ b/unicodetools/src/main/java/org/unicode/tools/Segmenter.java
@@ -1062,8 +1062,8 @@ public class Segmenter {
                             return "\\u" + Utility.hex(codePoint);
                         }
                         if (JavaRegex_slash.contains(codePoint))
-                            return "\\" + UTF16.valueOf(codePoint);
-                        return UTF16.valueOf(codePoint);
+                            return "\\" + Character.toString(codePoint);
+                        return Character.toString(codePoint);
                     }
                 };
 

--- a/unicodetools/src/main/java/org/unicode/tools/Segmenter.java
+++ b/unicodetools/src/main/java/org/unicode/tools/Segmenter.java
@@ -14,7 +14,6 @@ import com.google.common.collect.Multimap;
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.text.NumberFormat;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSet.SpanCondition;
 import com.ibm.icu.text.UnicodeSetIterator;
@@ -163,8 +162,8 @@ public class Segmenter {
             return true;
         }
         // don't break in middle of surrogate
-        if (UTF16.isLeadSurrogate(text.charAt(position - 1))
-                && UTF16.isTrailSurrogate(text.charAt(position))) {
+        if (Character.isHighSurrogate(text.charAt(position - 1))
+                && Character.isLowSurrogate(text.charAt(position))) {
             breakRule = NOBREAK_SUPPLEMENTARY;
             return false;
         }
@@ -1055,9 +1054,9 @@ public class Segmenter {
                         if (JavaRegex_uxxx.contains(codePoint)) {
                             if (codePoint > 0xFFFF) {
                                 return "\\u"
-                                        + Utility.hex(UTF16.getLeadSurrogate(codePoint))
+                                        + Utility.hex(Character.highSurrogate(codePoint))
                                         + "\\u"
-                                        + Utility.hex(UTF16.getTrailSurrogate(codePoint));
+                                        + Utility.hex(Character.lowSurrogate(codePoint));
                             }
                             return "\\u" + Utility.hex(codePoint);
                         }

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/CandidateData.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/CandidateData.java
@@ -729,7 +729,7 @@ public class CandidateData implements Transform<String, String>, EmojiDataSource
         //        if (Emoji.HAIR_PIECES.containsSome(cp)) { // HACK
         //            names.put(combo,
         //
-        // EmojiData.EMOJI_DATA.getName(UTF16.valueOf(Character.codePointAt(combo, 0)))
+        // EmojiData.EMOJI_DATA.getName(Character.toString(Character.codePointAt(combo, 0)))
         //                    + ": " +
         //                    getName(Character.codePointBefore(combo, combo.length())));
         //        }

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/Emoji.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/Emoji.java
@@ -35,6 +35,7 @@ import org.unicode.props.UcdProperty;
 import org.unicode.props.UcdPropertyValues;
 import org.unicode.props.UcdPropertyValues.Age_Values;
 import org.unicode.text.utility.Settings;
+import org.unicode.text.utility.UTF16Plus;
 import org.unicode.text.utility.Utility;
 
 /**
@@ -234,7 +235,7 @@ public class Emoji {
     public static final char EMOJI_VARIANT = '\uFE0F';
     public static final char TEXT_VARIANT = '\uFE0E';
 
-    public static final String RIGHTWARDS_ARROW = Character.toString(0x27A1) + EMOJI_VARIANT;
+    public static final String RIGHTWARDS_ARROW = "\u27A1" + EMOJI_VARIANT;
     public static final String ZWJ_RIGHTWARDS_ARROW = JOINER_STR + RIGHTWARDS_ARROW;
 
     // HACK
@@ -264,9 +265,8 @@ public class Emoji {
     public static final String TRANSGENDER = "\u26A7";
     public static final char TRANSGENDER_CP = '\u26A7';
 
-    public static final String ZWJ_HANDSHAKE_ZWJ =
-            JOINER_STR + Character.toString(0x1F91D) + JOINER_STR;
-    public static final String ZWJ_HEART_ZWJ = JOINER_STR + Character.toString(0x2764) + JOINER_STR;
+    public static final String ZWJ_HANDSHAKE_ZWJ = JOINER_STR + cpToString(0x1F91D) + JOINER_STR;
+    public static final String ZWJ_HEART_ZWJ = JOINER_STR + "\u2764" + JOINER_STR;
 
     static final UnicodeMap<String> TO_NEUTRAL =
             new UnicodeMap<String>()
@@ -289,65 +289,45 @@ public class Emoji {
 
     static final UnicodeMap<String> MALE_TO_OTHER =
             new UnicodeMap<String>()
-                    .put(
-                            Character.toString(0x2642),
-                            Character.toString(0x2640)) // MALE SIGN→FEMALE SIGN
-                    .put(Character.toString(0x1F466), Character.toString(0x1F467)) // boy→girl
-                    .put(Character.toString(0x1F468), Character.toString(0x1F469)) // man→woman
-                    .put(
-                            Character.toString(0x1F474),
-                            Character.toString(0x1F475)) // old man→old woman
-                    .put(
-                            Character.toString(0x1F385),
-                            Character.toString(0x1F936)) // Santa Claus→Mrs. Claus
-                    .put(
-                            Character.toString(0x1F934),
-                            Character.toString(0x1F478)) // prince→princess
-                    .put(
-                            Character.toString(0x1F57A),
-                            Character.toString(0x1F483)) // man dancing→woman dancing
-                    //            .put(Character.toString(0x1F46C), Character.toString(0x1F46B)) //
+                    .put("\u2642", "\u2640)") // MALE SIGN→FEMALE SIGN
+                    .put(cpToString(0x1F466), cpToString(0x1F467)) // boy→girl
+                    .put(cpToString(0x1F468), cpToString(0x1F469)) // man→woman
+                    .put(cpToString(0x1F474), cpToString(0x1F475)) // old man→old woman
+                    .put(cpToString(0x1F385), cpToString(0x1F936)) // Santa Claus→Mrs. Claus
+                    .put(cpToString(0x1F934), cpToString(0x1F478)) // prince→princess
+                    .put(cpToString(0x1F57A), cpToString(0x1F483)) // man dancing→woman dancing
+                    //            .put(cpToString(0x1F46C), cpToString(0x1F46B)) //
                     // two men
                     // holding hands→man and woman holding hands
-                    //            .put(Character.toString(0x1F46C), Character.toString(0x1F46D)) //
+                    //            .put(cpToString(0x1F46C), cpToString(0x1F46D)) //
                     // two men
                     // holding hands→two women holding hands
-                    //            .put(Character.toString(0x1F935), "") // man in tuxedo→<NONE>
-                    //            .put(Character.toString(0x1F574), "") // man in suit
+                    //            .put(cpToString(0x1F935), "") // man in tuxedo→<NONE>
+                    //            .put(cpToString(0x1F574), "") // man in suit
                     // levitating→<NONE>
-                    //            .put(Character.toString(0x1F472), "") // man with Chinese
+                    //            .put(cpToString(0x1F472), "") // man with Chinese
                     // cap→<NONE>
-                    //            .put(Character.toString(0x1F9D4), "") // BEARDED PERSON→<NONE>
+                    //            .put(cpToString(0x1F9D4), "") // BEARDED PERSON→<NONE>
                     .freeze();
     static final UnicodeMap<String> FEMALE_TO_OTHER =
             new UnicodeMap<String>()
-                    .put(
-                            Character.toString(0x2640),
-                            Character.toString(0x2642)) // FEMALE SIGN→MALE SIGN
-                    .put(Character.toString(0x1F467), Character.toString(0x1F466)) // girl→boy
-                    .put(Character.toString(0x1F469), Character.toString(0x1F468)) // woman→man
-                    .put(
-                            Character.toString(0x1F475),
-                            Character.toString(0x1F474)) // old woman→old man
-                    .put(
-                            Character.toString(0x1F936),
-                            Character.toString(0x1F385)) // Mrs. Claus→Santa Claus
-                    .put(
-                            Character.toString(0x1F478),
-                            Character.toString(0x1F934)) // princess→prince
-                    .put(
-                            Character.toString(0x1F483),
-                            Character.toString(0x1F57A)) // woman dancing→man dancing
-                    //            .put(Character.toString(0x1F46D), Character.toString(0x1F46C)) //
+                    .put("\u2640", "\u2642") // FEMALE SIGN→MALE SIGN
+                    .put(cpToString(0x1F467), cpToString(0x1F466)) // girl→boy
+                    .put(cpToString(0x1F469), cpToString(0x1F468)) // woman→man
+                    .put(cpToString(0x1F475), cpToString(0x1F474)) // old woman→old man
+                    .put(cpToString(0x1F936), cpToString(0x1F385)) // Mrs. Claus→Santa Claus
+                    .put(cpToString(0x1F478), cpToString(0x1F934)) // princess→prince
+                    .put(cpToString(0x1F483), cpToString(0x1F57A)) // woman dancing→man dancing
+                    //            .put(cpToString(0x1F46D), cpToString(0x1F46C)) //
                     // two women
                     // holding hands→two men holding hands
-                    //            .put(Character.toString(0x1F46D), Character.toString(0x1F46B)) //
+                    //            .put(cpToString(0x1F46D), cpToString(0x1F46B)) //
                     // two women
                     // holding hands→man and woman holding hands
-                    //            .put(Character.toString(0x1F470), "") // bride with veil→<NONE>
-                    //            .put(Character.toString(0x1F930), "") // pregnant woman→<NONE>
-                    //            .put(Character.toString(0x1F931), "") // breast-feeding→<NONE>
-                    //            .put(Character.toString(0x1F9D5), "") // woman with
+                    //            .put(cpToString(0x1F470), "") // bride with veil→<NONE>
+                    //            .put(cpToString(0x1F930), "") // pregnant woman→<NONE>
+                    //            .put(cpToString(0x1F931), "") // breast-feeding→<NONE>
+                    //            .put(cpToString(0x1F9D5), "") // woman with
                     // headscarf→<NONE>
                     .freeze();
     static final UnicodeSet NEUTRAL =
@@ -510,7 +490,7 @@ public class Emoji {
     public static final int TAG_BASE = 0xE0000;
     public static final int TAG_TERM_CHAR = 0xE007F;
     public static final UnicodeSet TAGS = new UnicodeSet(TAG_BASE, TAG_TERM_CHAR).freeze();
-    public static final String TAG_TERM = Character.toString(TAG_TERM_CHAR);
+    public static final String TAG_TERM = cpToString(TAG_TERM_CHAR);
 
     public static final char KEYCAP_MARK = '\u20E3';
     public static final String KEYCAP_MARK_STRING = String.valueOf(KEYCAP_MARK);
@@ -566,6 +546,11 @@ public class Emoji {
 
     // public static final UnicodeSet SKIP_ANDROID = new UnicodeSet("[♨ ⚠ ▶ ◀ ✉ ✏ ✒ ✂ ⬆ ↗ ➡ ↘ ⬇ ↙ ⬅
     // ↖ ↕ ↔ ↩ ↪ ⤴ ⤵ ♻ ☑ ✔ ✖ 〽 ✳ ✴ ❇ ▪ ▫ ◻ ◼ ‼ ⁉ 〰 © ® 🅰 🅱 ℹ Ⓜ 🅾 🅿 ™ 🈂 🈷 ㊗ ㊙]").freeze();
+
+    /** Abbreviated form of Character.toString(c). */
+    private static final String cpToString(int c) {
+        return Character.toString(c);
+    }
 
     public static final VersionInfo getUnicodeVersionForEmojiVersion(VersionInfo emojiVersion) {
         VersionInfo unicodeVersion = EMOJI_TO_UNICODE_VERSION.get(emojiVersion);
@@ -652,11 +637,11 @@ public class Emoji {
     public static final int GIRL = 0x1F467;
     public static final int MAN = 0x1F468;
     public static final int WOMAN = 0x1F469;
-    public static final String ADULT = Character.toString(0x1F9D1);
-    public static final String CHILD = Character.toString(0x1F9D2);
-    public static final String MAN_STR = Character.toString(MAN);
-    public static final String WOMAN_STR = Character.toString(WOMAN);
-    public static final String NEUTRAL_FAMILY = Character.toString(0x1F46A);
+    public static final String ADULT = cpToString(0x1F9D1);
+    public static final String CHILD = cpToString(0x1F9D2);
+    public static final String MAN_STR = cpToString(MAN);
+    public static final String WOMAN_STR = cpToString(WOMAN);
+    public static final String NEUTRAL_FAMILY = cpToString(0x1F46A);
     public static final UnicodeSet NEUTRAL_FAMILY_ZWJ_SEQUENCES =
             new UnicodeSet()
                     .add(ADULT + JOINER + CHILD)
@@ -857,7 +842,7 @@ public class Emoji {
             if (overrideSource != null) {
                 type = overrideSource;
             } else if (CountEmoji.ZwjType.getType(chars) != CountEmoji.ZwjType.family) {
-                overrideSource = BEST_OVERRIDE.get(Character.toString(chars.codePointAt(0)));
+                overrideSource = BEST_OVERRIDE.get(UTF16Plus.codePointSubstringAt(chars, 0));
                 if (overrideSource != null) {
                     type = overrideSource;
                 }
@@ -1048,7 +1033,7 @@ public class Emoji {
             if (b.length() != 0) {
                 b.append(' ');
             }
-            b.append("U+" + Utility.hex(cp) + " " + Character.toString(cp));
+            b.append("U+" + Utility.hex(cp) + " " + cpToString(cp));
         }
         return b.toString();
     }

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/Emoji.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/Emoji.java
@@ -9,7 +9,6 @@ import com.ibm.icu.lang.CharSequences;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.LocaleDisplayNames;
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.Output;
 import com.ibm.icu.util.ULocale;
@@ -235,7 +234,7 @@ public class Emoji {
     public static final char EMOJI_VARIANT = '\uFE0F';
     public static final char TEXT_VARIANT = '\uFE0E';
 
-    public static final String RIGHTWARDS_ARROW = UTF16.valueOf(0x27A1) + EMOJI_VARIANT;
+    public static final String RIGHTWARDS_ARROW = Character.toString(0x27A1) + EMOJI_VARIANT;
     public static final String ZWJ_RIGHTWARDS_ARROW = JOINER_STR + RIGHTWARDS_ARROW;
 
     // HACK
@@ -265,8 +264,9 @@ public class Emoji {
     public static final String TRANSGENDER = "\u26A7";
     public static final char TRANSGENDER_CP = '\u26A7';
 
-    public static final String ZWJ_HANDSHAKE_ZWJ = JOINER_STR + UTF16.valueOf(0x1F91D) + JOINER_STR;
-    public static final String ZWJ_HEART_ZWJ = JOINER_STR + UTF16.valueOf(0x2764) + JOINER_STR;
+    public static final String ZWJ_HANDSHAKE_ZWJ =
+            JOINER_STR + Character.toString(0x1F91D) + JOINER_STR;
+    public static final String ZWJ_HEART_ZWJ = JOINER_STR + Character.toString(0x2764) + JOINER_STR;
 
     static final UnicodeMap<String> TO_NEUTRAL =
             new UnicodeMap<String>()
@@ -289,43 +289,66 @@ public class Emoji {
 
     static final UnicodeMap<String> MALE_TO_OTHER =
             new UnicodeMap<String>()
-                    .put(UTF16.valueOf(0x2642), UTF16.valueOf(0x2640)) // MALE SIGN→FEMALE SIGN
-                    .put(UTF16.valueOf(0x1F466), UTF16.valueOf(0x1F467)) // boy→girl
-                    .put(UTF16.valueOf(0x1F468), UTF16.valueOf(0x1F469)) // man→woman
-                    .put(UTF16.valueOf(0x1F474), UTF16.valueOf(0x1F475)) // old man→old woman
-                    .put(UTF16.valueOf(0x1F385), UTF16.valueOf(0x1F936)) // Santa Claus→Mrs. Claus
-                    .put(UTF16.valueOf(0x1F934), UTF16.valueOf(0x1F478)) // prince→princess
                     .put(
-                            UTF16.valueOf(0x1F57A),
-                            UTF16.valueOf(0x1F483)) // man dancing→woman dancing
-                    //            .put(UTF16.valueOf(0x1F46C), UTF16.valueOf(0x1F46B)) // two men
+                            Character.toString(0x2642),
+                            Character.toString(0x2640)) // MALE SIGN→FEMALE SIGN
+                    .put(Character.toString(0x1F466), Character.toString(0x1F467)) // boy→girl
+                    .put(Character.toString(0x1F468), Character.toString(0x1F469)) // man→woman
+                    .put(
+                            Character.toString(0x1F474),
+                            Character.toString(0x1F475)) // old man→old woman
+                    .put(
+                            Character.toString(0x1F385),
+                            Character.toString(0x1F936)) // Santa Claus→Mrs. Claus
+                    .put(
+                            Character.toString(0x1F934),
+                            Character.toString(0x1F478)) // prince→princess
+                    .put(
+                            Character.toString(0x1F57A),
+                            Character.toString(0x1F483)) // man dancing→woman dancing
+                    //            .put(Character.toString(0x1F46C), Character.toString(0x1F46B)) //
+                    // two men
                     // holding hands→man and woman holding hands
-                    //            .put(UTF16.valueOf(0x1F46C), UTF16.valueOf(0x1F46D)) // two men
+                    //            .put(Character.toString(0x1F46C), Character.toString(0x1F46D)) //
+                    // two men
                     // holding hands→two women holding hands
-                    //            .put(UTF16.valueOf(0x1F935), "") // man in tuxedo→<NONE>
-                    //            .put(UTF16.valueOf(0x1F574), "") // man in suit levitating→<NONE>
-                    //            .put(UTF16.valueOf(0x1F472), "") // man with Chinese cap→<NONE>
-                    //            .put(UTF16.valueOf(0x1F9D4), "") // BEARDED PERSON→<NONE>
+                    //            .put(Character.toString(0x1F935), "") // man in tuxedo→<NONE>
+                    //            .put(Character.toString(0x1F574), "") // man in suit
+                    // levitating→<NONE>
+                    //            .put(Character.toString(0x1F472), "") // man with Chinese
+                    // cap→<NONE>
+                    //            .put(Character.toString(0x1F9D4), "") // BEARDED PERSON→<NONE>
                     .freeze();
     static final UnicodeMap<String> FEMALE_TO_OTHER =
             new UnicodeMap<String>()
-                    .put(UTF16.valueOf(0x2640), UTF16.valueOf(0x2642)) // FEMALE SIGN→MALE SIGN
-                    .put(UTF16.valueOf(0x1F467), UTF16.valueOf(0x1F466)) // girl→boy
-                    .put(UTF16.valueOf(0x1F469), UTF16.valueOf(0x1F468)) // woman→man
-                    .put(UTF16.valueOf(0x1F475), UTF16.valueOf(0x1F474)) // old woman→old man
-                    .put(UTF16.valueOf(0x1F936), UTF16.valueOf(0x1F385)) // Mrs. Claus→Santa Claus
-                    .put(UTF16.valueOf(0x1F478), UTF16.valueOf(0x1F934)) // princess→prince
                     .put(
-                            UTF16.valueOf(0x1F483),
-                            UTF16.valueOf(0x1F57A)) // woman dancing→man dancing
-                    //            .put(UTF16.valueOf(0x1F46D), UTF16.valueOf(0x1F46C)) // two women
+                            Character.toString(0x2640),
+                            Character.toString(0x2642)) // FEMALE SIGN→MALE SIGN
+                    .put(Character.toString(0x1F467), Character.toString(0x1F466)) // girl→boy
+                    .put(Character.toString(0x1F469), Character.toString(0x1F468)) // woman→man
+                    .put(
+                            Character.toString(0x1F475),
+                            Character.toString(0x1F474)) // old woman→old man
+                    .put(
+                            Character.toString(0x1F936),
+                            Character.toString(0x1F385)) // Mrs. Claus→Santa Claus
+                    .put(
+                            Character.toString(0x1F478),
+                            Character.toString(0x1F934)) // princess→prince
+                    .put(
+                            Character.toString(0x1F483),
+                            Character.toString(0x1F57A)) // woman dancing→man dancing
+                    //            .put(Character.toString(0x1F46D), Character.toString(0x1F46C)) //
+                    // two women
                     // holding hands→two men holding hands
-                    //            .put(UTF16.valueOf(0x1F46D), UTF16.valueOf(0x1F46B)) // two women
+                    //            .put(Character.toString(0x1F46D), Character.toString(0x1F46B)) //
+                    // two women
                     // holding hands→man and woman holding hands
-                    //            .put(UTF16.valueOf(0x1F470), "") // bride with veil→<NONE>
-                    //            .put(UTF16.valueOf(0x1F930), "") // pregnant woman→<NONE>
-                    //            .put(UTF16.valueOf(0x1F931), "") // breast-feeding→<NONE>
-                    //            .put(UTF16.valueOf(0x1F9D5), "") // woman with headscarf→<NONE>
+                    //            .put(Character.toString(0x1F470), "") // bride with veil→<NONE>
+                    //            .put(Character.toString(0x1F930), "") // pregnant woman→<NONE>
+                    //            .put(Character.toString(0x1F931), "") // breast-feeding→<NONE>
+                    //            .put(Character.toString(0x1F9D5), "") // woman with
+                    // headscarf→<NONE>
                     .freeze();
     static final UnicodeSet NEUTRAL =
             new UnicodeSet(
@@ -487,7 +510,7 @@ public class Emoji {
     public static final int TAG_BASE = 0xE0000;
     public static final int TAG_TERM_CHAR = 0xE007F;
     public static final UnicodeSet TAGS = new UnicodeSet(TAG_BASE, TAG_TERM_CHAR).freeze();
-    public static final String TAG_TERM = UTF16.valueOf(TAG_TERM_CHAR);
+    public static final String TAG_TERM = Character.toString(TAG_TERM_CHAR);
 
     public static final char KEYCAP_MARK = '\u20E3';
     public static final String KEYCAP_MARK_STRING = String.valueOf(KEYCAP_MARK);
@@ -629,11 +652,11 @@ public class Emoji {
     public static final int GIRL = 0x1F467;
     public static final int MAN = 0x1F468;
     public static final int WOMAN = 0x1F469;
-    public static final String ADULT = UTF16.valueOf(0x1F9D1);
-    public static final String CHILD = UTF16.valueOf(0x1F9D2);
-    public static final String MAN_STR = UTF16.valueOf(MAN);
-    public static final String WOMAN_STR = UTF16.valueOf(WOMAN);
-    public static final String NEUTRAL_FAMILY = UTF16.valueOf(0x1F46A);
+    public static final String ADULT = Character.toString(0x1F9D1);
+    public static final String CHILD = Character.toString(0x1F9D2);
+    public static final String MAN_STR = Character.toString(MAN);
+    public static final String WOMAN_STR = Character.toString(WOMAN);
+    public static final String NEUTRAL_FAMILY = Character.toString(0x1F46A);
     public static final UnicodeSet NEUTRAL_FAMILY_ZWJ_SEQUENCES =
             new UnicodeSet()
                     .add(ADULT + JOINER + CHILD)
@@ -834,7 +857,7 @@ public class Emoji {
             if (overrideSource != null) {
                 type = overrideSource;
             } else if (CountEmoji.ZwjType.getType(chars) != CountEmoji.ZwjType.family) {
-                overrideSource = BEST_OVERRIDE.get(UTF16.valueOf(chars.codePointAt(0)));
+                overrideSource = BEST_OVERRIDE.get(Character.toString(chars.codePointAt(0)));
                 if (overrideSource != null) {
                     type = overrideSource;
                 }
@@ -1025,7 +1048,7 @@ public class Emoji {
             if (b.length() != 0) {
                 b.append(' ');
             }
-            b.append("U+" + Utility.hex(cp) + " " + UTF16.valueOf(cp));
+            b.append("U+" + Utility.hex(cp) + " " + Character.toString(cp));
         }
         return b.toString();
     }

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/EmojiAnnotations.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/EmojiAnnotations.java
@@ -4,7 +4,6 @@ import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.lang.CharSequences;
 import com.ibm.icu.text.SimpleFormatter;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.Output;
 import java.util.Collections;
@@ -372,7 +371,7 @@ public class EmojiAnnotations extends Birelation<String, String> {
                                 s,
                                 sep,
                                 outShortName.value,
-                                KEYCAP_PATTERN.format(UTF16.valueOf(s.charAt(0))));
+                                KEYCAP_PATTERN.format(Character.toString(s.charAt(0))));
                 if (keycapDatum != null && keycapDatum.getShortName().contains("#")) {
                     keywordsToAppendTo.addAll(keycapDatum.getKeywords());
                 }

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/EmojiData.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/EmojiData.java
@@ -12,7 +12,6 @@ import com.ibm.icu.lang.CharSequences;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.BreakIterator;
 import com.ibm.icu.text.Transform;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetSpanner;
 import com.ibm.icu.util.ICUException;
@@ -61,7 +60,7 @@ public class EmojiData implements EmojiDataSource {
     static final int BUNNY_DANCERS = 0x1f46f;
     static final int WRESTLERS = 0x1f93c;
     static final int HANDSHAKE = 0x1f91d;
-    static final String HANDSHAKE_STRING = UTF16.valueOf(0x1f91d);
+    static final String HANDSHAKE_STRING = Character.toString(0x1f91d);
     public static final String NEUTRAL_HOLDING = "🧑‍🤝‍🧑";
     public static final String SAMPLE_NEUTRAL_HOLDING_WITH_SKIN = "🧑🏼‍🤝‍🧑🏻";
     public static final String MAN_WITH_RED_HAIR = "👨‍🦰";
@@ -71,8 +70,8 @@ public class EmojiData implements EmojiDataSource {
 
     static final String ZWJ_HANDSHAKE_ZWJ = Emoji.ZWJ_HANDSHAKE_ZWJ;
 
-    static final String RIGHTWARDS_HAND = UTF16.valueOf(0x1faf1);
-    static final String LEFTWARDS_HAND = UTF16.valueOf(0x1faf2);
+    static final String RIGHTWARDS_HAND = Character.toString(0x1faf1);
+    static final String LEFTWARDS_HAND = Character.toString(0x1faf2);
     static final String SHAKING_HANDS = RIGHTWARDS_HAND + Emoji.JOINER_STR + LEFTWARDS_HAND;
 
     public static boolean ALLOW_UNICODE_NAME = System.getProperty("ALLOW_UNICODE_NAME") != null;
@@ -452,7 +451,7 @@ public class EmojiData implements EmojiDataSource {
                                                     + ", modifier "
                                                     + Utility.hex(last)
                                                     + " "
-                                                    + UTF16.valueOf(cp1)
+                                                    + Character.toString(cp1)
                                                     + "not following base ");
                                 }
                                 modifierBasesRgi.add(last);
@@ -470,7 +469,7 @@ public class EmojiData implements EmojiDataSource {
                         boolean isSingleton = codePoint != -1;
                         if (isSingleton) {
                             first = codePoint;
-                            source = UTF16.valueOf(codePoint);
+                            source = Character.toString(codePoint);
                         } else {
                             first = source.codePointAt(0);
                         }
@@ -763,15 +762,15 @@ public class EmojiData implements EmojiDataSource {
         femaleToOther = TreeMultimap.create();
         otherHuman = new UnicodeSet();
         // UnicodeMap<String> fromMan = new UnicodeMap<String>()
-        // .put(0x2642, UTF16.valueOf(0x2640)) // MALE SIGN→FEMALE SIGN
-        // .put(0x1F466, UTF16.valueOf(0x1F467)) // boy→girl
-        // .put(0x1F468, UTF16.valueOf(0x1F469)) // man→woman
+        // .put(0x2642, Character.toString(0x2640)) // MALE SIGN→FEMALE SIGN
+        // .put(0x1F466, Character.toString(0x1F467)) // boy→girl
+        // .put(0x1F468, Character.toString(0x1F469)) // man→woman
         // .freeze();
         //
         // UnicodeMap<String> fromWoman = new UnicodeMap<String>()
-        // .put(0x2640,UTF16.valueOf(0x2642)) // FEMALE SIGN→MALE SIGN
-        // .put(0x1F467, UTF16.valueOf(0x1F466)) // girl→boy
-        // .put(0x1F469, UTF16.valueOf(0x1F468)) // woman→man
+        // .put(0x2640,Character.toString(0x2642)) // FEMALE SIGN→MALE SIGN
+        // .put(0x1F467, Character.toString(0x1F466)) // girl→boy
+        // .put(0x1F469, Character.toString(0x1F468)) // woman→man
         // .freeze();
 
         for (String emoji : allEmojiWithoutDefectives) {
@@ -1315,7 +1314,7 @@ public class EmojiData implements EmojiDataSource {
         return _getName(source, false, CandidateData.getInstance());
     }
 
-    static final String DEBUG_STRING = UTF16.valueOf(0x1F3F4);
+    static final String DEBUG_STRING = Character.toString(0x1F3F4);
 
     private String _getName(
             String source, boolean toLower, Transform<String, String> otherNameSource) {
@@ -1323,9 +1322,9 @@ public class EmojiData implements EmojiDataSource {
             int debug = 0;
         }
         // workaround: preserve skin tones for direction ZWJ sequences
-        String trimmed = source.replace(UTF16.valueOf(Emoji.EMOJI_VARIANT), "");
-        if (trimmed.endsWith(Emoji.JOINER_STR + UTF16.valueOf(0x27A1))) {
-            trimmed = trimmed.replace(Emoji.JOINER_STR + UTF16.valueOf(0x27A1), "");
+        String trimmed = source.replace(Character.toString(Emoji.EMOJI_VARIANT), "");
+        if (trimmed.endsWith(Emoji.JOINER_STR + Character.toString(0x27A1))) {
+            trimmed = trimmed.replace(Emoji.JOINER_STR + Character.toString(0x27A1), "");
             String name = _getName(trimmed, toLower, otherNameSource);
             if (name != null) {
                 String[] components = name.split(":");
@@ -2093,7 +2092,7 @@ public class EmojiData implements EmojiDataSource {
         if (MODIFIERS.contains(second)) {
             return item;
         }
-        return UTF16.valueOf(first) + Emoji.EMOJI_VARIANT_STRING + item.substring(firstLen);
+        return Character.toString(first) + Emoji.EMOJI_VARIANT_STRING + item.substring(firstLen);
     }
 
     private static void showDiff(
@@ -2295,7 +2294,7 @@ public class EmojiData implements EmojiDataSource {
     public boolean isOtherGroup(String s) {
         if (version.compareTo(Emoji.VERSION17) >= 0) {
             String base = getBaseRemovingModsGender(s);
-            if (base == UTF16.valueOf(0x1F430) || base == UTF16.valueOf(0x1FAEF)) {
+            if (base == Character.toString(0x1F430) || base == Character.toString(0x1FAEF)) {
                 return true;
             }
         }

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/EmojiDataSource.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/EmojiDataSource.java
@@ -1,7 +1,6 @@
 package org.unicode.tools.emoji;
 
 import com.ibm.icu.impl.UnicodeMap;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import org.unicode.tools.emoji.Emoji.Qualified;
 
@@ -44,7 +43,7 @@ public interface EmojiDataSource {
     public String getName(String s);
 
     public default String getName(int codepoint) {
-        return getName(UTF16.valueOf(codepoint));
+        return getName(Character.toString(codepoint));
     }
 
     public UnicodeMap<String> getRawNames();

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/EmojiFrequency.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/EmojiFrequency.java
@@ -31,6 +31,7 @@ import java.util.regex.Pattern;
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.Counter;
+import org.unicode.text.utility.UTF16Plus;
 import org.unicode.text.utility.Utility;
 import org.unicode.tools.MultiComparator;
 import org.unicode.tools.emoji.CountEmoji.Category;
@@ -227,7 +228,7 @@ public class EmojiFrequency {
                 }
                 String subcategory = order.getCategory(dataS);
                 if (subcategory == null) {
-                    subcategory = order.getCategory(Character.toString(s.codePointAt(0)));
+                    subcategory = order.getCategory(UTF16Plus.codePointSubstringAt(s, 0));
                     if (subcategory == null) {
                         continue;
                     }

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/EmojiFrequency.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/EmojiFrequency.java
@@ -227,7 +227,7 @@ public class EmojiFrequency {
                 }
                 String subcategory = order.getCategory(dataS);
                 if (subcategory == null) {
-                    subcategory = order.getCategory(UTF16.valueOf(s.codePointAt(0)));
+                    subcategory = order.getCategory(Character.toString(s.codePointAt(0)));
                     if (subcategory == null) {
                         continue;
                     }
@@ -308,7 +308,7 @@ public class EmojiFrequency {
     static int matches(UnicodeSet unicodeSet, String input, int offset) {
         SortedSet<String> items = (SortedSet<String>) unicodeSet.strings();
         int cp = input.codePointAt(offset);
-        SortedSet<String> subset = items.subSet(UTF16.valueOf(cp), UTF16.valueOf(cp + 1));
+        SortedSet<String> subset = items.subSet(Character.toString(cp), Character.toString(cp + 1));
         int bestLength = -1;
         int inputLength = input.length();
         int allowedLength = inputLength - offset;
@@ -788,7 +788,7 @@ public class EmojiFrequency {
                         boolean found = m.find(pos);
                         if (!found) break;
                         int cp = Integer.parseInt(m.group(1), 16);
-                        String str = UTF16.valueOf(cp);
+                        String str = Character.toString(cp);
                         long count = Long.parseLong(m.group(2));
                         if (factor == 0) {
                             factor = 1_000_000_000.0 / count;

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/EmojiMatcher.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/EmojiMatcher.java
@@ -1,7 +1,6 @@
 package org.unicode.tools.emoji;
 
 import com.ibm.icu.lang.CharSequences;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.util.List;
 
@@ -243,7 +242,7 @@ public class EmojiMatcher {
         StringBuilder nonEmojiBuffer = new StringBuilder();
         for (int cp : CharSequences.codePoints(str)) {
             if (nopres.contains(cp) && cp >= 0x7F) { // hack to exclude keycap bases
-                noPres2.add(UTF16.valueOf(cp));
+                noPres2.add(Character.toString(cp));
             } else {
                 nonEmojiBuffer.appendCodePoint(cp);
             }

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/EmojiOrder.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/EmojiOrder.java
@@ -379,7 +379,7 @@ public class EmojiOrder {
                 if (sorted.contains(string)) {
                     continue;
                 }
-                if (string.contains(UTF16.valueOf(0x1F90C))) {
+                if (string.contains(Character.toString(0x1F90C))) {
                     int debug = 0;
                 }
                 { // just for formatting
@@ -795,7 +795,7 @@ public class EmojiOrder {
             String handshake =
                     compositeBase ? EmojiData.COUPLES_TO_HANDSHAKE_VERSION.get(base) : base;
             int firstCp = handshake.codePointAt(0);
-            String lead = UTF16.valueOf(firstCp);
+            String lead = Character.toString(firstCp);
             String trail = handshake.substring(Character.charCount(firstCp));
             for (String skin : EmojiData.MODIFIERS) {
                 String combo = lead + skin + trail;

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/FixEmojiText.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/FixEmojiText.java
@@ -1,7 +1,6 @@
 package org.unicode.tools.emoji;
 
 import com.ibm.icu.lang.UCharacter;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.io.File;
 import java.io.IOException;
@@ -41,7 +40,7 @@ public class FixEmojiText {
                 }
             } else {
                 for (int cp : With.codePointArray(arg)) {
-                    process2(UTF16.valueOf(cp), result);
+                    process2(Character.toString(cp), result);
                 }
             }
             out.println(result);

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/GenerateAnnotations.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/GenerateAnnotations.java
@@ -3,7 +3,6 @@ package org.unicode.tools.emoji;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.dev.util.CollectionUtilities;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.VersionInfo;
 import java.util.Collection;
@@ -101,8 +100,8 @@ public class GenerateAnnotations {
         }
     }
 
-    private static String MAN = UTF16.valueOf(0x1F468);
-    private static String ADULT = UTF16.valueOf(0x1F9D1);
+    private static String MAN = Character.toString(0x1F468);
+    private static String ADULT = Character.toString(0x1F9D1);
 
     private static void showGenderVariants(EmojiData betaData) {
         Multimap<CountEmoji.ZwjType, String> data = TreeMultimap.create();
@@ -113,7 +112,7 @@ public class GenerateAnnotations {
             CountEmoji.ZwjType type = CountEmoji.ZwjType.getType(s);
             if (s.contains(Emoji.MALE)) {
                 int first = s.codePointAt(0);
-                data.put(type, UTF16.valueOf(first));
+                data.put(type, Character.toString(first));
             } else {
                 switch (type) {
                     case family:

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/GenerateEmoji.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/GenerateEmoji.java
@@ -1343,13 +1343,14 @@ public class GenerateEmoji {
     private static void showNames(PrintWriter out, Set<String> minimal, boolean abbreviate) {
         UnicodeSet us = new UnicodeSet().addAll(minimal);
         for (EntryRange r : us.ranges()) {
-            out.print(getCodeAndName2(UTF16.valueOf(r.codepoint), false));
+            out.print(getCodeAndName2(Character.toString(r.codepoint), false));
             if (r.codepoint != r.codepointEnd) {
                 if (abbreviate) {
-                    out.print("<br>\n…" + getCodeAndName2(UTF16.valueOf(r.codepointEnd), false));
+                    out.print(
+                            "<br>\n…" + getCodeAndName2(Character.toString(r.codepointEnd), false));
                 } else {
                     for (int cp = r.codepoint + 1; cp <= r.codepointEnd; ++cp) {
-                        out.print("<br>\n" + getCodeAndName2(UTF16.valueOf(cp), false));
+                        out.print("<br>\n" + getCodeAndName2(Character.toString(cp), false));
                     }
                 }
             }
@@ -2151,7 +2152,7 @@ public class GenerateEmoji {
             // continue;
             // }
             // //if (Emoji.EMOJI_CHARS.contains(item)) {
-            // String s2 = UTF16.valueOf(item);
+            // String s2 = Character.toString(item);
             // out.println(getBestImage(s2, true, ""));
             // // if (name.length() != 0) {
             // // name.append();
@@ -3607,7 +3608,7 @@ public class GenerateEmoji {
     // Set<String> result = new LinkedHashSet<>();
     // for (int cp : CharSequences.codePoints(string)) {
     // if (cp != 0x200D && cp != 0xFE0F) {
-    // result.addAll(EmojiAnnotations.ANNOTATIONS_TO_CHARS.getKeys(UTF16.valueOf(cp)));
+    // result.addAll(EmojiAnnotations.ANNOTATIONS_TO_CHARS.getKeys(Character.toString(cp)));
     // }
     // }
     // return result;
@@ -4728,7 +4729,7 @@ public class GenerateEmoji {
             }
             String name;
             if (Emoji.TAG_BASE + ' ' <= cp && cp < Emoji.TAG_TERM_CHAR) {
-                name = "tag_" + UTF16.valueOf(cp - Emoji.TAG_BASE);
+                name = "tag_" + Character.toString(cp - Emoji.TAG_BASE);
             } else if (cp == Emoji.TAG_TERM_CHAR) {
                 name = "tag_term";
             } else {

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/GenerateEmojiData.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/GenerateEmojiData.java
@@ -5,7 +5,6 @@ import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.lang.CharSequences;
 import com.ibm.icu.text.DateFormat;
 import com.ibm.icu.text.SimpleDateFormat;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSet.EntryRange;
 import com.ibm.icu.util.ICUUncheckedIOException;
@@ -836,11 +835,11 @@ public class GenerateEmojiData {
                         s = range.string;
                         rangeCount = 1;
                     } else {
-                        s = UTF16.valueOf(range.codepoint);
+                        s = Character.toString(range.codepoint);
                         rangeCount = range.codepointEnd - range.codepoint + 1;
                     }
 
-                    if (s.contains(UTF16.valueOf(0x1F9D6))) {
+                    if (s.contains(Character.toString(0x1F9D6))) {
                         int debug = 0;
                     }
 
@@ -851,7 +850,7 @@ public class GenerateEmojiData {
                             throw new IllegalArgumentException("internal error");
                         }
                         for (int cp = range.codepoint; cp <= range.codepointEnd; ++cp) {
-                            s = UTF16.valueOf(cp);
+                            s = Character.toString(cp);
                             out.write(
                                     tabber.process(
                                                     Utility.hex(s)
@@ -900,7 +899,7 @@ public class GenerateEmojiData {
                                                         + (showName ? "" : "\t" + getName(s)))
                                         + "\n");
                     } else {
-                        final String e = UTF16.valueOf(range.codepointEnd);
+                        final String e = Character.toString(range.codepointEnd);
                         out.write(
                                 tabber.process(
                                                 Utility.hex(range.codepoint)
@@ -1086,7 +1085,8 @@ public class GenerateEmojiData {
         //        String result = emojiDataSource.getName("🧙‍♀️");
         //
         //        for (int cp : CharSequences.codePoints(EXPLICIT_GENDER_LIST)) {
-        //            System.out.println("U+" + Utility.hex(cp) + " " + getName(UTF16.valueOf(cp)));
+        //            System.out.println("U+" + Utility.hex(cp) + " " +
+        // getName(Character.toString(cp)));
         //        }
         UnicodeMap<ZwjType> types = new UnicodeMap<>();
         for (String s : emojiDataSource.getZwjSequencesNormal()) {

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/GenerateSpecImage.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/GenerateSpecImage.java
@@ -1,7 +1,6 @@
 package org.unicode.tools.emoji;
 
 import com.google.common.collect.ImmutableList;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSet.SpanCondition;
 import com.ibm.icu.text.UnicodeSetSpanner;
@@ -156,7 +155,7 @@ public class GenerateSpecImage {
                 if (!modString.isEmpty()) {
                     modString += ", ";
                 }
-                switch (UTF16.valueOf(mod)) {
+                switch (Character.toString(mod)) {
                     case "🏻":
                         modString += "light skin tone";
                         break;
@@ -185,7 +184,7 @@ public class GenerateSpecImage {
             if (!emojiSet.contains(cp)) {
                 continue;
             }
-            String cell = GenerateEmoji.getBestImage(UTF16.valueOf(cp), false, null);
+            String cell = GenerateEmoji.getBestImage(Character.toString(cp), false, null);
             System.out.println(cell);
         }
     }

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/ListFonts.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/ListFonts.java
@@ -3,7 +3,6 @@ package org.unicode.tools.emoji;
 import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UScript;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSet.EntryRange;
 import java.awt.Font;
@@ -105,7 +104,7 @@ public class ListFonts {
         for (EntryRange range : NON_C.ranges()) {
             for (int cp = range.codepoint; cp <= range.codepointEnd; ++cp) {
                 if (f.canDisplay(cp)) {
-                    GlyphVector gv = f.createGlyphVector(frc, UTF16.valueOf(cp));
+                    GlyphVector gv = f.createGlyphVector(frc, Character.toString(cp));
                     final int glyphCode = gv.getGlyphCode(0);
                     if (glyphCode >= 0) {
                         result.add(cp);

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/LoadImage.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/LoadImage.java
@@ -8,7 +8,6 @@ import com.ibm.icu.lang.UScript.ScriptUsage;
 import com.ibm.icu.text.BreakIterator;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.Transform;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import com.ibm.icu.util.ULocale;
@@ -445,7 +444,7 @@ public class LoadImage extends Component {
                 it.next(); ) {
             int i = it.codepoint;
             if (f.canDisplay(i)) {
-                GlyphVector gv = f.createGlyphVector(frc, UTF16.valueOf(i));
+                GlyphVector gv = f.createGlyphVector(frc, Character.toString(i));
                 final int glyphCode = gv.getGlyphCode(0);
                 if (glyphCode >= 0) {
                     result.add(i);

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/ProposalData.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/ProposalData.java
@@ -7,7 +7,6 @@ import com.google.common.collect.Multimap;
 import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.lang.CharSequences;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ICUException;
 import com.ibm.icu.util.ICUUncheckedIOException;
@@ -150,7 +149,7 @@ public class ProposalData {
     //        Collection<String> result = proposal.get(source);
     //        if (result.isEmpty()) {
     //            for (int cp : CharSequences.codePoints(source)) {
-    //                result = proposal.get(UTF16.valueOf(cp));
+    //                result = proposal.get(Character.toString(cp));
     //                if (!result.isEmpty()) {
     //                    break;
     //                }
@@ -455,13 +454,13 @@ public class ProposalData {
     }
 
     public static <T> String showLine(int codepoint, int codepointEnd, T value) {
-        String chars = UTF16.valueOf(codepoint);
+        String chars = Character.toString(codepoint);
         String charsWV = EmojiDataSourceCombined.EMOJI_DATA.addEmojiVariants(chars);
         String source = Utility.hex(chars);
         String names = getName(charsWV);
         String years = BirthInfo.getYear(charsWV) + "";
         if (codepoint != codepointEnd) {
-            String chars2 = UTF16.valueOf(codepointEnd);
+            String chars2 = Character.toString(codepointEnd);
             String charsWV2 = EmojiDataSourceCombined.EMOJI_DATA.addEmojiVariants(chars2);
             source += ".." + Utility.hex(chars2);
             charsWV += ".." + charsWV2;
@@ -541,15 +540,15 @@ public class ProposalData {
                             + "\n"
                             + "<p>This file is abbreviated by replacing certain characters that are always included in the same proposal:</p>"
                             + "<ul><li>skintones ("
-                            + ChartUtilities.htmlSpanForSkintone(UTF16.valueOf(0x1F3FB))
+                            + ChartUtilities.htmlSpanForSkintone(Character.toString(0x1F3FB))
                             + " "
-                            + ChartUtilities.htmlSpanForSkintone(UTF16.valueOf(0x1F3FC))
+                            + ChartUtilities.htmlSpanForSkintone(Character.toString(0x1F3FC))
                             + " "
-                            + ChartUtilities.htmlSpanForSkintone(UTF16.valueOf(0x1F3FD))
+                            + ChartUtilities.htmlSpanForSkintone(Character.toString(0x1F3FD))
                             + " "
-                            + ChartUtilities.htmlSpanForSkintone(UTF16.valueOf(0x1F3FE))
+                            + ChartUtilities.htmlSpanForSkintone(Character.toString(0x1F3FE))
                             + " "
-                            + ChartUtilities.htmlSpanForSkintone(UTF16.valueOf(0x1F3FF))
+                            + ChartUtilities.htmlSpanForSkintone(Character.toString(0x1F3FF))
                             + ") by "
                             + ChartUtilities.htmlSpanForSkintone(SKIN_REPRESENTATIVE)
                             + "</li>\n"

--- a/unicodetools/src/main/java/org/unicode/tools/emoji/UnicodeSets.java
+++ b/unicodetools/src/main/java/org/unicode/tools/emoji/UnicodeSets.java
@@ -1,7 +1,6 @@
 package org.unicode.tools.emoji;
 
 import com.ibm.icu.lang.CharSequences;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSet.SpanCondition;
 import com.ibm.icu.text.UnicodeSetSpanner;
@@ -15,7 +14,7 @@ public class UnicodeSets {
                 spanner.replaceFrom(
                         input, "", CountMethod.MIN_ELEMENTS, SpanCondition.NOT_CONTAINED);
         for (int cp : CharSequences.codePoints(extractedString)) {
-            extracted.add(UTF16.valueOf(cp));
+            extracted.add(Character.toString(cp));
         }
         return spanner.deleteFrom(input);
     }

--- a/unicodetools/src/main/java/org/unicode/unused/CheckSystemFonts.java
+++ b/unicodetools/src/main/java/org/unicode/unused/CheckSystemFonts.java
@@ -18,7 +18,6 @@ import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UScript;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.Normalizer;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import java.awt.Font;
@@ -504,7 +503,7 @@ public class CheckSystemFonts {
     }
 
     private static String showChar(Integer item, boolean html) {
-        return rtlProtect(UTF16.valueOf(item), html);
+        return rtlProtect(Character.toString(item), html);
     }
 
     static UnicodeSet RTL = new UnicodeSet("[[:bc=R:][:bc=AL:][:bc=AN:]]").freeze();
@@ -649,7 +648,7 @@ public class CheckSystemFonts {
                                 "Adding "
                                         + Utility.hex(it.codepoint)
                                         + "\t"
-                                        + UTF16.valueOf(it.codepoint)
+                                        + Character.toString(it.codepoint)
                                         + "\tto "
                                         + set.toPattern(false));
                     }

--- a/unicodetools/src/main/java/org/unicode/unused/DataInputCompressor.java
+++ b/unicodetools/src/main/java/org/unicode/unused/DataInputCompressor.java
@@ -6,7 +6,6 @@
  */
 package org.unicode.unused;
 
-import com.ibm.icu.text.UTF16;
 import java.io.DataInput;
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -136,7 +135,7 @@ public final class DataInputCompressor implements ObjectInput {
         stringBuffer.setLength(0);
         for (int i = 0; i < len; ++i) {
             int cp = (int) readULong();
-            UTF16.append(stringBuffer, cp);
+            stringBuffer.appendCodePoint(cp);
         }
         return stringBuffer.toString();
     }

--- a/unicodetools/src/main/java/org/unicode/unused/DataOutputCompressor.java
+++ b/unicodetools/src/main/java/org/unicode/unused/DataOutputCompressor.java
@@ -116,7 +116,7 @@ public final class DataOutputCompressor implements ObjectOutput {
     public void writeChars(String s) throws IOException {
         int cp = 0;
         for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-            cp = UTF16.charAt(s, i);
+            cp = s.codePointAt(i);
             writeULong(cp);
         }
     }

--- a/unicodetools/src/main/java/org/unicode/unused/DataOutputCompressor.java
+++ b/unicodetools/src/main/java/org/unicode/unused/DataOutputCompressor.java
@@ -115,7 +115,7 @@ public final class DataOutputCompressor implements ObjectOutput {
 
     public void writeChars(String s) throws IOException {
         int cp = 0;
-        for (int i = 0; i < s.length(); i += UTF16.getCharCount(cp)) {
+        for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
             cp = UTF16.charAt(s, i);
             writeULong(cp);
         }

--- a/unicodetools/src/main/java/org/unicode/unused/GenerateUcaDecompositions.java
+++ b/unicodetools/src/main/java/org/unicode/unused/GenerateUcaDecompositions.java
@@ -6,7 +6,6 @@ import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UProperty;
 import com.ibm.icu.lang.UProperty.NameChoice;
 import com.ibm.icu.text.Normalizer2;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -65,7 +64,7 @@ public class GenerateUcaDecompositions {
                 continue;
             }
 
-            final String s = UTF16.valueOf(i);
+            final String s = Character.toString(i);
             final CEList ceList = uca.getCEList(s, true);
 
             char2Ces.put(i, ceList);
@@ -93,10 +92,10 @@ public class GenerateUcaDecompositions {
                 continue;
             }
             if (ucaDecomp == null) {
-                ucaDecomp = UTF16.valueOf(i);
+                ucaDecomp = Character.toString(i);
             }
             if (nfkdOrNull == null) {
-                nfkdOrNull = UTF16.valueOf(i);
+                nfkdOrNull = Character.toString(i);
             }
             if (nfkdOrNull.equals(ucaDecomp)) {
                 continue;
@@ -118,7 +117,7 @@ public class GenerateUcaDecompositions {
                             + ";\t#\t"
                             + gcName
                             + "\t"
-                            + UTF16.valueOf(i)
+                            + Character.toString(i)
                             + "\t"
                             + UCharacter.getExtendedName(i)
                             + "\t→\t"

--- a/unicodetools/src/main/java/org/unicode/unused/UnicodePropertySource.java
+++ b/unicodetools/src/main/java/org/unicode/unused/UnicodePropertySource.java
@@ -9,7 +9,6 @@ package org.unicode.unused;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UProperty;
 import com.ibm.icu.text.Normalizer;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import java.util.Arrays;
@@ -65,7 +64,7 @@ public abstract class UnicodePropertySource implements Cloneable {
         if (other.length() == 1) {
             return codepoint == other.charAt(0);
         }
-        return other.equals(UTF16.valueOf(codepoint));
+        return other.equals(Character.toString(codepoint));
     }
 
     public UnicodeSet getPropertySet(boolean charEqualsValue, UnicodeSet result) {
@@ -182,30 +181,32 @@ public abstract class UnicodePropertySource implements Cloneable {
                     case UProperty.AGE:
                         return UCharacter.getAge(codePoint).toString();
                     case UProperty.BIDI_MIRRORING_GLYPH:
-                        return UTF16.valueOf(UCharacter.getMirror(codePoint));
+                        return Character.toString(UCharacter.getMirror(codePoint));
                     case UProperty.CASE_FOLDING:
-                        return UCharacter.foldCase(UTF16.valueOf(codePoint), true);
+                        return UCharacter.foldCase(Character.toString(codePoint), true);
                     case UProperty.ISO_COMMENT:
                         return UCharacter.getISOComment(codePoint);
                     case UProperty.LOWERCASE_MAPPING:
-                        return UCharacter.toLowerCase(Locale.ENGLISH, UTF16.valueOf(codePoint));
+                        return UCharacter.toLowerCase(
+                                Locale.ENGLISH, Character.toString(codePoint));
                     case UProperty.NAME:
                         return UCharacter.getName(codePoint);
                     case UProperty.SIMPLE_CASE_FOLDING:
-                        return UTF16.valueOf(UCharacter.foldCase(codePoint, true));
+                        return Character.toString(UCharacter.foldCase(codePoint, true));
                     case UProperty.SIMPLE_LOWERCASE_MAPPING:
-                        return UTF16.valueOf(UCharacter.toLowerCase(codePoint));
+                        return Character.toString(UCharacter.toLowerCase(codePoint));
                     case UProperty.SIMPLE_TITLECASE_MAPPING:
-                        return UTF16.valueOf(UCharacter.toTitleCase(codePoint));
+                        return Character.toString(UCharacter.toTitleCase(codePoint));
                     case UProperty.SIMPLE_UPPERCASE_MAPPING:
-                        return UTF16.valueOf(UCharacter.toUpperCase(codePoint));
+                        return Character.toString(UCharacter.toUpperCase(codePoint));
                     case UProperty.TITLECASE_MAPPING:
                         return UCharacter.toTitleCase(
-                                Locale.ENGLISH, UTF16.valueOf(codePoint), null);
+                                Locale.ENGLISH, Character.toString(codePoint), null);
                     case UProperty.UNICODE_1_NAME:
                         return UCharacter.getName1_0(codePoint);
                     case UProperty.UPPERCASE_MAPPING:
-                        return UCharacter.toUpperCase(Locale.ENGLISH, UTF16.valueOf(codePoint));
+                        return UCharacter.toUpperCase(
+                                Locale.ENGLISH, Character.toString(codePoint));
                     case NFC:
                         return Normalizer.normalize(codePoint, Normalizer.NFC);
                     case NFD:

--- a/unicodetools/src/main/java/org/unicode/utilities/LinkUtilities.java
+++ b/unicodetools/src/main/java/org/unicode/utilities/LinkUtilities.java
@@ -15,7 +15,6 @@ import com.ibm.icu.lang.UProperty;
 import com.ibm.icu.lang.UProperty.NameChoice;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.StringPrepParseException;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSet.EntryRange;
 import com.ibm.icu.text.UnicodeSet.SpanCondition;
@@ -1154,12 +1153,12 @@ public class LinkUtilities {
                             + Utility.hex(value2)
                             + "\t#"
                             + " “"
-                            + quote(UTF16.valueOf(cp))
+                            + quote(Character.toString(cp))
                             + "” "
                             + UCharacter.getExtendedName(cp)
                             + " 🡆 "
                             + " “"
-                            + quote(UTF16.valueOf(value2))
+                            + quote(Character.toString(value2))
                             + "” "
                             + UCharacter.getExtendedName(value2));
         }

--- a/unicodetools/src/main/java/org/unicode/utilities/UnicodeSetFormatter.java
+++ b/unicodetools/src/main/java/org/unicode/utilities/UnicodeSetFormatter.java
@@ -200,7 +200,7 @@ public class UnicodeSetFormatter {
             appendQuoted(s);
             lastString = s;
         } else {
-            appendUnicodeSetItem(UTF16.charAt(s, 0));
+            appendUnicodeSetItem(s.codePointAt(0));
         }
         return this;
     }
@@ -222,7 +222,7 @@ public class UnicodeSetFormatter {
         } else if (spaceComp != null && spaceComp.compare(s, lastString) != 0) {
             target.append(' ');
         } else {
-            int cp = UTF16.charAt(s, 0);
+            int cp = s.codePointAt(0);
             if (!toQuote.contains(cp) && !QUOTED_SYNTAX.contains(cp)) {
                 int type = UCharacter.getType(cp);
                 if (type == UCharacter.NON_SPACING_MARK || type == UCharacter.ENCLOSING_MARK) {
@@ -262,7 +262,7 @@ public class UnicodeSetFormatter {
         } else {
             int cp;
             for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
-                appendQuoted(cp = UTF16.charAt(s, i));
+                appendQuoted(cp = s.codePointAt(i));
             }
         }
         target.append("}");

--- a/unicodetools/src/main/java/org/unicode/utilities/UnicodeSetFormatter.java
+++ b/unicodetools/src/main/java/org/unicode/utilities/UnicodeSetFormatter.java
@@ -304,7 +304,7 @@ public class UnicodeSetFormatter {
                 }
                 break;
         }
-        UTF16.append(target, codePoint);
+        target.appendCodePoint(codePoint);
         return this;
     }
 

--- a/unicodetools/src/main/java/org/unicode/utilities/UnicodeSetFormatter.java
+++ b/unicodetools/src/main/java/org/unicode/utilities/UnicodeSetFormatter.java
@@ -157,7 +157,7 @@ public class UnicodeSetFormatter {
             } else {
                 for (int i = it.codepoint; i <= it.codepointEnd; ++i) {
                     if (!putAtEnd.contains(i)) {
-                        orderedStrings.add(UTF16.valueOf(i));
+                        orderedStrings.add(Character.toString(i));
                     }
                 }
             }
@@ -235,7 +235,7 @@ public class UnicodeSetFormatter {
     }
 
     private void addSpaceAsNeededBefore(int codepoint) {
-        addSpaceAsNeededBefore(UTF16.valueOf(codepoint));
+        addSpaceAsNeededBefore(Character.toString(codepoint));
     }
 
     private void flushLast() {
@@ -250,7 +250,7 @@ public class UnicodeSetFormatter {
                 }
             }
             appendQuoted(lastCodePoint);
-            lastString = UTF16.valueOf(lastCodePoint);
+            lastString = Character.toString(lastCodePoint);
             firstCodePoint = lastCodePoint = -2;
         }
     }
@@ -271,7 +271,7 @@ public class UnicodeSetFormatter {
     UnicodeSetFormatter appendQuoted(int codePoint) {
         if (toQuote.contains(codePoint)) {
             if (quoter != null) {
-                target.append(quoter.transform(UTF16.valueOf(codePoint)));
+                target.append(quoter.transform(Character.toString(codePoint)));
                 return this;
             }
             if (codePoint > 0xFFFF) {

--- a/unicodetools/src/main/java/org/unicode/utilities/UnicodeSetFormatter.java
+++ b/unicodetools/src/main/java/org/unicode/utilities/UnicodeSetFormatter.java
@@ -261,7 +261,7 @@ public class UnicodeSetFormatter {
             target.append(quoter.transform(s));
         } else {
             int cp;
-            for (int i = 0; i < s.length(); i += UTF16.getCharCount(cp)) {
+            for (int i = 0; i < s.length(); i += Character.charCount(cp)) {
                 appendQuoted(cp = UTF16.charAt(s, i));
             }
         }

--- a/unicodetools/src/test/java/org/unicode/idna/TestIdna.java
+++ b/unicodetools/src/test/java/org/unicode/idna/TestIdna.java
@@ -4,7 +4,6 @@ import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.Normalizer2;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.io.IOException;
 import java.util.Locale;
@@ -69,7 +68,7 @@ public class TestIdna extends TestFmwkMinusMinus {
 
         private String getIdnabisMapping(int source) {
             String idnabisMapping;
-            idnabisMapping = UCharacter.toLowerCase(Locale.ROOT, UTF16.valueOf(source));
+            idnabisMapping = UCharacter.toLowerCase(Locale.ROOT, Character.toString(source));
             if (wideNarrow.containsSome(idnabisMapping)) {
                 StringBuilder temp = new StringBuilder();
                 int cp;

--- a/unicodetools/src/test/java/org/unicode/idna/TestUts46.java
+++ b/unicodetools/src/test/java/org/unicode/idna/TestUts46.java
@@ -6,7 +6,6 @@ import com.ibm.icu.text.DateFormat;
 import com.ibm.icu.text.Normalizer2;
 import com.ibm.icu.text.SimpleDateFormat;
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.TimeZone;
 import com.ibm.icu.util.ULocale;
@@ -667,9 +666,9 @@ public class TestUts46 extends TestFmwkMinusMinus {
             "\u02E3\u034F\u2115\u200B\uFE63\u00AD\uFF0D\u180C"
                     + "\u212C\uFE00\u017F\u2064"
                     // + "\\U0001D530"
-                    + UTF16.valueOf(0x1D530)
+                    + Character.toString(0x1D530)
                     // + "\\U000E01EF"
-                    + UTF16.valueOf(0xE01EF)
+                    + Character.toString(0xE01EF)
                     + "\uFB04",
             "B",
             "\u5921\u591E\u591C\u5919",

--- a/unicodetools/src/test/java/org/unicode/propstest/CheckNames.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/CheckNames.java
@@ -2,7 +2,6 @@ package org.unicode.propstest;
 
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.impl.UnicodeMap.EntryRange;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -65,8 +64,8 @@ public class CheckNames {
             if (name.string != null) {
                 add2(name.string, value);
             } else {
-                add2(UTF16.valueOf(name.codepoint), value);
-                add2(UTF16.valueOf(name.codepointEnd), value);
+                add2(Character.toString(name.codepoint), value);
+                add2(Character.toString(name.codepointEnd), value);
                 // we don't care about intervening; all CJK...
             }
         }

--- a/unicodetools/src/test/java/org/unicode/propstest/CheckProperties.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/CheckProperties.java
@@ -6,7 +6,6 @@ import com.ibm.icu.impl.Row.R2;
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.impl.UnicodeMap.EntryRange;
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.VersionInfo;
 import java.io.DataOutput;
@@ -746,7 +745,7 @@ public class CheckProperties {
             } else {
                 result.append(" ");
             }
-            final String string = UTF16.valueOf(cp);
+            final String string = Character.toString(cp);
             String name = latest.getResolvedValue(UcdProperty.Name, string);
             if (name == null) {
                 name = latest.getResolvedValue(UcdProperty.Name_Alias, string);

--- a/unicodetools/src/test/java/org/unicode/propstest/CheckXidmod.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/CheckXidmod.java
@@ -6,7 +6,6 @@ import com.ibm.icu.impl.Utility;
 import com.ibm.icu.lang.UProperty;
 import com.ibm.icu.lang.UScript;
 import com.ibm.icu.text.Normalizer2;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import java.util.Comparator;
@@ -319,9 +318,13 @@ public class CheckXidmod {
 
     private void showSet(String title, UnicodeSet uset) {
         for (UnicodeSetIterator it = new UnicodeSetIterator(uset); it.nextRange(); ) {
-            logln("\t\t" + getCodeAndName(UTF16.valueOf(it.codepoint)) + "\t//" + title);
+            logln("\t\t" + getCodeAndName(Character.toString(it.codepoint)) + "\t//" + title);
             if (it.codepoint != it.codepointEnd) {
-                logln("\t\t... " + getCodeAndName(UTF16.valueOf(it.codepointEnd)) + "\t//" + title);
+                logln(
+                        "\t\t... "
+                                + getCodeAndName(Character.toString(it.codepointEnd))
+                                + "\t//"
+                                + title);
             }
         }
     }

--- a/unicodetools/src/test/java/org/unicode/propstest/FindProps.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/FindProps.java
@@ -4,7 +4,6 @@ import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.text.Transform;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import com.ibm.icu.util.ULocale;
@@ -15,6 +14,7 @@ import org.unicode.cldr.util.With;
 import org.unicode.props.GenerateEnums;
 import org.unicode.props.IndexUnicodeProperties;
 import org.unicode.props.UcdProperty;
+import org.unicode.text.utility.UTF16Plus;
 
 public class FindProps {
     static final IndexUnicodeProperties latest =
@@ -94,8 +94,7 @@ public class FindProps {
     static Transform<String, String> GET_NAME =
             new Transform<String, String>() {
                 public String transform(String s) {
-                    int len = UTF16.countCodePoint(s);
-                    if (len == 1) {
+                    if (UTF16Plus.isSingleCodePoint(s)) {
                         return names.get(s);
                     }
                     StringBuilder result = new StringBuilder();

--- a/unicodetools/src/test/java/org/unicode/propstest/Ids.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/Ids.java
@@ -1,7 +1,6 @@
 package org.unicode.propstest;
 
 import com.google.common.base.Splitter;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.io.File;
 import java.util.List;
@@ -37,7 +36,7 @@ public class Ids {
                     pua = puaCounter;
                     data.put(m.group(), puaCounter++);
                 }
-                b.append(UTF16.valueOf(pua));
+                b.append(Character.toString(pua));
                 start = m.end();
             }
             b.append(string.substring(start));
@@ -66,7 +65,7 @@ public class Ids {
             List<String> parts = semi.splitToList(line);
             int radical = Integer.parseInt(parts.get(1), 16);
             int ideo = Integer.parseInt(parts.get(2), 16);
-            DecompIds.put(ideo, UTF16.valueOf(radical));
+            DecompIds.put(ideo, Character.toString(radical));
         }
     }
 
@@ -119,7 +118,7 @@ public class Ids {
                         "U+"
                                 + Utility.hex(key)
                                 + "\t"
-                                + UTF16.valueOf(key)
+                                + Character.toString(key)
                                 + "\t"
                                 + value
                                 + "\t=>\t"
@@ -131,7 +130,8 @@ public class Ids {
         //        for (Entry<Integer, String> entry : Ids.entrySet()) {
         //            int key = entry.getKey();
         //            String value = entry.getValue();
-        //            System.out.println("U+" + Utility.hex(key) + "\t" + UTF16.valueOf(key) + "\t"
+        //            System.out.println("U+" + Utility.hex(key) + "\t" + Character.toString(key) +
+        // "\t"
         // + value);
         //        }
         for (Entry<String, Integer> entry : cleanup.data.entrySet()) {
@@ -161,7 +161,7 @@ public class Ids {
                 } else {
                     value = Ids.get(codePoint);
                     if (value == null) { // PUA
-                        value = UTF16.valueOf(codePoint);
+                        value = Character.toString(codePoint);
                         DecompIds.put(codePoint, value);
                     } else if (codePoint == value.codePointAt(0)) {
                         DecompIds.put(codePoint, value);

--- a/unicodetools/src/test/java/org/unicode/propstest/ListPropsNfcDiff.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/ListPropsNfcDiff.java
@@ -3,7 +3,6 @@ package org.unicode.propstest;
 import com.google.common.base.Objects;
 import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.impl.UnicodeMap;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -156,7 +155,7 @@ public class ListPropsNfcDiff {
         Normalizer nfc = Default.nfc();
         Normalizer nfkc = Default.nfkc();
         for (int cp = 0; cp <= 0x10FFFF; ++cp) {
-            String s = UTF16.valueOf(cp);
+            String s = Character.toString(cp);
             String nfcValue = nfc.transform(s);
             int singleCodePoint = UnicodeSet.getSingleCodePoint(nfcValue);
             if (singleCodePoint != Integer.MAX_VALUE && singleCodePoint != cp) {

--- a/unicodetools/src/test/java/org/unicode/propstest/TestPropNormalization.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/TestPropNormalization.java
@@ -1,7 +1,6 @@
 package org.unicode.propstest;
 
 import com.ibm.icu.text.Normalizer2;
-import com.ibm.icu.text.UTF16;
 import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.unicode.cldr.util.Timer;
@@ -24,7 +23,7 @@ public class TestPropNormalization extends TestFmwkMinusMinus {
         Timer t = new Timer();
         t.start();
         for (int i = 0; i < 0x110000; ++i) {
-            n.normalize(UTF16.valueOf(i));
+            n.normalize(Character.toString(i));
         }
         t.stop();
         logln(t.toString());
@@ -72,13 +71,13 @@ public class TestPropNormalization extends TestFmwkMinusMinus {
     }
 
     public void checkDecomp(PropNormalizationData pnd, Type type, Normalizer oldNfd, int i) {
-        String newNfd0 = pnd.normalize(UTF16.valueOf(i), type);
+        String newNfd0 = pnd.normalize(Character.toString(i), type);
         boolean oldNorm = oldNfd.isNormalized(i);
         if (oldNorm == (newNfd0 == null)) {
             return;
         }
         if (newNfd0 == null) {
-            newNfd0 = UTF16.valueOf(i);
+            newNfd0 = Character.toString(i);
         }
         String oldNfd0 = oldNfd.normalize(i);
         if (!Objects.equals(oldNfd0, newNfd0)) {

--- a/unicodetools/src/test/java/org/unicode/propstest/TestProperties.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/TestProperties.java
@@ -46,6 +46,7 @@ import org.unicode.props.UnicodeProperty;
 import org.unicode.props.ValueCardinality;
 import org.unicode.text.UCD.Default;
 import org.unicode.text.UCD.Normalizer;
+import org.unicode.text.utility.UTF16Plus;
 import org.unicode.tools.emoji.EmojiData;
 import org.unicode.unittest.TestFmwkMinusMinus;
 
@@ -314,7 +315,7 @@ public class TestProperties extends TestFmwkMinusMinus {
             if (!dt.getValue(codepoint).equals("Canonical")) {
                 continue;
             }
-            String decompositionFirst = Character.toString(dm.getValue(codepoint).codePointAt(0));
+            String decompositionFirst = UTF16Plus.codePointSubstringAt(dm.getValue(codepoint), 0);
             String decompositionFirstNFCQC = nfcqc.getValue(decompositionFirst);
             if (!decompositionFirstNFCQC.equals("Yes")) {
                 errln(
@@ -333,7 +334,7 @@ public class TestProperties extends TestFmwkMinusMinus {
         UnicodeMap<String> nfkcqc = iup.load(UcdProperty.NFKC_Quick_Check);
         UnicodeMap<String> dm = iup.load(UcdProperty.Decomposition_Mapping);
         for (String codepoint : nfkcqc.getSet("Yes")) {
-            String decompositionFirst = Character.toString(dm.getValue(codepoint).codePointAt(0));
+            String decompositionFirst = UTF16Plus.codePointSubstringAt(dm.getValue(codepoint), 0);
             String decompositionFirstNFKCQC = nfkcqc.getValue(decompositionFirst);
             if (!decompositionFirstNFKCQC.equals("Yes")) {
                 errln(

--- a/unicodetools/src/test/java/org/unicode/propstest/TestXSet.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/TestXSet.java
@@ -3,7 +3,6 @@ package org.unicode.propstest;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableBiMap.Builder;
 import com.ibm.icu.lang.CharSequences;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.util.Map.Entry;
 import org.junit.jupiter.api.Test;
@@ -149,7 +148,7 @@ public class TestXSet extends TestFmwkMinusMinus {
         XSet<String> result = new XSet<>();
         for (int ch : CharSequences.codePoints(a1)) {
             if (ch != '[' && ch != ']') {
-                result.add(UTF16.valueOf(ch));
+                result.add(Character.toString(ch));
             }
         }
         return result;

--- a/unicodetools/src/test/java/org/unicode/test/CaseBitTest.java
+++ b/unicodetools/src/test/java/org/unicode/test/CaseBitTest.java
@@ -20,6 +20,7 @@ import org.unicode.text.UCD.Default;
 import org.unicode.text.UCD.ToolUnicodePropertySource;
 import org.unicode.text.UCD.UCD_Types;
 import org.unicode.text.utility.Settings;
+import org.unicode.text.utility.UTF16Plus;
 import org.unicode.text.utility.Utility;
 import org.unicode.unittest.TestFmwkMinusMinus;
 import org.unicode.unused.CaseBit;
@@ -132,7 +133,7 @@ public class CaseBitTest extends TestFmwkMinusMinus {
             regular++;
         }
         for (String s : uca.getContractions()) {
-            if (UTF16.countCodePoint(s) != 1) { // don't count twice
+            if (!UTF16Plus.isSingleCodePoint(s)) { // don't count twice
                 s = Default.nfd().normalize(s);
                 sorted.put(uca.getCEList(s, true), s);
                 contractions++;

--- a/unicodetools/src/test/java/org/unicode/test/CompareBoundaries.java
+++ b/unicodetools/src/test/java/org/unicode/test/CompareBoundaries.java
@@ -4,7 +4,6 @@
 package org.unicode.test;
 
 import com.ibm.icu.impl.UnicodeMap;
-import com.ibm.icu.text.UTF16;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -228,7 +227,7 @@ public class CompareBoundaries {
 
                 // Sequence of UTF-16 code units
                 for (int i = 0; i < 2; ++i) {
-                    chrseq.append(UTF16.valueOf(intseq[i]));
+                    chrseq.append(Character.toString(intseq[i]));
                 }
 
                 // Determine WB and SB boundaries
@@ -293,7 +292,7 @@ public class CompareBoundaries {
 
                     // Sequence of UTF-16 code units
                     for (int i = 0; i < 3; ++i) {
-                        chrseq.append(UTF16.valueOf(intseq[i]));
+                        chrseq.append(Character.toString(intseq[i]));
                     }
 
                     // Determine WB and SB boundaries
@@ -375,7 +374,7 @@ public class CompareBoundaries {
 
                         // Sequence of UTF-16 code units
                         for (int i = 0; i < 4; ++i) {
-                            chrseq.append(UTF16.valueOf(intseq[i]));
+                            chrseq.append(Character.toString(intseq[i]));
                         }
 
                         // Determine WB and SB boundaries

--- a/unicodetools/src/test/java/org/unicode/test/TestSecurity.java
+++ b/unicodetools/src/test/java/org/unicode/test/TestSecurity.java
@@ -119,7 +119,7 @@ public class TestSecurity extends TestFmwkMinusMinus {
             checkTransform(transformMap, source, value);
             if (value.codePointCount(0, value.length()) > 1) {
                 for (int cp : CharSequences.codePoints(value)) {
-                    String v = UTF16.valueOf(cp);
+                    String v = Character.toString(cp);
                     checkTransform(transformMap, value, v);
                 }
             }

--- a/unicodetools/src/test/java/org/unicode/text/UCD/TestCodeInvariants.java
+++ b/unicodetools/src/test/java/org/unicode/text/UCD/TestCodeInvariants.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.text.Normalizer2;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSet.EntryRange;
 import java.util.Arrays;
@@ -207,7 +206,7 @@ public class TestCodeInvariants {
                 }
 
                 System.out.print(")");
-                System.out.print("  " + UTF16.valueOf(cp));
+                System.out.print("  " + Character.toString(cp));
                 System.out.print("  \"" + NAME.get(cp) + "\"");
 
                 if (flagged) {
@@ -239,7 +238,7 @@ public class TestCodeInvariants {
                 + "\t"
                 + Utility.hex(codePoint)
                 + " ( "
-                + UTF16.valueOf(codePoint)
+                + Character.toString(codePoint)
                 + " ) "
                 + NAME.get(codePoint);
     }

--- a/unicodetools/src/test/java/org/unicode/text/UCD/TestCodeInvariants.java
+++ b/unicodetools/src/test/java/org/unicode/text/UCD/TestCodeInvariants.java
@@ -202,7 +202,7 @@ public class TestCodeInvariants {
                 System.out.print("  ≡  " + Utility.hex(nfdOrNull) + " ( ");
 
                 for (int i = 0; i < nfdOrNull.length(); i += Character.charCount(ch)) {
-                    ch = UTF16.charAt(nfdOrNull, i);
+                    ch = nfdOrNull.codePointAt(i);
                     System.out.print(gcbPropShortName + "=" + GCB.get(ch).getShortName() + " ");
                 }
 

--- a/unicodetools/src/test/java/org/unicode/tools/emoji/unittest/TestEmojiDataConsistency.java
+++ b/unicodetools/src/test/java/org/unicode/tools/emoji/unittest/TestEmojiDataConsistency.java
@@ -2,7 +2,6 @@ package org.unicode.tools.emoji.unittest;
 
 import com.google.common.base.Splitter;
 import com.ibm.icu.impl.UnicodeMap;
-import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import com.ibm.icu.util.ICUException;
@@ -261,7 +260,7 @@ public class TestEmojiDataConsistency extends TestFmwkMinusMinus {
                                         + "; \t"
                                         + prop
                                         + "\t# "
-                                        + UTF16.valueOf(it.codepoint)
+                                        + Character.toString(it.codepoint)
                                         + "    "
                                         + getName(it.codepoint)));
             } else {
@@ -275,9 +274,9 @@ public class TestEmojiDataConsistency extends TestFmwkMinusMinus {
                                         + "; \t"
                                         + prop
                                         + "\t# "
-                                        + UTF16.valueOf(it.codepoint)
+                                        + Character.toString(it.codepoint)
                                         + ".."
-                                        + UTF16.valueOf(it.codepointEnd)
+                                        + Character.toString(it.codepointEnd)
                                         + " "
                                         + getName(it.codepoint)
                                         + ".."


### PR DESCRIPTION
ICU class UTF16 predates Java 5+ standard APIs for working with code points. Many of its call sites can be modernized.

**Best reviewed one commit at a time.**

- UTF16.getCharCount() -> Character.charCount()
- UTF16.charAt() -> codePointAt()
    - use StringBuilder/StringBuffer instance method where possible
    - otherwise static Character method
    - note: charAt() works from the middle of a surrogate pair, codePointAt() expects to be at a code point boundary
- UTF16.charAt() -> codePointBefore() for backward iteration
- use UTF16Plus.isSingleCodePoint() rather than counting through the whole string
- use .appendCodePoint()
- add & use UTF16Plus.insertCodePoint()
- UTF16.valueOf() -> Character.toString()
- replace surrogate testers and getters with Character methods
- class Emoji uses a lot of Character.toString(supplementary), create local cpToString()
- codePointSubstringAt() for codePointAt() + toString(), avoid decoding & reencoding

(I intend to squash & merge.)