### PR TITLE
Add math characters with vertical negation to DoNotEmit

### DIFF
--- a/unicodetools/data/ucd/dev/DoNotEmit.txt
+++ b/unicodetools/data/ucd/dev/DoNotEmit.txt
@@ -1,5 +1,5 @@
 # DoNotEmit-18.0.0.txt
-# Date: 2026-02-03, 23:09:55 GMT
+# Date: 2026-05-08, 00:14:00 GMT
 # © 2026 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -511,5 +511,10 @@
 17A4; 17A2 17B6; Deprecated # KHMER INDEPENDENT VOWEL QAA; KHMER LETTER QA, KHMER VOWEL SIGN AA
 17D8; 17D4 179B 17D4; Discouraged # KHMER SIGN BEYYAL; KHMER SIGN KHAN, KHMER LETTER LO, KHMER SIGN KHAN
 17E8 17D3; 19E0; Discouraged # KHMER DIGIT EIGHT, KHMER SIGN BATHAMASAT; KHMER SYMBOL PATHAMASAT
+
+# Precomposed form of mathematical symbols negated with a vertical bar
+221E 20D2; 29DE; Precomposed_Form # INFINITY, COMBINING LONG VERTICAL LINE OVERLAY; INFINITY NEGATED WITH VERTICAL BAR
+223E 20D2; 1DB1B; Precomposed_Form # INVERTED LAZY S, COMBINING LONG VERTICAL LINE OVERLAY; LEIBNIZIAN DISSIMILARITY
+1DB11 20D2; 1DB12; Precomposed_Form # LEIBNIZIAN CONGRUENCE, COMBINING LONG VERTICAL LINE OVERLAY; LEIBNIZIAN CONGRUENCE WITH VERTICAL BAR
 
 # EOF

--- a/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/MakeUnicodeFiles.java
@@ -1159,7 +1159,11 @@ public class MakeUnicodeFiles {
                                             UcdPropertyValues.Script_Values.forName(
                                                             script.getValue(
                                                                     dispreferred.codePointAt(0)))
-                                                    == Script_Values.Khmer))
+                                                    == Script_Values.Khmer),
+                            new DoNotEmitSubsection(
+                                    "Precomposed form of mathematical symbols negated with a vertical bar",
+                                    "[:Do_Not_Emit_Type=Precomposed_Form:]",
+                                    dispreferred -> dispreferred.contains("\u20D2")))
                 };
         for (final var section : sections) {
             pw.println();

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/AdditionComparisons/293.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/AdditionComparisons/293.txt
@@ -42,6 +42,7 @@ end Ignoring;
 # the obscure ⅁, ⅋, or ♯ which is relatively obscure in mathematical usage)
 # rather than Yes (like the very common ∃ or ∂).
 
+Ignoring Do_Not_Emit_Dispreferred Do_Not_Emit_Dispreferred_Type:
 Propertywise [
     \x{1DB0A}  \N{TWO-LINE GREATER-THAN}
     \x{1DB0B}  \N{TWO-LINE LESS-THAN}
@@ -56,8 +57,9 @@ Propertywise [
     \x{2141} ⅁ \N{TURNED SANS-SERIF CAPITAL G}
     \x{214B} ⅋ \N{TURNED AMPERSAND}
 ] AreAlike
+end Ignoring;
 
-Ignoring Line_Break East_Asian_Width Vertical_Orientation Pattern_Syntax:
+Ignoring Line_Break East_Asian_Width Vertical_Orientation Pattern_Syntax Do_Not_Emit_Dispreferred Do_Not_Emit_Dispreferred_Type:
 Propertywise [
     \x{1DB0A}  \N{TWO-LINE GREATER-THAN}
     \x{1DB0B}  \N{TWO-LINE LESS-THAN}
@@ -92,7 +94,7 @@ Propertywise [
 end Ignoring;
 
 # Symbols incorporating a lazy S.
-Ignoring Pattern_Syntax:
+Ignoring Pattern_Syntax Do_Not_Emit_Dispreferred Do_Not_Emit_Dispreferred_Type:
 Propertywise [
     \x{223E} ∾ \N{INVERTED LAZY S}
     \x{1DB17}  \N{LEIBNIZIAN COINCIDENCE}


### PR DESCRIPTION
[UTC-187-A123] Action Item for Roozbeh Pournader, PAG: Add DoNotEmit sequences <U+221E, U+20D2> for U+29DE INFINITY NEGATED WITH VERTICAL BAR, <U+1DB11, U+20D2> for U+1DB12 LEIBNIZIAN CONGRUENCE WITH VERTICAL BAR, and <U+223E, U+20D2> for U+1DB1B LEIBNIZIAN DISSIMILARITY, with type = Precomposed_Form. For Unicode Version 18.0. See L2/26-096 item 2.2.

- [x] Approver: Feel free to merge on my behalf
    - [ ] rebase & merge one or more commits
    - [x] squash & merge multiple commits into one