### PR TITLE
fix TODO in hasCompatDecomposition()

### DIFF
--- a/unicodetools/src/main/java/org/unicode/props/NormalizationDataIUP.java
+++ b/unicodetools/src/main/java/org/unicode/props/NormalizationDataIUP.java
@@ -247,8 +247,8 @@ public class NormalizationDataIUP implements NormalizationData {
      */
     @Override
     public boolean hasCompatDecomposition(int i) {
-        // TODO: Looks like a misnomer. Should be called hasDecomposition() or else check dt!=None.
-        return isCanonicalOrCompat(decompType.get(i));
+        // TODO: Misnomer? Should be called hasDecomposition() or else check isCompat().
+        return isCanonicalOrCompat(decompType.get(i)); // dt != None
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
I noticed that I got this TODO only half right in https://github.com/unicode-org/unicodetools/pull/1394 and didn't want to wait for another approval cycle before merging that.

- [x] Approver: Feel free to merge on my behalf
    - [x] rebase & merge one or more commits
    - [ ] squash & merge multiple commits into one