### PR TITLE
UTC-187-A144 change Identifier_Type of U+028C

### DIFF
--- a/unicodetools/data/security/dev/IdentifierType.txt
+++ b/unicodetools/data/security/dev/IdentifierType.txt
@@ -1,5 +1,5 @@
 # IdentifierType.txt
-# Date: 2026-05-11, 16:38:13 GMT
+# Date: 2026-05-11, 17:11:59 GMT
 # © 2026 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -172,7 +172,7 @@
 0289          ; Recommended                    # 1.1        LATIN SMALL LETTER U BAR
 028A          ; Technical                      # 1.1        LATIN SMALL LETTER UPSILON
 028B          ; Recommended                    # 1.1        LATIN SMALL LETTER V WITH HOOK
-028C          ; Uncommon_Use                   # 1.1        LATIN SMALL LETTER TURNED V
+028C          ; Uncommon_Use Technical         # 1.1        LATIN SMALL LETTER TURNED V
 028D..0291    ; Technical                      # 1.1    [5] LATIN SMALL LETTER TURNED W..LATIN SMALL LETTER Z WITH CURL
 0292          ; Recommended                    # 1.1        LATIN SMALL LETTER EZH
 0293..029D    ; Technical                      # 1.1   [11] LATIN SMALL LETTER EZH WITH CURL..LATIN SMALL LETTER J WITH CROSSED-TAIL

--- a/unicodetools/data/security/dev/IdentifierType.txt
+++ b/unicodetools/data/security/dev/IdentifierType.txt
@@ -1,5 +1,5 @@
 # IdentifierType.txt
-# Date: 2026-05-03, 21:54:14 GMT
+# Date: 2026-05-11, 16:38:13 GMT
 # © 2026 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -172,7 +172,8 @@
 0289          ; Recommended                    # 1.1        LATIN SMALL LETTER U BAR
 028A          ; Technical                      # 1.1        LATIN SMALL LETTER UPSILON
 028B          ; Recommended                    # 1.1        LATIN SMALL LETTER V WITH HOOK
-028C..0291    ; Technical                      # 1.1    [6] LATIN SMALL LETTER TURNED V..LATIN SMALL LETTER Z WITH CURL
+028C          ; Uncommon_Use                   # 1.1        LATIN SMALL LETTER TURNED V
+028D..0291    ; Technical                      # 1.1    [5] LATIN SMALL LETTER TURNED W..LATIN SMALL LETTER Z WITH CURL
 0292          ; Recommended                    # 1.1        LATIN SMALL LETTER EZH
 0293..029D    ; Technical                      # 1.1   [11] LATIN SMALL LETTER EZH WITH CURL..LATIN SMALL LETTER J WITH CROSSED-TAIL
 029E          ; Technical Obsolete             # 1.1        LATIN SMALL LETTER TURNED K

--- a/unicodetools/data/security/dev/data/source/removals.txt
+++ b/unicodetools/data/security/dev/data/source/removals.txt
@@ -1247,5 +1247,5 @@ AB6C..AB6D ; Technical
 1DF96 ; Technical Obsolete
 2B81E ; Uncommon_Use
 
-# UTC-187-A144
+# UTC-187-A144: Change Identifier_Type for U+028C LATIN SMALL LETTER TURNED V from Technical to Technical Uncommon_Use.
 028C ; Technical Uncommon_Use

--- a/unicodetools/data/security/dev/data/source/removals.txt
+++ b/unicodetools/data/security/dev/data/source/removals.txt
@@ -341,7 +341,7 @@ A78B..A78C ; uncommon-use # ( Ꞌ ) LATIN CAPITAL LETTER SALTILLO .. ( ꞌ ) LAT
 #0138; historic # symbol (phonetic)
 0180 018D 01AA..01AB 01BA..01BB 01BE; technical # symbol (phonetic)
 01C0..01C3; technical # symbol (phonetic)
-0250..0252  0255  0258  025A  025C..25F  0261..0262  0264..0267  026A..026E  0270..0271  0273..274  0276..027F  0281..0282  0284..0287  0289  028C..0291  0293  0295..02A2; technical # symbol (phonetic)
+0250..0252  0255  0258  025A  025C..25F  0261..0262  0264..0267  026A..026E  0270..0271  0273..274  0276..027F  0281..0282  0284..0287  0289  028D..0291  0293  0295..02A2; technical # symbol (phonetic)
 02A3..02AB; technical #  symbol (Latin digraph)
 02AC          ; technical # symbol (phonetic) #      (ʬ)  LATIN LETTER BILABIAL PERCUSSIVE
 02AD          ; technical # symbol (phonetic) #      (ʭ)  LATIN LETTER BIDENTAL PERCUSSIVE
@@ -1246,3 +1246,6 @@ AB6C..AB6D ; Technical
 1DF90..1DF94 ; Technical Obsolete
 1DF96 ; Technical Obsolete
 2B81E ; Uncommon_Use
+
+# UTC-187-A144
+028C ; Uncommon_Use

--- a/unicodetools/data/security/dev/data/source/removals.txt
+++ b/unicodetools/data/security/dev/data/source/removals.txt
@@ -1248,4 +1248,4 @@ AB6C..AB6D ; Technical
 2B81E ; Uncommon_Use
 
 # UTC-187-A144
-028C ; Uncommon_Use
+028C ; Technical Uncommon_Use


### PR DESCRIPTION
UTC-187-A144: Action Item for Josh Hadley, PAG: Change Identifier_Type for U+028C LATIN SMALL LETTER TURNED V from Technical to Technical Uncommon_Use. For Unicode Version 18.0. See [L2/26-096](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/26-096) item 8.3.

Updated `removals.txt` source to change Identifier_Type of U+028C from `Technical` to `Technical Uncommon_Use`. Generated data with changes.

@roozbehp N.B. I still got some unexpected changes to `intentional.txt` when generating. I've omitted that changed file from this PR.

- [x] Approver: Feel free to merge on my behalf
    - [ ] rebase & merge one or more commits
    - [x] squash & merge multiple commits into one