### PR TITLE
Add confusables for WAW WITH RING after glyph correction

### DIFF
--- a/unicodetools/data/security/dev/confusables.txt
+++ b/unicodetools/data/security/dev/confusables.txt
@@ -1,5 +1,5 @@
 # confusables.txt
-# Date: 2026-05-15, 02:47:39 GMT
+# Date: 2026-05-15, 06:55:18 GMT
 # © 2026 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -6321,7 +6321,6 @@ FC50 ;	0646 0649 ;	MA	# ( ‎ﱐ‎ → ‎نى‎ ) ARABIC LIGATURE NOON WITH Y
 
 102E4 ;	0648 ;	MA	#* ( 𐋤 → ‎و‎ ) COPTIC EPACT DIGIT FOUR → ARABIC LETTER WAW	# 
 1EE05 ;	0648 ;	MA	# ( ‎𞸅‎ → ‎و‎ ) ARABIC MATHEMATICAL WAW → ARABIC LETTER WAW	# 
-1EE85 ;	0648 ;	MA	# ( ‎𞺅‎ → ‎و‎ ) ARABIC MATHEMATICAL LOOPED WAW → ARABIC LETTER WAW	# 
 1EEA5 ;	0648 ;	MA	# ( ‎𞺥‎ → ‎و‎ ) ARABIC MATHEMATICAL DOUBLE-STRUCK WAW → ARABIC LETTER WAW	# 
 FEEE ;	0648 ;	MA	# ( ‎ﻮ‎ → ‎و‎ ) ARABIC LETTER WAW FINAL FORM → ARABIC LETTER WAW	# 
 FEED ;	0648 ;	MA	# ( ‎ﻭ‎ → ‎و‎ ) ARABIC LETTER WAW ISOLATED FORM → ARABIC LETTER WAW	# 
@@ -6356,6 +6355,8 @@ FBDD ;	0648 0313 0674 ;	MA	# ( ‎ﯝ‎ → ‎و̓ٴ‎ ) ARABIC LETTER U WITH
 
 FDF8 ;	0648 0633 0644 0645 ;	MA	# ( ‎ﷸ‎ → ‎وسلم‎ ) ARABIC LIGATURE WASALLAM ISOLATED FORM → ARABIC LETTER WAW, ARABIC LETTER SEEN, ARABIC LETTER LAM, ARABIC LETTER MEEM	# 
 
+1EE85 ;	06C5 ;	MA	# ( ‎𞺅‎ → ‎ۅ‎ ) ARABIC MATHEMATICAL LOOPED WAW → ARABIC LETTER KIRGHIZ OE	# →‎ۄ‎→
+06C4 ;	06C5 ;	MA	# ( ‎ۄ‎ → ‎ۅ‎ ) ARABIC LETTER WAW WITH RING → ARABIC LETTER KIRGHIZ OE	# 
 FBE1 ;	06C5 ;	MA	# ( ‎ﯡ‎ → ‎ۅ‎ ) ARABIC LETTER KIRGHIZ OE FINAL FORM → ARABIC LETTER KIRGHIZ OE	# 
 FBE0 ;	06C5 ;	MA	# ( ‎ﯠ‎ → ‎ۅ‎ ) ARABIC LETTER KIRGHIZ OE ISOLATED FORM → ARABIC LETTER KIRGHIZ OE	# 
 
@@ -9227,5 +9228,5 @@ FF88 ;	793B ;	MA	# ( ﾈ → 礻 ) HALFWIDTH KATAKANA LETTER NE → CJK UNIFIED 
 
 6B25 ;	2B81E ;	MA	# ( 欥 → 𫠞 ) CJK UNIFIED IDEOGRAPH-6B25 → CJK UNIFIED IDEOGRAPH-2B81E	# 
 
-# total: 6383
+# total: 6384
 

--- a/unicodetools/data/security/dev/confusablesSummary.txt
+++ b/unicodetools/data/security/dev/confusablesSummary.txt
@@ -1,5 +1,5 @@
 # confusablesSummary.txt
-# Date: 2026-05-15, 02:47:39 GMT
+# Date: 2026-05-15, 06:55:18 GMT
 # © 2026 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -9400,12 +9400,11 @@
 ←	(‎ ﲎ ‎)	FC8E	 ARABIC LIGATURE NOON WITH ALEF MAKSURA FINAL FORM
 ←	(‎ ﲏ ‎)	FC8F	 ARABIC LIGATURE NOON WITH YEH FINAL FORM	# →‎ني‎→
 
-#	و	ࢱ	𐋤	𞸅	𞺅	𞺥	ﻭ	ﻮ
+#	و	ࢱ	𐋤	𞸅	𞺥	ﻭ	ﻮ
 	(‎ و ‎)	0648	 ARABIC LETTER WAW
 ←	(‎ ࢱ ‎)	08B1	 ARABIC LETTER STRAIGHT WAW
 ←	(‎ 𐋤 ‎)	102E4	 COPTIC EPACT DIGIT FOUR
 ←	(‎ 𞸅 ‎)	1EE05	 ARABIC MATHEMATICAL WAW
-←	(‎ 𞺅 ‎)	1EE85	 ARABIC MATHEMATICAL LOOPED WAW
 ←	(‎ 𞺥 ‎)	1EEA5	 ARABIC MATHEMATICAL DOUBLE-STRUCK WAW
 ←	(‎ ﻭ ‎)	FEED	 ARABIC LETTER WAW ISOLATED FORM
 ←	(‎ ﻮ ‎)	FEEE	 ARABIC LETTER WAW FINAL FORM
@@ -9963,10 +9962,12 @@
 ←	(‎ ﮘ ‎)	FB98	 ARABIC LETTER GUEH INITIAL FORM
 ←	(‎ ﮙ ‎)	FB99	 ARABIC LETTER GUEH MEDIAL FORM
 
-#	ۅ	ﯠ	ﯡ
-	(‎ ۅ ‎)	06C5	 ARABIC LETTER KIRGHIZ OE
-←	(‎ ﯠ ‎)	FBE0	 ARABIC LETTER KIRGHIZ OE ISOLATED FORM
-←	(‎ ﯡ ‎)	FBE1	 ARABIC LETTER KIRGHIZ OE FINAL FORM
+#	ۅ	ۄ	𞺅	ﯠ	ﯡ
+	(‎ ۄ ‎)	06C4	 ARABIC LETTER WAW WITH RING
+←	(‎ ۅ ‎)	06C5	 ARABIC LETTER KIRGHIZ OE
+←	(‎ 𞺅 ‎)	1EE85	 ARABIC MATHEMATICAL LOOPED WAW
+←	(‎ ﯠ ‎)	FBE0	 ARABIC LETTER KIRGHIZ OE ISOLATED FORM	# →‎ۅ‎→
+←	(‎ ﯡ ‎)	FBE1	 ARABIC LETTER KIRGHIZ OE FINAL FORM	# →‎ۅ‎→
 
 #	ۛ	⃛	᪴
 	(‎ ۛ ‎)	06DB	 ARABIC SMALL HIGH THREE DOTS
@@ -16338,5 +16339,5 @@
 	(‎ 𮶵 ‎)	2EDB5	 CJK UNIFIED IDEOGRAPH-2EDB5
 ←	(‎ 𲪏 ‎)	32A8F	 CJK UNIFIED IDEOGRAPH-32A8F
 
-# total : 7820
+# total : 7821
 

--- a/unicodetools/data/security/dev/data/confusablesSummaryIdentifier.txt
+++ b/unicodetools/data/security/dev/data/confusablesSummaryIdentifier.txt
@@ -1,5 +1,5 @@
 # confusablesSummaryIdentifier.txt
-# Date: 2026-05-03, 21:54:14 GMT
+# Date: 2026-05-15, 06:55:18 GMT
 # © 2026 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -756,6 +756,10 @@
 	(‎ چ̆ ‎)	0686 0306	 ARABIC LETTER TCHEH, COMBINING BREVE
 ←	(‎ ࣁ ‎)	08C1	 ARABIC LETTER TCHEH WITH SMALL V	# →‎چٚ‎→
 
+#	ۅ	ۄ
+	(‎ ۄ ‎)	06C4	 ARABIC LETTER WAW WITH RING
+←	(‎ ۅ ‎)	06C5	 ARABIC LETTER KIRGHIZ OE
+
 #	ݧ	ࢩ
 	(‎ ݧ ‎)	0767	 ARABIC LETTER NOON WITH TWO DOTS BELOW
 ←	(‎ ࢩ ‎)	08A9	 ARABIC LETTER YEH WITH TWO DOTS BELOW AND DOT ABOVE	# →‎ݔ‎→
@@ -1471,5 +1475,5 @@
 	(‎ へ ‎)	3078	 HIRAGANA LETTER HE
 ←	(‎ ヘ ‎)	30D8	 KATAKANA LETTER HE
 
-# total : 528
+# total : 529
 

--- a/unicodetools/data/security/dev/data/source/confusables-source.txt
+++ b/unicodetools/data/security/dev/data/source/confusables-source.txt
@@ -6244,3 +6244,7 @@ A7E2 ; 0393 # 181-A14
 
 # Empty set and O with stroke (PAG ref #548)
 2205; 00D8
+
+# UTC Action Item 187-A33
+06C4; 1EE85
+06C4; 06C5

--- a/unicodetools/data/security/dev/data/source/formatted-source.txt
+++ b/unicodetools/data/security/dev/data/source/formatted-source.txt
@@ -1,5 +1,5 @@
 # formatted-source.txt
-# Date: 2026-05-15, 02:47:37 GMT
+# Date: 2026-05-15, 06:55:17 GMT
 # © 2026 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -5074,6 +5074,9 @@
 06C1 ;	FBA8	# ( ‎ہ‎ ~ ‎ﮨ‎ ) ARABIC LETTER HEH GOAL ~ ARABIC LETTER HEH GOAL INITIAL FORM
 06C1 ;	FBA9	# ( ‎ہ‎ ~ ‎ﮩ‎ ) ARABIC LETTER HEH GOAL ~ ARABIC LETTER HEH GOAL MEDIAL FORM
 
+06C4 ;	1EE85	# ( ‎ۄ‎ ~ ‎𞺅‎ ) ARABIC LETTER WAW WITH RING ~ ARABIC MATHEMATICAL LOOPED WAW
+
+06C5 ;	06C4	# ( ‎ۅ‎ ~ ‎ۄ‎ ) ARABIC LETTER KIRGHIZ OE ~ ARABIC LETTER WAW WITH RING
 06C5 ;	FBE0	# ( ‎ۅ‎ ~ ‎ﯠ‎ ) ARABIC LETTER KIRGHIZ OE ~ ARABIC LETTER KIRGHIZ OE ISOLATED FORM
 06C5 ;	FBE1	# ( ‎ۅ‎ ~ ‎ﯡ‎ ) ARABIC LETTER KIRGHIZ OE ~ ARABIC LETTER KIRGHIZ OE FINAL FORM
 

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateConfusables.java
@@ -617,6 +617,7 @@ public class GenerateConfusables {
                         || cp == 0xFE58 // Skip SMALL EM DASH since it would merge two classes
                         // Skip FULLWIDTH HYPHEN-MINUS since it would merge two classes
                         || cp == 0xFF0D
+                        || cp == 0x1EE85 // Skip ARABIC MATHEMATICAL LOOPED WAW
                         || (0x1F130 <= cp && cp <= 0x1F14F) // Skip squared Latin letters
                         || (0x1F200 <= cp && cp <= 0x1F23B) // Skip Enclosed Ideographic Supplement
                         // Skip square compatibility characters that have a power of 2 or 3.


### PR DESCRIPTION
* [UTC-187-A33] Action Item for Roozbeh Pournader, SAH: Add U+06C4 ARABIC LETTER WAW WITH RING and U+1EE85 ARABIC MATHEMATICAL LOOPED WAW to the confusables data file, for Unicode Version 18.0. [Ref: 4.1 in L2/26-100]

* Also add a second pair of confusables for U+06C4 (with U+06C5) based on discussions at SEW because their chart glyphs now look very similar.

- [ ] Approver: Feel free to merge on my behalf
    - [ ] rebase & merge one or more commits
    - [ ] squash & merge multiple commits into one