### PR TITLE
SpecialCasing: ß point to core spec

### DIFF
--- a/unicodetools/data/ucd/dev/SpecialCasing.txt
+++ b/unicodetools/data/ucd/dev/SpecialCasing.txt
@@ -1,5 +1,5 @@
 # SpecialCasing-18.0.0.txt
-# Date: 2026-02-03, 23:10:25 GMT
+# Date: 2026-05-19, 02:48:44 GMT
 # © 2026 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -63,8 +63,16 @@
 # do not modify the case mapping algorithms in the core specification, chapter 3.
 # ================================================================================
 
-# The German es-zed is special--the normal mapping is to SS.
-# Note: the titlecase should never occur in practice. It is equal to titlecase(uppercase(<es-zed>))
+# The German sharp s (ß, also called es-zed) is special:
+# The customary uppercase mapping is to SS,
+# rather than to the newer U+1E9E capital sharp s.
+#
+# Note: The Case Pair Stability policy forbids
+# changing the default Unicode uppercasing of U+00DF to U+1E9E.
+#
+# For details see The Unicode Standard, section 5.18.2, under “German sharp s”.
+#
+# Note: The titlecase should never occur in practice. It is equal to titlecase(uppercase('ß')).
 
 00DF; 00DF; 0053 0073; 0053 0053; # LATIN SMALL LETTER SHARP S
 

--- a/unicodetools/src/main/java/org/unicode/text/UCD/GenerateCaseFolding.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/GenerateCaseFolding.java
@@ -647,6 +647,21 @@ public class GenerateCaseFolding implements UCD_Types {
         return false;
     }
 
+    private static final String SHARP_S_COMMENTS =
+            """
+            # The German sharp s (ß, also called es-zed) is special:
+            # The customary uppercase mapping is to SS,
+            # rather than to the newer U+1E9E capital sharp s.
+            #
+            # Note: The Case Pair Stability policy forbids
+            # changing the default Unicode uppercasing of U+00DF to U+1E9E.
+            #
+            # For details see The Unicode Standard, section 5.18.2, under “German sharp s”.
+            #
+            # Note: The titlecase should never occur in practice. \
+            It is equal to titlecase(uppercase('ß')).
+            """;
+
     static void generateSpecialCasing(boolean normalize) throws IOException {
         final Map<Integer, String> sorted = new TreeMap<Integer, String>();
 
@@ -856,9 +871,7 @@ public class GenerateCaseFolding implements UCD_Types {
                 boolean skipLine = false;
                 switch (order) {
                     case 1:
-                        out.println("# The German es-zed is special--the normal mapping is to SS.");
-                        out.println(
-                                "# Note: the titlecase should never occur in practice. It is equal to titlecase(uppercase(<es-zed>))");
+                        out.print(SHARP_S_COMMENTS);
                         break;
                     case 2:
                         out.println(


### PR DESCRIPTION
[[185-A99](https://www.unicode.org/cgi-bin/GetL2Ref.pl?185-A99)] Action Item for Markus Scherer, PAG: In SpecialCasing.txt, near the mapping for U+00DF sharp s, add a brief note about details in the core spec, and link to the core spec 5.18.2 “German sharp s” section. For Unicode Version 18.0. See [L2/25-228](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/25-228) item 2.1.