### PR TITLE
Unescaped final Soft characters in LinkFormattingTest.txt #527

### DIFF
--- a/unicodetools/data/linkification/dev/LinkFormattingTest.txt
+++ b/unicodetools/data/linkification/dev/LinkFormattingTest.txt
@@ -1,5 +1,5 @@
 # LinkFormattingTest.txt
-# Date: 2026-05-19, 16:47:55 GMT 
+# Date: 2026-05-19, 22:01:10 GMT 
 # © 2026 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -193,7 +193,7 @@ https://fiu-vro.wikipedia.org/wiki/Maa_(hod'ot%C3%A4ht)
 https://fiu-vro.wikipedia.org/wiki/Maa_(hod'otäht)
 
 # {𝑺=https:// 𝑯=ty.wikipedia.org 𝑷=wiki 𝑷=’Afirita}
-https://ty.wikipedia.org/wiki/’Afirita
+https://ty.wikipedia.org/wiki/%E2%80%99Afirita
 https://ty.wikipedia.org/wiki/’Afirita
 
 # {𝑺=https:// 𝑯=ab.wikipedia.org 𝑷=wiki 𝑷=Вашингтон,_Џьорџь}
@@ -201,7 +201,7 @@ https://ab.wikipedia.org/wiki/%D0%92%D0%B0%D1%88%D0%B8%D0%BD%D0%B3%D1%82%D0%BE%D
 https://ab.wikipedia.org/wiki/Вашингтон,_Џьорџь
 
 # {𝑺=https:// 𝑯=mni.wikipedia.org 𝑷=wiki 𝑷=ꯅ꯭ꯌꯨ_ꯌꯣꯔ꯭ꯛ_ꯁꯤꯇꯤꯒꯤ_ꯌꯨ.ꯑꯦꯁ.}
-https://mni.wikipedia.org/wiki/ꯅ꯭ꯌꯨ_ꯌꯣꯔ꯭ꯛ_ꯁꯤꯇꯤꯒꯤ_ꯌꯨ.ꯑꯦꯁ.
+https://mni.wikipedia.org/wiki/%EA%AF%85%EA%AF%AD%EA%AF%8C%EA%AF%A8_%EA%AF%8C%EA%AF%A3%EA%AF%94%EA%AF%AD%EA%AF%9B_%EA%AF%81%EA%AF%A4%EA%AF%87%EA%AF%A4%EA%AF%92%EA%AF%A4_%EA%AF%8C%EA%AF%A8.%EA%AF%91%EA%AF%A6%EA%AF%81.
 https://mni.wikipedia.org/wiki/ꯅ꯭ꯌꯨ_ꯌꯣꯔ꯭ꯛ_ꯁꯤꯇꯤꯒꯤ_ꯌꯨ.ꯑꯦꯁ%2E
 
 # {𝑺=https:// 𝑯=azb.wikipedia.org 𝑷=wiki 𝑷=واشینقتن،_دی.سی.}
@@ -209,11 +209,11 @@ https://azb.wikipedia.org/wiki/%D9%88%D8%A7%D8%B4%DB%8C%D9%86%D9%82%D8%AA%D9%86%
 https://azb.wikipedia.org/wiki/واشینقتن،_دی.سی%2E
 
 # {𝑺=https:// 𝑯=mad.wikipedia.org 𝑷=wiki 𝑷=Tasè’}
-https://mad.wikipedia.org/wiki/Tas%C3%A8’
+https://mad.wikipedia.org/wiki/Tas%C3%A8%E2%80%99
 https://mad.wikipedia.org/wiki/Tasè%E2%80%99
 
 # {𝑺=https:// 𝑯=wuu.wikipedia.org 𝑷=wiki 𝑷=聖保羅（巴西）}
-https://wuu.wikipedia.org/wiki/聖保羅（巴西）
+https://wuu.wikipedia.org/wiki/%E8%81%96%E4%BF%9D%E7%BE%85%EF%BC%88%E5%B7%B4%E8%A5%BF%EF%BC%89
 https://wuu.wikipedia.org/wiki/聖保羅（巴西）
 
 # {𝑺=https:// 𝑯=vep.wikipedia.org 𝑷=wiki 𝑷=Brüssel'}
@@ -225,7 +225,7 @@ https://tw.wikipedia.org/wiki/Wiase_Nyinaa_W%C9%9Bbsaet_(_World_Wide_Web;_WWW_)
 https://tw.wikipedia.org/wiki/Wiase_Nyinaa_Wɛbsaet_(_World_Wide_Web;_WWW_)
 
 # {𝑺=https:// 𝑯=ja.wikibooks.org 𝑷=wiki 𝑷=植物学 𝑷=植物とはどのような生き物か？}
-https://ja.wikibooks.org/wiki/植物学/植物とはどのような生き物か？
+https://ja.wikibooks.org/wiki/%E6%A4%8D%E7%89%A9%E5%AD%A6/%E6%A4%8D%E7%89%A9%E3%81%A8%E3%81%AF%E3%81%A9%E3%81%AE%E3%82%88%E3%81%86%E3%81%AA%E7%94%9F%E3%81%8D%E7%89%A9%E3%81%8B%EF%BC%9F
 https://ja.wikibooks.org/wiki/植物学/植物とはどのような生き物か%EF%BC%9F
 
 # {𝑺=https:// 𝑯=bn.wikibooks.org 𝑷=wiki 𝑷=উইকিশৈশব:দেশসমূহ_(অ-হ) 𝑷=ইসরায়েল}
@@ -233,7 +233,7 @@ https://bn.wikibooks.org/wiki/%E0%A6%89%E0%A6%87%E0%A6%95%E0%A6%BF%E0%A6%B6%E0%A
 https://bn.wikibooks.org/wiki/উইকিশৈশব:দেশসমূহ_(অ-হ)/ইসরায়েল
 
 # {𝑺=https:// 𝑯=haw.wikipedia.org 𝑷=wiki 𝑷=Puke_noi‘i_kū‘ikena}
-https://haw.wikipedia.org/wiki/Puke_noi‘i_k%C5%AB‘ikena
+https://haw.wikipedia.org/wiki/Puke_noi%E2%80%98i_k%C5%AB%E2%80%98ikena
 https://haw.wikipedia.org/wiki/Puke_noi‘i_kū‘ikena
 
 # {𝑺=https:// 𝑯=new.wikipedia.org 𝑷=wiki 𝑷=विन्सेन्ट_भ्यान_ग:}
@@ -249,11 +249,11 @@ https://ks.wikipedia.org/wiki/%D8%B4%D8%A7%D8%B1%D9%95%DA%A9%DB%94
 https://ks.wikipedia.org/wiki/شارٕک%DB%94
 
 # {𝑺=https:// 𝑯=zh.wikipedia.org 𝑷=wiki 𝑷=联合国教育、科学及文化组织}
-https://zh.wikipedia.org/wiki/联合国教育、科学及文化组织
+https://zh.wikipedia.org/wiki/%E8%81%94%E5%90%88%E5%9B%BD%E6%95%99%E8%82%B2%E3%80%81%E7%A7%91%E5%AD%A6%E5%8F%8A%E6%96%87%E5%8C%96%E7%BB%84%E7%BB%87
 https://zh.wikipedia.org/wiki/联合国教育、科学及文化组织
 
 # {𝑺=https:// 𝑯=am.wikipedia.org 𝑷=wiki 𝑷=«የሰብዓዊ_መብት_አቀፋዊ_መግለጽ»}
-https://am.wikipedia.org/wiki/%C2%ABየሰብዓዊ_መብት_አቀፋዊ_መግለጽ%C2%BB
+https://am.wikipedia.org/wiki/%C2%AB%E1%8B%A8%E1%88%B0%E1%89%A5%E1%8B%93%E1%8B%8A_%E1%88%98%E1%89%A5%E1%89%B5_%E1%8A%A0%E1%89%80%E1%8D%8B%E1%8B%8A_%E1%88%98%E1%8C%8D%E1%88%88%E1%8C%BD%C2%BB
 https://am.wikipedia.org/wiki/«የሰብዓዊ_መብት_አቀፋዊ_መግለጽ%C2%BB
 
 # {𝑺=https:// 𝑯=bo.wikipedia.org 𝑷=wiki 𝑷=༼མ་ཧ་བ་ར་ཏ།༽}
@@ -261,7 +261,7 @@ https://bo.wikipedia.org/wiki/%E0%BC%BC%E0%BD%98%E0%BC%8B%E0%BD%A7%E0%BC%8B%E0%B
 https://bo.wikipedia.org/wiki/༼མ་ཧ་བ་ར་ཏ།༽
 
 # {𝑺=https:// 𝑯=am.wikipedia.org 𝑷=wiki 𝑷=አፈ፡ታሪክ}
-https://am.wikipedia.org/wiki/አፈ፡ታሪክ
+https://am.wikipedia.org/wiki/%E1%8A%A0%E1%8D%88%E1%8D%A1%E1%89%B3%E1%88%AA%E1%8A%AD
 https://am.wikipedia.org/wiki/አፈ፡ታሪክ
 
 # {𝑺=https:// 𝑯=it.wikibooks.org 𝑷=wiki 𝑷=Questo_è_l'ebraismo!}

--- a/unicodetools/data/linkification/dev/LinkFormattingTest.txt
+++ b/unicodetools/data/linkification/dev/LinkFormattingTest.txt
@@ -1,5 +1,5 @@
 # LinkFormattingTest.txt
-# Date: 2026-02-03, 23:10:02 GMT 
+# Date: 2026-05-19, 16:47:55 GMT 
 # © 2026 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -186,7 +186,7 @@ https://av.wikipedia.org/wiki/Ракь_(планета)
 
 # {𝑺=https:// 𝑯=bo.wikipedia.org 𝑷=wiki 𝑷=སའི་གོ་ལ།}
 https://bo.wikipedia.org/wiki/%E0%BD%A6%E0%BD%A0%E0%BD%B2%E0%BC%8B%E0%BD%82%E0%BD%BC%E0%BC%8B%E0%BD%A3%E0%BC%8D
-https://bo.wikipedia.org/wiki/སའི་གོ་ལ།
+https://bo.wikipedia.org/wiki/སའི་གོ་ལ%E0%BC%8D
 
 # {𝑺=https:// 𝑯=fiu-vro.wikipedia.org 𝑷=wiki 𝑷=Maa_(hod'otäht)}
 https://fiu-vro.wikipedia.org/wiki/Maa_(hod'ot%C3%A4ht)
@@ -202,15 +202,15 @@ https://ab.wikipedia.org/wiki/Вашингтон,_Џьорџь
 
 # {𝑺=https:// 𝑯=mni.wikipedia.org 𝑷=wiki 𝑷=ꯅ꯭ꯌꯨ_ꯌꯣꯔ꯭ꯛ_ꯁꯤꯇꯤꯒꯤ_ꯌꯨ.ꯑꯦꯁ.}
 https://mni.wikipedia.org/wiki/ꯅ꯭ꯌꯨ_ꯌꯣꯔ꯭ꯛ_ꯁꯤꯇꯤꯒꯤ_ꯌꯨ.ꯑꯦꯁ.
-https://mni.wikipedia.org/wiki/ꯅ꯭ꯌꯨ_ꯌꯣꯔ꯭ꯛ_ꯁꯤꯇꯤꯒꯤ_ꯌꯨ.ꯑꯦꯁ.
+https://mni.wikipedia.org/wiki/ꯅ꯭ꯌꯨ_ꯌꯣꯔ꯭ꯛ_ꯁꯤꯇꯤꯒꯤ_ꯌꯨ.ꯑꯦꯁ%2E
 
 # {𝑺=https:// 𝑯=azb.wikipedia.org 𝑷=wiki 𝑷=واشینقتن،_دی.سی.}
 https://azb.wikipedia.org/wiki/%D9%88%D8%A7%D8%B4%DB%8C%D9%86%D9%82%D8%AA%D9%86%D8%8C_%D8%AF%DB%8C.%D8%B3%DB%8C.
-https://azb.wikipedia.org/wiki/واشینقتن،_دی.سی.
+https://azb.wikipedia.org/wiki/واشینقتن،_دی.سی%2E
 
 # {𝑺=https:// 𝑯=mad.wikipedia.org 𝑷=wiki 𝑷=Tasè’}
 https://mad.wikipedia.org/wiki/Tas%C3%A8’
-https://mad.wikipedia.org/wiki/Tasè’
+https://mad.wikipedia.org/wiki/Tasè%E2%80%99
 
 # {𝑺=https:// 𝑯=wuu.wikipedia.org 𝑷=wiki 𝑷=聖保羅（巴西）}
 https://wuu.wikipedia.org/wiki/聖保羅（巴西）
@@ -218,7 +218,7 @@ https://wuu.wikipedia.org/wiki/聖保羅（巴西）
 
 # {𝑺=https:// 𝑯=vep.wikipedia.org 𝑷=wiki 𝑷=Brüssel'}
 https://vep.wikipedia.org/wiki/Br%C3%BCssel'
-https://vep.wikipedia.org/wiki/Brüssel'
+https://vep.wikipedia.org/wiki/Brüssel%27
 
 # {𝑺=https:// 𝑯=tw.wikipedia.org 𝑷=wiki 𝑷=Wiase_Nyinaa_Wɛbsaet_(_World_Wide_Web;_WWW_)}
 https://tw.wikipedia.org/wiki/Wiase_Nyinaa_W%C9%9Bbsaet_(_World_Wide_Web;_WWW_)
@@ -226,7 +226,7 @@ https://tw.wikipedia.org/wiki/Wiase_Nyinaa_Wɛbsaet_(_World_Wide_Web;_WWW_)
 
 # {𝑺=https:// 𝑯=ja.wikibooks.org 𝑷=wiki 𝑷=植物学 𝑷=植物とはどのような生き物か？}
 https://ja.wikibooks.org/wiki/植物学/植物とはどのような生き物か？
-https://ja.wikibooks.org/wiki/植物学/植物とはどのような生き物か？
+https://ja.wikibooks.org/wiki/植物学/植物とはどのような生き物か%EF%BC%9F
 
 # {𝑺=https:// 𝑯=bn.wikibooks.org 𝑷=wiki 𝑷=উইকিশৈশব:দেশসমূহ_(অ-হ) 𝑷=ইসরায়েল}
 https://bn.wikibooks.org/wiki/%E0%A6%89%E0%A6%87%E0%A6%95%E0%A6%BF%E0%A6%B6%E0%A7%88%E0%A6%B6%E0%A6%AC:%E0%A6%A6%E0%A7%87%E0%A6%B6%E0%A6%B8%E0%A6%AE%E0%A7%82%E0%A6%B9_(%E0%A6%85-%E0%A6%B9)/%E0%A6%87%E0%A6%B8%E0%A6%B0%E0%A6%BE%E0%A6%AF%E0%A6%BC%E0%A7%87%E0%A6%B2
@@ -238,7 +238,7 @@ https://haw.wikipedia.org/wiki/Puke_noi‘i_kū‘ikena
 
 # {𝑺=https:// 𝑯=new.wikipedia.org 𝑷=wiki 𝑷=विन्सेन्ट_भ्यान_ग:}
 https://new.wikipedia.org/wiki/%E0%A4%B5%E0%A4%BF%E0%A4%A8%E0%A5%8D%E0%A4%B8%E0%A5%87%E0%A4%A8%E0%A5%8D%E0%A4%9F_%E0%A4%AD%E0%A5%8D%E0%A4%AF%E0%A4%BE%E0%A4%A8_%E0%A4%97:
-https://new.wikipedia.org/wiki/विन्सेन्ट_भ्यान_ग:
+https://new.wikipedia.org/wiki/विन्सेन्ट_भ्यान_ग%3A
 
 # {𝑺=https:// 𝑯=he.wikipedia.org 𝑷=wiki 𝑷=נאט"ו}
 https://he.wikipedia.org/wiki/%D7%A0%D7%90%D7%98%22%D7%95
@@ -246,7 +246,7 @@ https://he.wikipedia.org/wiki/נאט"ו
 
 # {𝑺=https:// 𝑯=ks.wikipedia.org 𝑷=wiki 𝑷=شارٕک۔}
 https://ks.wikipedia.org/wiki/%D8%B4%D8%A7%D8%B1%D9%95%DA%A9%DB%94
-https://ks.wikipedia.org/wiki/شارٕک۔
+https://ks.wikipedia.org/wiki/شارٕک%DB%94
 
 # {𝑺=https:// 𝑯=zh.wikipedia.org 𝑷=wiki 𝑷=联合国教育、科学及文化组织}
 https://zh.wikipedia.org/wiki/联合国教育、科学及文化组织
@@ -254,7 +254,7 @@ https://zh.wikipedia.org/wiki/联合国教育、科学及文化组织
 
 # {𝑺=https:// 𝑯=am.wikipedia.org 𝑷=wiki 𝑷=«የሰብዓዊ_መብት_አቀፋዊ_መግለጽ»}
 https://am.wikipedia.org/wiki/%C2%ABየሰብዓዊ_መብት_አቀፋዊ_መግለጽ%C2%BB
-https://am.wikipedia.org/wiki/«የሰብዓዊ_መብት_አቀፋዊ_መግለጽ»
+https://am.wikipedia.org/wiki/«የሰብዓዊ_መብት_አቀፋዊ_መግለጽ%C2%BB
 
 # {𝑺=https:// 𝑯=bo.wikipedia.org 𝑷=wiki 𝑷=༼མ་ཧ་བ་ར་ཏ།༽}
 https://bo.wikipedia.org/wiki/%E0%BC%BC%E0%BD%98%E0%BC%8B%E0%BD%A7%E0%BC%8B%E0%BD%96%E0%BC%8B%E0%BD%A2%E0%BC%8B%E0%BD%8F%E0%BC%8D%E0%BC%BD
@@ -266,7 +266,7 @@ https://am.wikipedia.org/wiki/አፈ፡ታሪክ
 
 # {𝑺=https:// 𝑯=it.wikibooks.org 𝑷=wiki 𝑷=Questo_è_l'ebraismo!}
 https://it.wikibooks.org/wiki/Questo_%C3%A8_l'ebraismo!
-https://it.wikibooks.org/wiki/Questo_è_l'ebraismo!
+https://it.wikibooks.org/wiki/Questo_è_l'ebraismo%21
 
 # {𝑺=https:// 𝑯=my.wikipedia.org 𝑷=wiki 𝑷=ခို၊_ချိုးနှင့်_အလားတူငှက်များ}
 https://my.wikipedia.org/wiki/%E1%80%81%E1%80%AD%E1%80%AF%E1%81%8A_%E1%80%81%E1%80%BB%E1%80%AD%E1%80%AF%E1%80%B8%E1%80%94%E1%80%BE%E1%80%84%E1%80%B7%E1%80%BA_%E1%80%A1%E1%80%9C%E1%80%AC%E1%80%B8%E1%80%90%E1%80%B0%E1%80%84%E1%80%BE%E1%80%80%E1%80%BA%E1%80%99%E1%80%BB%E1%80%AC%E1%80%B8

--- a/unicodetools/data/linkification/dev/LinkFormattingTest.txt
+++ b/unicodetools/data/linkification/dev/LinkFormattingTest.txt
@@ -1,5 +1,5 @@
 # LinkFormattingTest.txt
-# Date: 2026-05-19, 22:01:10 GMT 
+# Date: 2026-05-20, 15:27:01 GMT 
 # © 2026 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -52,17 +52,17 @@ https://example.com/αβγ/δεζ?θ=ικλ&μ=γξο#πρς
 
 # Escape soft at end of Path (with nothing following)				
 # {𝑺=https:// 𝑯=example.com 𝑷=αβγ 𝑷=δ.εζ.}
-https://example.com/%CE%B1%CE%B2%CE%B3/%CE%B4.%CE%B5%CE%B6.
+https://example.com/%CE%B1%CE%B2%CE%B3/%CE%B4.%CE%B5%CE%B6%2E
 https://example.com/αβγ/δ.εζ%2E
 
 # Escape soft at end of Query (with nothing following)				
 # {𝑺=https:// 𝑯=example.com 𝑷=αβγ 𝑷=δ.εζ. 𝑸=θ 𝑽=ικλ 𝑸=μ 𝑽=γ.ξο.}
-https://example.com/%CE%B1%CE%B2%CE%B3/%CE%B4.%CE%B5%CE%B6.?%CE%B8=%CE%B9%CE%BA%CE%BB&%CE%BC=%CE%B3.%CE%BE%CE%BF.
+https://example.com/%CE%B1%CE%B2%CE%B3/%CE%B4.%CE%B5%CE%B6.?%CE%B8=%CE%B9%CE%BA%CE%BB&%CE%BC=%CE%B3.%CE%BE%CE%BF%2E
 https://example.com/αβγ/δ.εζ.?θ=ικλ&μ=γ.ξο%2E
 
 # Escape soft at end of Fragment (with nothing following)				
 # {𝑺=https:// 𝑯=example.com 𝑷=αβγ 𝑷=δ.εζ 𝑸=θ 𝑽=ικλ 𝑸=μ 𝑽=γ.ξο 𝑭=π.ρς.}
-https://example.com/%CE%B1%CE%B2%CE%B3/%CE%B4.%CE%B5%CE%B6?%CE%B8=%CE%B9%CE%BA%CE%BB&%CE%BC=%CE%B3.%CE%BE%CE%BF#%CF%80.%CF%81%CF%82.
+https://example.com/%CE%B1%CE%B2%CE%B3/%CE%B4.%CE%B5%CE%B6?%CE%B8=%CE%B9%CE%BA%CE%BB&%CE%BC=%CE%B3.%CE%BE%CE%BF#%CF%80.%CF%81%CF%82%2E
 https://example.com/αβγ/δ.εζ?θ=ικλ&μ=γ.ξο#π.ρς%2E
 
 # Escape ? in Path					
@@ -82,7 +82,7 @@ https://example.com/αβ%20γ/δεζ?θ=ικ%20λ&=γξο#πρ%20σ
 
 # Escape soft ('.') unless followed by include					
 # {𝑺=https:// 𝑯=example.com 𝑷=αβγ. 𝑷=δεζ. 𝑸=θ 𝑽=ικ.λ 𝑸= 𝑽=γξο. 𝑭=πρς.}
-https://example.com/%CE%B1%CE%B2%CE%B3./%CE%B4%CE%B5%CE%B6.?%CE%B8=%CE%B9%CE%BA.%CE%BB&=%CE%B3%CE%BE%CE%BF.#%CF%80%CF%81%CF%82.
+https://example.com/%CE%B1%CE%B2%CE%B3./%CE%B4%CE%B5%CE%B6.?%CE%B8=%CE%B9%CE%BA.%CE%BB&=%CE%B3%CE%BE%CE%BF.#%CF%80%CF%81%CF%82%2E
 https://example.com/αβγ./δεζ.?θ=ικ.λ&=γξο.#πρς%2E
 
 # Escape unmatched brackets					
@@ -201,11 +201,11 @@ https://ab.wikipedia.org/wiki/%D0%92%D0%B0%D1%88%D0%B8%D0%BD%D0%B3%D1%82%D0%BE%D
 https://ab.wikipedia.org/wiki/Вашингтон,_Џьорџь
 
 # {𝑺=https:// 𝑯=mni.wikipedia.org 𝑷=wiki 𝑷=ꯅ꯭ꯌꯨ_ꯌꯣꯔ꯭ꯛ_ꯁꯤꯇꯤꯒꯤ_ꯌꯨ.ꯑꯦꯁ.}
-https://mni.wikipedia.org/wiki/%EA%AF%85%EA%AF%AD%EA%AF%8C%EA%AF%A8_%EA%AF%8C%EA%AF%A3%EA%AF%94%EA%AF%AD%EA%AF%9B_%EA%AF%81%EA%AF%A4%EA%AF%87%EA%AF%A4%EA%AF%92%EA%AF%A4_%EA%AF%8C%EA%AF%A8.%EA%AF%91%EA%AF%A6%EA%AF%81.
+https://mni.wikipedia.org/wiki/%EA%AF%85%EA%AF%AD%EA%AF%8C%EA%AF%A8_%EA%AF%8C%EA%AF%A3%EA%AF%94%EA%AF%AD%EA%AF%9B_%EA%AF%81%EA%AF%A4%EA%AF%87%EA%AF%A4%EA%AF%92%EA%AF%A4_%EA%AF%8C%EA%AF%A8.%EA%AF%91%EA%AF%A6%EA%AF%81%2E
 https://mni.wikipedia.org/wiki/ꯅ꯭ꯌꯨ_ꯌꯣꯔ꯭ꯛ_ꯁꯤꯇꯤꯒꯤ_ꯌꯨ.ꯑꯦꯁ%2E
 
 # {𝑺=https:// 𝑯=azb.wikipedia.org 𝑷=wiki 𝑷=واشینقتن،_دی.سی.}
-https://azb.wikipedia.org/wiki/%D9%88%D8%A7%D8%B4%DB%8C%D9%86%D9%82%D8%AA%D9%86%D8%8C_%D8%AF%DB%8C.%D8%B3%DB%8C.
+https://azb.wikipedia.org/wiki/%D9%88%D8%A7%D8%B4%DB%8C%D9%86%D9%82%D8%AA%D9%86%D8%8C_%D8%AF%DB%8C.%D8%B3%DB%8C%2E
 https://azb.wikipedia.org/wiki/واشینقتن،_دی.سی%2E
 
 # {𝑺=https:// 𝑯=mad.wikipedia.org 𝑷=wiki 𝑷=Tasè’}
@@ -217,7 +217,7 @@ https://wuu.wikipedia.org/wiki/%E8%81%96%E4%BF%9D%E7%BE%85%EF%BC%88%E5%B7%B4%E8%
 https://wuu.wikipedia.org/wiki/聖保羅（巴西）
 
 # {𝑺=https:// 𝑯=vep.wikipedia.org 𝑷=wiki 𝑷=Brüssel'}
-https://vep.wikipedia.org/wiki/Br%C3%BCssel'
+https://vep.wikipedia.org/wiki/Br%C3%BCssel%27
 https://vep.wikipedia.org/wiki/Brüssel%27
 
 # {𝑺=https:// 𝑯=tw.wikipedia.org 𝑷=wiki 𝑷=Wiase_Nyinaa_Wɛbsaet_(_World_Wide_Web;_WWW_)}
@@ -237,7 +237,7 @@ https://haw.wikipedia.org/wiki/Puke_noi%E2%80%98i_k%C5%AB%E2%80%98ikena
 https://haw.wikipedia.org/wiki/Puke_noi‘i_kū‘ikena
 
 # {𝑺=https:// 𝑯=new.wikipedia.org 𝑷=wiki 𝑷=विन्सेन्ट_भ्यान_ग:}
-https://new.wikipedia.org/wiki/%E0%A4%B5%E0%A4%BF%E0%A4%A8%E0%A5%8D%E0%A4%B8%E0%A5%87%E0%A4%A8%E0%A5%8D%E0%A4%9F_%E0%A4%AD%E0%A5%8D%E0%A4%AF%E0%A4%BE%E0%A4%A8_%E0%A4%97:
+https://new.wikipedia.org/wiki/%E0%A4%B5%E0%A4%BF%E0%A4%A8%E0%A5%8D%E0%A4%B8%E0%A5%87%E0%A4%A8%E0%A5%8D%E0%A4%9F_%E0%A4%AD%E0%A5%8D%E0%A4%AF%E0%A4%BE%E0%A4%A8_%E0%A4%97%3A
 https://new.wikipedia.org/wiki/विन्सेन्ट_भ्यान_ग%3A
 
 # {𝑺=https:// 𝑯=he.wikipedia.org 𝑷=wiki 𝑷=נאט"ו}
@@ -265,7 +265,7 @@ https://am.wikipedia.org/wiki/%E1%8A%A0%E1%8D%88%E1%8D%A1%E1%89%B3%E1%88%AA%E1%8
 https://am.wikipedia.org/wiki/አፈ፡ታሪክ
 
 # {𝑺=https:// 𝑯=it.wikibooks.org 𝑷=wiki 𝑷=Questo_è_l'ebraismo!}
-https://it.wikibooks.org/wiki/Questo_%C3%A8_l'ebraismo!
+https://it.wikibooks.org/wiki/Questo_%C3%A8_l'ebraismo%21
 https://it.wikibooks.org/wiki/Questo_è_l'ebraismo%21
 
 # {𝑺=https:// 𝑯=my.wikipedia.org 𝑷=wiki 𝑷=ခို၊_ချိုးနှင့်_အလားတူငှက်များ}

--- a/unicodetools/src/main/java/org/unicode/tools/GenerateLinkData.java
+++ b/unicodetools/src/main/java/org/unicode/tools/GenerateLinkData.java
@@ -34,6 +34,7 @@ import org.unicode.utilities.LinkUtilities;
 import org.unicode.utilities.LinkUtilities.LinkTermination;
 import org.unicode.utilities.LinkUtilities.Part;
 import org.unicode.utilities.LinkUtilities.UrlInternals;
+import org.unicode.utilities.LinkUtilities.UrlInternals.EndStatus;
 
 /**
  * Generate UTS #58 property and test files
@@ -450,7 +451,7 @@ public class GenerateLinkData {
 
                                 UrlInternals internals = UrlInternals.from(fullSourcePath);
 
-                                String actual = internals.minimalEscape(false, null);
+                                String actual = internals.minimalEscape(EndStatus.FINAL, null);
 
                                 String expected = parts.size() < 6 ? null : parts.get(5);
                                 if (expected != null && !actual.equals(expected)) {
@@ -471,7 +472,7 @@ public class GenerateLinkData {
                                     ++errorCount.value;
                                     // for debugging
                                     UrlInternals.from(fullSourcePath);
-                                    internals.minimalEscape(false, null);
+                                    internals.minimalEscape(EndStatus.FINAL, null);
                                     comments.clear();
                                     return;
                                 }
@@ -514,7 +515,7 @@ public class GenerateLinkData {
                                 // Divide into parts
                                 UrlInternals internals = UrlInternals.from(line);
 
-                                String actual = internals.minimalEscape(true, null);
+                                String actual = internals.minimalEscape(EndStatus.FINAL, null);
 
                                 outputTestCase(out.tempPrintWriter, comments, internals, actual);
                             });
@@ -595,7 +596,7 @@ public class GenerateLinkData {
                                 UrlInternals parts = UrlInternals.from(item);
                                 String host = parts.get(Part.HOST).get(0).get(0);
                                 hostCounter.add(host, 1);
-                                url = parts.minimalEscape(true, escaped);
+                                url = parts.minimalEscape(EndStatus.FINAL, escaped);
                                 break;
                         }
                     }

--- a/unicodetools/src/main/java/org/unicode/tools/GenerateLinkData.java
+++ b/unicodetools/src/main/java/org/unicode/tools/GenerateLinkData.java
@@ -450,6 +450,7 @@ public class GenerateLinkData {
                                 String fullSourcePath = oldValue.toString();
 
                                 UrlInternals internals = UrlInternals.from(fullSourcePath);
+                                // String maximal = internals.maximalEscape(EndStatus.FINAL, null);
 
                                 String actual = internals.minimalEscape(EndStatus.FINAL, null);
 
@@ -466,14 +467,13 @@ public class GenerateLinkData {
                                                             title,
                                                             line,
                                                             internals,
-                                                            fullSourcePath,
+                                                            internals.fullEscape(),
                                                             "expected:\t" + expected,
                                                             "actual:  \t" + actual));
                                     ++errorCount.value;
-                                    // for debugging
-                                    UrlInternals.from(fullSourcePath);
-                                    internals.minimalEscape(EndStatus.FINAL, null);
+                                    ensureRoundTrip(internals, fullSourcePath);
                                     comments.clear();
+
                                     return;
                                 }
                                 outputTestCase(out.tempPrintWriter, comments, internals, actual);
@@ -515,9 +515,13 @@ public class GenerateLinkData {
                                 // Divide into parts
                                 UrlInternals internals = UrlInternals.from(line);
 
-                                String actual = internals.minimalEscape(EndStatus.FINAL, null);
+                                String minimallyEscaped =
+                                        internals.minimalEscape(EndStatus.FINAL, null);
 
-                                outputTestCase(out.tempPrintWriter, comments, internals, actual);
+                                ensureRoundTrip(internals, minimallyEscaped);
+
+                                outputTestCase(
+                                        out.tempPrintWriter, comments, internals, minimallyEscaped);
                             });
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -525,6 +529,15 @@ public class GenerateLinkData {
         if (errorCount.value != 0) {
             throw new IllegalArgumentException("Failures in writing test file: " + errorCount);
         }
+    }
+
+    private static void ensureRoundTrip(UrlInternals sourceInternals, String resultingPath) {
+        UrlInternals targetInternals = UrlInternals.from(resultingPath);
+        if (!targetInternals.equals(sourceInternals)) {
+            throw new IllegalArgumentException("Fails roundtrip");
+        }
+        // for testing
+        String minimal = sourceInternals.minimalEscape(EndStatus.FINAL, null);
     }
 
     private static void outputTestCase(

--- a/unicodetools/src/main/java/org/unicode/tools/GenerateLinkData.java
+++ b/unicodetools/src/main/java/org/unicode/tools/GenerateLinkData.java
@@ -536,8 +536,6 @@ public class GenerateLinkData {
         if (!targetInternals.equals(sourceInternals)) {
             throw new IllegalArgumentException("Fails roundtrip");
         }
-        // for testing
-        String minimal = sourceInternals.minimalEscape(EndStatus.FINAL, null);
     }
 
     private static void outputTestCase(

--- a/unicodetools/src/main/java/org/unicode/utilities/LinkUtilities.java
+++ b/unicodetools/src/main/java/org/unicode/utilities/LinkUtilities.java
@@ -459,13 +459,15 @@ public class LinkUtilities {
             this.data = ImmutableSortedMap.copyOf(data);
         }
 
+        public enum EndStatus {MEDIAL, FINAL}
+        
         /**
          * Minimally escape. Presumes that the parts use \ for interior quoting.<br>
          *
-         * @param atEndOfText TODO
+         * @param endStatus TODO
          * @param escapedCounter TODO
          */
-        public String minimalEscape(boolean atEndOfText, Counter<Integer> escapedCounter) {
+        public String minimalEscape(EndStatus endStatus, Counter<Integer> escapedCounter) {
             StringBuilder output = new StringBuilder();
             // get the last part
             List<Entry<Part, List<List<String>>>> ordered = List.copyOf(data.entrySet());
@@ -580,7 +582,7 @@ public class LinkUtilities {
                     }
                 }
                 // fix
-                if (atEndOfText || part != lastPart) {
+                if (endStatus==EndStatus.MEDIAL || part != lastPart) {
                     appendCodePointsBetween(output, cps, copiedAlready, n);
                 } else if (copiedAlready < n) {
                     appendCodePointsBetween(output, cps, copiedAlready, n - 1);

--- a/unicodetools/src/main/java/org/unicode/utilities/LinkUtilities.java
+++ b/unicodetools/src/main/java/org/unicode/utilities/LinkUtilities.java
@@ -18,6 +18,7 @@ import com.ibm.icu.text.StringPrepParseException;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSet.EntryRange;
 import com.ibm.icu.text.UnicodeSet.SpanCondition;
+import com.ibm.icu.util.Output;
 import com.ibm.icu.util.VersionInfo;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -608,14 +609,30 @@ public class LinkUtilities {
         }
 
         public String fullEscape() {
-            return data.entrySet().stream()
-                    .map(
-                            x -> {
-                                Part part = x.getKey();
-                                List<List<String>> value = x.getValue();
-                                return part.fullEscape(value);
-                            })
-                    .collect(Collectors.joining());
+            Output<Part> last = new Output<>();
+            String result =
+                    data.entrySet().stream()
+                            .map(
+                                    x -> {
+                                        Part part = x.getKey();
+                                        last.value = part;
+                                        List<List<String>> value = x.getValue();
+                                        return part.fullEscape(value);
+                                    })
+                            .collect(Collectors.joining());
+            // handle the very last character, if soft
+            if (last.value != null && last.value != Part.HOST && last.value != Part.PROTOCOL) {
+                int lastCodePoint = result.codePointBefore(result.length());
+                if (LinkTermination.Soft.base.contains(lastCodePoint)) {
+                    // escape final soft code point
+                    int indexBeforeLast = result.length() - Character.charCount(lastCodePoint);
+                    StringBuilder resultBuilder =
+                            new StringBuilder(result.substring(0, indexBeforeLast));
+                    appendPercentEscaped(resultBuilder, lastCodePoint, null);
+                    result = resultBuilder.toString();
+                }
+            }
+            return result;
         }
 
         public List<List<String>> get(Part part) {

--- a/unicodetools/src/main/java/org/unicode/utilities/LinkUtilities.java
+++ b/unicodetools/src/main/java/org/unicode/utilities/LinkUtilities.java
@@ -459,8 +459,11 @@ public class LinkUtilities {
             this.data = ImmutableSortedMap.copyOf(data);
         }
 
-        public enum EndStatus {MEDIAL, FINAL}
-        
+        public enum EndStatus {
+            MEDIAL,
+            FINAL
+        }
+
         /**
          * Minimally escape. Presumes that the parts use \ for interior quoting.<br>
          *
@@ -582,7 +585,7 @@ public class LinkUtilities {
                     }
                 }
                 // fix
-                if (endStatus==EndStatus.MEDIAL || part != lastPart) {
+                if (endStatus == EndStatus.MEDIAL || part != lastPart) {
                     appendCodePointsBetween(output, cps, copiedAlready, n);
                 } else if (copiedAlready < n) {
                     appendCodePointsBetween(output, cps, copiedAlready, n - 1);

--- a/unicodetools/src/main/java/org/unicode/utilities/LinkUtilities.java
+++ b/unicodetools/src/main/java/org/unicode/utilities/LinkUtilities.java
@@ -584,7 +584,6 @@ public class LinkUtilities {
                             throw new IllegalArgumentException();
                     }
                 }
-                // fix
                 if (endStatus == EndStatus.MEDIAL || part != lastPart) {
                     appendCodePointsBetween(output, cps, copiedAlready, n);
                 } else if (copiedAlready < n) {

--- a/unicodetools/src/main/java/org/unicode/utilities/LinkUtilities.java
+++ b/unicodetools/src/main/java/org/unicode/utilities/LinkUtilities.java
@@ -33,6 +33,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.Stack;
@@ -87,31 +88,42 @@ public class LinkUtilities {
 
     private static final UnicodeSet SOFAR = new UnicodeSet();
 
-    // https://url.spec.whatwg.org/#percent-encoded-bytes
-
+    /**
+     * Based on https://url.spec.whatwg.org/#percent-encoded-bytes. Is the default for maximal
+     * encoding, but can be customized
+     */
     public enum WHATWG_PERCENT_ENCODED {
-        C0(null, "[\\u0000-\\u001F\\u007E-\\u10FFFF]"), // C0 controls and all code points greater
-        // than U+007E (~).
-        FRAGMENT(C0, "[\\ \"<>`]"), // C0 and U+0020 SPACE, U+0022 ("), U+003C (<), U+003E (>), and
-        // U+0060 (`).
-        QUERY(
-                C0,
-                "[\\ \"<>]"), // C0 and U+0020 SPACE, U+0022 ("), U+0023 (#), U+003C (<), and U+003E
-        // (>)
-        SPECIAL_QUERY(QUERY, "[']"), // query percent-encode set and U+0027 ('). Used for http://...
-        PATH(QUERY, "[?\\^`\\{\\}]"), // query percent-encode set and U+003F (?), U+005E (^), U+0060
-        // (`),
-        // U+007B ({), and U+007D (}).
-        USERINFO(
-                PATH,
-                "[/:;=@\\[-\\]|]"), // path and U+002F (/), U+003A (:), U+003B (;), U+003D (=),
-        // U+0040 (@), U+005B ([) to U+005D (]), inclusive, and U+007C
-        // (|).
-        COMPONENT(
-                USERINFO,
-                "[\\$-\\&+,]") // userinfo and U+0024 ($) to U+0026 (&), inclusive, U+002B (+), and
-    // U+002C (,).
-    ;
+        /** C0 controls and all code points greater than U+007E (~). */
+        C0(null, "[\\u0000-\\u001F\\u007E-\\x{10FFFF}]"),
+
+        /** C0 and U+0020 SPACE, U+0022 ("), U+003C (<), U+003E (>), andU+0060 (`). */
+        FRAGMENT(C0, "[\\ \"<>`]"),
+
+        /** C0 and U+0020 SPACE, U+0022 ("), U+0023 (#), U+003C (<), and U+003E (>) */
+        QUERY(C0, "[\\ \"<>]"),
+
+        /** query percent-encode set and U+0027 ('). Used for http://... */
+        SPECIAL_QUERY(QUERY, "[']"),
+
+        /**
+         * query percent-encode set and<br>
+         * U+003F (?), U+005E (^), U+0060 (`), U+007B ({), and U+007D (}).
+         */
+        PATH(QUERY, "[?\\^`\\{\\}]"),
+
+        /**
+         * path and<br>
+         * U+002F (/), U+003A (:), U+003B (;), U+003D (=), U+0040 (@), U+005B ([) to U+005D (]),
+         * inclusive, and U+007C (|).
+         */
+        USERINFO(PATH, "[/:;=@\\[-\\]|]"),
+
+        /**
+         * userinfo and <br>
+         * U+0024 ($) to U+0026 (&), inclusive, U+002B (+), and U+002C (,).
+         */
+        COMPONENT(USERINFO, "[\\$-\\&+,]");
+
         public final UnicodeSet set;
 
         private WHATWG_PERCENT_ENCODED(WHATWG_PERCENT_ENCODED base, String uset) {
@@ -614,6 +626,19 @@ public class LinkUtilities {
         @Override
         public String toString() {
             return toString(Part.ALL); // show all
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof UrlInternals urlInternals) {
+                return data.equals(urlInternals.data);
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(data);
         }
 
         public String toString(Set<Part> partsToShow) {

--- a/unicodetools/src/test/java/org/unicode/unittest/LinkUtilitiesTest.java
+++ b/unicodetools/src/test/java/org/unicode/unittest/LinkUtilitiesTest.java
@@ -33,6 +33,7 @@ import org.unicode.utilities.LinkUtilities.LinkTermination;
 import org.unicode.utilities.LinkUtilities.Part;
 import org.unicode.utilities.LinkUtilities.UrlInternals;
 import org.unicode.utilities.LinkUtilities.UrlInternals.EndStatus;
+import org.unicode.utilities.LinkUtilities.WHATWG_PERCENT_ENCODED;
 
 /** The following is very temporary, just during the spec development. */
 public class LinkUtilitiesTest extends TestFmwkMinusMinus {
@@ -640,5 +641,52 @@ public class LinkUtilitiesTest extends TestFmwkMinusMinus {
         UrlInternals ui = LinkUtilities.UrlInternals.from(test);
         String actual = ui.minimalEscape(EndStatus.FINAL, null);
         assertEquals(test, expected, actual);
+
+        UrlInternals roundTrip = LinkUtilities.UrlInternals.from(actual);
+        assertEquals(test, ui, roundTrip);
     }
+
+    @Test
+    public void testEquals() {
+        String test = "https://bo.wikipedia.org/wiki/སའི་གོ་ལ།";
+        // force different string
+        String notSameReference = test.substring(0, 5) + test.substring(5);
+        assertFalse(test, test == notSameReference);
+
+        UrlInternals ui = LinkUtilities.UrlInternals.from(test);
+        UrlInternals ui2 = LinkUtilities.UrlInternals.from(notSameReference);
+        assertEquals(test, ui, ui2);
+        UrlInternals ui3 = LinkUtilities.UrlInternals.from(test + "a");
+        assertNotEquals(test, ui, ui3);
+    }
+
+    static final UnicodeSet OK_TO_UNESCAPE = new UnicodeSet("\\p{ascii}");
+
+    @Test
+    public void testMaximalEscape() {
+        List<String> tests =
+                List.of(
+                        "https://mni.wikipedia.org/wiki/ꯅ꯭ꯌꯨ_ꯌꯣꯔ꯭ꯛ_ꯁꯤꯇꯤꯒꯤ_ꯌꯨ.ꯑꯦꯁ.",
+                        "https://bo.wikipedia.org/α\\/b\\?c?γ\\=β\\&\\##j");
+        for (String test : tests) {
+            UrlInternals ui = LinkUtilities.UrlInternals.from(test);
+            String actual = ui.fullEscape();
+            assertTrue(test, OK_TO_UNESCAPE.containsAll(actual));
+            UrlInternals roundTrip = LinkUtilities.UrlInternals.from(actual);
+            assertEquals(test, ui, roundTrip);
+        }
+    }
+    
+    @Test
+    public void testWhatWGEscapes() {
+        UnicodeSet mustEscape = new UnicodeSet(OK_TO_UNESCAPE).complement();
+        for (WHATWG_PERCENT_ENCODED item : WHATWG_PERCENT_ENCODED.values()) {
+        	if (!item.set.containsAll(mustEscape)) {
+        		UnicodeSet missing = new UnicodeSet(mustEscape).removeAll(item.set);
+        		System.out.println(missing);
+        	}
+            assertTrue(item.name(),  item.set.containsAll(mustEscape));
+        }
+    }
+
 }

--- a/unicodetools/src/test/java/org/unicode/unittest/LinkUtilitiesTest.java
+++ b/unicodetools/src/test/java/org/unicode/unittest/LinkUtilitiesTest.java
@@ -410,7 +410,8 @@ public class LinkUtilitiesTest extends TestFmwkMinusMinus {
                                     if (wikipos >= 0) {
                                         url = prefix + url.substring(wikipos + 6);
                                         UrlInternals parts = UrlInternals.from(url);
-                                        String actual = parts.minimalEscape(EndStatus.FINAL, escaped);
+                                        String actual =
+                                                parts.minimalEscape(EndStatus.FINAL, escaped);
                                         counter.add(assertEquals(wikiLanguage, url, actual), 1);
                                     }
                                 }
@@ -631,13 +632,13 @@ public class LinkUtilitiesTest extends TestFmwkMinusMinus {
         String expected = "α/β%2Fγ";
         assertEquals(source.toString(), expected, unified);
     }
-    
+
     @Test
     public void testSha() {
-    	String test = "https://bo.wikipedia.org/wiki/སའི་གོ་ལ།";
-    	String expected = "https://bo.wikipedia.org/wiki/སའི་གོ་ལ%E0%BC%8D";
-    	UrlInternals ui = LinkUtilities.UrlInternals.from(test);
-    	String actual = ui.minimalEscape(EndStatus.FINAL, null);
-    	assertEquals(test, expected, actual);
+        String test = "https://bo.wikipedia.org/wiki/སའི་གོ་ལ།";
+        String expected = "https://bo.wikipedia.org/wiki/སའི་གོ་ལ%E0%BC%8D";
+        UrlInternals ui = LinkUtilities.UrlInternals.from(test);
+        String actual = ui.minimalEscape(EndStatus.FINAL, null);
+        assertEquals(test, expected, actual);
     }
 }

--- a/unicodetools/src/test/java/org/unicode/unittest/LinkUtilitiesTest.java
+++ b/unicodetools/src/test/java/org/unicode/unittest/LinkUtilitiesTest.java
@@ -32,6 +32,7 @@ import org.unicode.utilities.LinkUtilities.LinkScanner;
 import org.unicode.utilities.LinkUtilities.LinkTermination;
 import org.unicode.utilities.LinkUtilities.Part;
 import org.unicode.utilities.LinkUtilities.UrlInternals;
+import org.unicode.utilities.LinkUtilities.UrlInternals.EndStatus;
 
 /** The following is very temporary, just during the spec development. */
 public class LinkUtilitiesTest extends TestFmwkMinusMinus {
@@ -216,7 +217,7 @@ public class LinkUtilitiesTest extends TestFmwkMinusMinus {
 
                 final String expected = test[3].replace("χττψ://", "https://");
 
-                final String actual = source.minimalEscape(false, null);
+                final String actual = source.minimalEscape(EndStatus.FINAL, null);
                 counter.add(
                         assertEquals(
                                 line + ") " + Arrays.asList(test) + "\n" + pqf + "\n" + source,
@@ -261,7 +262,7 @@ public class LinkUtilitiesTest extends TestFmwkMinusMinus {
             String expected = test[1];
             UrlInternals internals = UrlInternals.from(test0);
             assertEquals(test0 + "\n", "\n" + expected, "\n" + internals.toString());
-            String min0 = internals.minimalEscape(false, null);
+            String min0 = internals.minimalEscape(EndStatus.FINAL, null);
         }
     }
 
@@ -311,7 +312,7 @@ public class LinkUtilitiesTest extends TestFmwkMinusMinus {
                     final Counter<Boolean> okCounter = new Counter<>();
                     Counter<Integer> escapedCounter = new Counter<>();
 
-                    String actual = parts.minimalEscape(false, escapedCounter);
+                    String actual = parts.minimalEscape(EndStatus.FINAL, escapedCounter);
                     okCounter.add(assertEquals(wikiLanguage, expected, actual), 1);
                     try {
                         processUrls(source, wikiLanguage, okCounter, escapedCounter);
@@ -409,7 +410,7 @@ public class LinkUtilitiesTest extends TestFmwkMinusMinus {
                                     if (wikipos >= 0) {
                                         url = prefix + url.substring(wikipos + 6);
                                         UrlInternals parts = UrlInternals.from(url);
-                                        String actual = parts.minimalEscape(false, escaped);
+                                        String actual = parts.minimalEscape(EndStatus.FINAL, escaped);
                                         counter.add(assertEquals(wikiLanguage, url, actual), 1);
                                     }
                                 }
@@ -610,13 +611,13 @@ public class LinkUtilitiesTest extends TestFmwkMinusMinus {
     public void testEscaping() {
         String source = "https://example.com?α%3Dβ=γ%3Dδ";
         UrlInternals internals = UrlInternals.from(source);
-        String actual = internals.minimalEscape(false, null);
+        String actual = internals.minimalEscape(EndStatus.FINAL, null);
         String expected = "https://example.com?α%3Dβ=γ%3Dδ";
         assertEquals(source, expected, actual.toString());
 
         source = "https://example.com/α/β%2Fγ";
         internals = UrlInternals.from(source);
-        actual = internals.minimalEscape(false, null);
+        actual = internals.minimalEscape(EndStatus.FINAL, null);
         expected = "https://example.com/α/β%2Fγ";
         assertEquals(source, expected, actual.toString());
     }
@@ -629,5 +630,14 @@ public class LinkUtilitiesTest extends TestFmwkMinusMinus {
                 LinkUtilities.joinListListEscaping(part.structure.sub, part.structure.sub2, source);
         String expected = "α/β%2Fγ";
         assertEquals(source.toString(), expected, unified);
+    }
+    
+    @Test
+    public void testSha() {
+    	String test = "https://bo.wikipedia.org/wiki/སའི་གོ་ལ།";
+    	String expected = "https://bo.wikipedia.org/wiki/སའི་གོ་ལ%E0%BC%8D";
+    	UrlInternals ui = LinkUtilities.UrlInternals.from(test);
+    	String actual = ui.minimalEscape(EndStatus.FINAL, null);
+    	assertEquals(test, expected, actual);
     }
 }

--- a/unicodetools/src/test/java/org/unicode/unittest/LinkUtilitiesTest.java
+++ b/unicodetools/src/test/java/org/unicode/unittest/LinkUtilitiesTest.java
@@ -676,17 +676,16 @@ public class LinkUtilitiesTest extends TestFmwkMinusMinus {
             assertEquals(test, ui, roundTrip);
         }
     }
-    
+
     @Test
     public void testWhatWGEscapes() {
         UnicodeSet mustEscape = new UnicodeSet(OK_TO_UNESCAPE).complement();
         for (WHATWG_PERCENT_ENCODED item : WHATWG_PERCENT_ENCODED.values()) {
-        	if (!item.set.containsAll(mustEscape)) {
-        		UnicodeSet missing = new UnicodeSet(mustEscape).removeAll(item.set);
-        		System.out.println(missing);
-        	}
-            assertTrue(item.name(),  item.set.containsAll(mustEscape));
+            if (!item.set.containsAll(mustEscape)) {
+                UnicodeSet missing = new UnicodeSet(mustEscape).removeAll(item.set);
+                System.out.println(missing);
+            }
+            assertTrue(item.name(), item.set.containsAll(mustEscape));
         }
     }
-
 }


### PR DESCRIPTION
There was a bad parameter passed in when processing the wiki URLs for use in the test data file. This exposed a bug in how that parameter was used. This corrects that, and gives the parameters more appropriate names (using an enum instead of a naked boolean).

Fixes https://github.com/unicode-org/properties/issues/527

NOTE: I could also regenerate the v17 file if needed. It has ~10 fixes also.

- [X] Approver: Feel free to merge on my behalf
    - [ ] rebase & merge one or more commits
    - [x] squash & merge multiple commits into one