### PR TITLE
Fix searching for single code points

### DIFF
--- a/UnicodeJsps/.settings/org.eclipse.jdt.core.prefs
+++ b/UnicodeJsps/.settings/org.eclipse.jdt.core.prefs
@@ -1,12 +1,12 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.processAnnotations=disabled
-org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=21

--- a/unicodetools/src/main/resources/org/unicode/text/tools/charindex.js
+++ b/unicodetools/src/main/resources/org/unicode/text/tools/charindex.js
@@ -33,7 +33,8 @@ for (let [property, propertyIndex] of indexEntries) {
   }
   for (let [snippetIndex, entry] of propertyIndex) {
     for (let range of entry.characters) {
-      radicalStrokeRanges.set(range, {property, snippetIndex});
+      let [first, last] = [range[0], range.at(-1)];
+      radicalStrokeRanges.set([first, last], {property, snippetIndex});
     }
   }
 }
@@ -43,7 +44,8 @@ for (let [name, entry] of indexEntries.get("Name")) {
     characterNames.set(entry.characters[0][0], name);
   } else {
     for (let range of entry.characters) {
-      characterNameRanges.set(range, name);
+      let [first, last] = [range[0], range.at(-1)];
+      characterNameRanges.set([first, last], name);
     }
   }
 }
@@ -201,8 +203,8 @@ function search(/**@type {string}*/ query) {
       if (name) {
         rangeCount += 1;
         result.push(
-          getString(indexEntries.get("Name").get(name) ??
-                    indexEntries.get("Name_Alias").get(name).html).replace(
+          getString((indexEntries.get("Name").get(name) ??
+                     indexEntries.get("Name_Alias").get(name)).html).replace(
           "[RESULT TEXT]", toHTML(getString(name))));
       }
     }


### PR DESCRIPTION
I broke some things in #1331, causing searches for single code points to return `Basic Latin` instead of the Name or Radical-Stroke entry.

- [ ] Approver: Feel free to merge on my behalf
    - [ ] rebase & merge one or more commits
    - [ ] squash & merge multiple commits into one