### PR TITLE
γ

### DIFF
--- a/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeJsp.java
+++ b/UnicodeJsps/src/main/java/org/unicode/jsp/UnicodeJsp.java
@@ -141,7 +141,8 @@ public class UnicodeJsp {
         if (showDevProperties) {
             originalParameters.add("showDevProperties=1");
         }
-        showDevProperties = Settings.latestVersionPhase == ReleasePhase.BETA || showDevProperties;
+        showDevProperties =
+                Settings.latestVersionPhase.compareTo(ReleasePhase.BETA) >= 0 || showDevProperties;
         UnicodeUtilities.showProperties(cp, history, showDevProperties, originalParameters, out);
     }
 
@@ -213,7 +214,8 @@ public class UnicodeJsp {
             throws IOException {
         List<String> originalParameters =
                 showDevProperties ? List.of("showDevProperties=1") : List.of();
-        showDevProperties = Settings.latestVersionPhase == ReleasePhase.BETA || showDevProperties;
+        showDevProperties =
+                Settings.latestVersionPhase.compareTo(ReleasePhase.BETA) >= 0 || showDevProperties;
         CodePointShower codePointShower =
                 new CodePointShower(
                         grouping,
@@ -436,7 +438,8 @@ public class UnicodeJsp {
     public static String getIdentifier(String script, boolean showDevProperties) {
         List<String> originalParameters =
                 showDevProperties ? List.of("showDevProperties=1") : List.of();
-        showDevProperties = Settings.latestVersionPhase == ReleasePhase.BETA || showDevProperties;
+        showDevProperties =
+                Settings.latestVersionPhase.compareTo(ReleasePhase.BETA) >= 0 || showDevProperties;
         return UnicodeUtilities.getIdentifier(script, showDevProperties, originalParameters);
     }
 
@@ -446,12 +449,14 @@ public class UnicodeJsp {
             "ICU version: "
                     + VersionInfo.ICU_VERSION.getVersionString(2, 2)
                     + "; "
-                    + "Unicode/Emoji version: "
+                    + "base Unicode/Emoji version: "
                     + Settings.lastVersion
                     + "; "
                     + (Settings.latestVersionPhase == ReleasePhase.BETA
-                            ? "Unicodeβ version: " + Settings.latestVersion + "; "
-                            : "");
+                            ? "Unicode β version: " + Settings.latestVersion + "; "
+                            : Settings.latestVersionPhase == ReleasePhase.GAMMA
+                                    ? "Unicode latest version: " + Settings.latestVersion + "; "
+                                    : "");
 
     public static String getVersions() {
         return "unicodetools "
@@ -466,12 +471,13 @@ public class UnicodeJsp {
     }
 
     static final String SUBHEAD =
-            Settings.latestVersionPhase == ReleasePhase.BETA
+            Settings.latestVersionPhase.compareTo(ReleasePhase.BETA) >= 0
                     ? "<p style='border: 1pt solid red;'>Unmarked properties are from Unicode V"
                             + Settings.lastVersion
-                            + "; the beta properties are from Unicode V"
+                            + "; changes in Unicode V"
                             + Settings.latestVersion
-                            + "β. "
+                            + Settings.latestVersionPhase
+                            + " are highlighted. "
                             + "For more information, see <a target='help' href='https://unicode-org.github.io/unicodetools/help/changes'>Unicode Utilities Beta</a>.</p>"
                     : "";
 

--- a/unicodetools/src/main/java/org/unicode/text/utility/Settings.java
+++ b/unicodetools/src/main/java/org/unicode/text/utility/Settings.java
@@ -27,7 +27,10 @@ public class Settings {
     public enum ReleasePhase {
         DEV("dev"), // Before α.
         ALPHA("α"), // α review.
-        BETA("β"); // β review.
+        BETA("β"), // β review.
+        // Produce release-final artefacts with no β markings (most relevant for the JSPs and
+        // charindex).
+        GAMMA("");
 
         private final String toString;
 


### PR DESCRIPTION
Fix the non-emoji part of #936.

The handling in the JSPs is somewhat hacky: they will still have yellow highlighting for changes in the latest version:
<img width="1259" height="659" alt="image" src="https://github.com/user-attachments/assets/5d401d47-5474-4bc2-bcae-60b297d864bb" />
[…]
<img width="941" height="46" alt="image" src="https://github.com/user-attachments/assets/ca71620d-1a32-4cec-a2d2-2f33461009dc" />


Compare β:
<img width="1251" height="651" alt="image" src="https://github.com/user-attachments/assets/de935019-9b96-4800-b844-5f927bfef405" />
[…]
<img width="941" height="45" alt="image" src="https://github.com/user-attachments/assets/fbb49883-df61-4dfc-99bd-5e12ec24005e" />


But then the JSPs are an internal tool, so this is somewhere between good enough and a feature (highlighting changes in γ gives us a last chance to review, and then the newly released version becomes the baseline when we roll over).

I checked that when setting the phase to γ, charindex produces non-draft links and does not have a version suffix:
<img width="600" height="282" alt="image" src="https://github.com/user-attachments/assets/eea93536-3ce7-4e11-8e3c-e5d2adf8096e" />


- [x] Approver: Feel free to merge on my behalf
    - [x] rebase & merge one or more commits
    - [x] squash & merge multiple commits into one