### PR TITLE
Fix the InSC of Gurung Khema A and add a test promised by L2/24-203

### DIFF
--- a/unicodetools/data/ucd/dev/IndicSyllabicCategory.txt
+++ b/unicodetools/data/ucd/dev/IndicSyllabicCategory.txt
@@ -1,5 +1,5 @@
 # IndicSyllabicCategory-18.0.0.txt
-# Date: 2026-06-24, 13:39:21 GMT
+# Date: 2026-07-02, 18:58:37 GMT
 # © 2026 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -481,7 +481,6 @@ ABD1          ; Vowel_Independent # Lo       MEETEI MAYEK LETTER ATIYA
 11D67..11D68  ; Vowel_Independent # Lo   [2] GUNJALA GONDI LETTER EE..GUNJALA GONDI LETTER AI
 11D6A..11D6B  ; Vowel_Independent # Lo   [2] GUNJALA GONDI LETTER OO..GUNJALA GONDI LETTER AU
 11F04..11F10  ; Vowel_Independent # Lo  [13] KAWI LETTER A..KAWI LETTER O
-16100         ; Vowel_Independent # Lo       GURUNG KHEMA LETTER A
 
 # ================================================
 
@@ -980,7 +979,7 @@ ABD2..ABDA    ; Consonant # Lo   [9] MEETEI MAYEK LETTER GOK..MEETEI MAYEK LETTE
 11DF1         ; Consonant # Lo       BENGALI LETTER ALTERNATE BARGIYA BA
 11EE0..11EF1  ; Consonant # Lo  [18] MAKASAR LETTER KA..MAKASAR LETTER A
 11F12..11F33  ; Consonant # Lo  [34] KAWI LETTER KA..KAWI LETTER JNYA
-16101..1611D  ; Consonant # Lo  [29] GURUNG KHEMA LETTER KA..GURUNG KHEMA LETTER SA
+16100..1611D  ; Consonant # Lo  [30] GURUNG KHEMA LETTER A..GURUNG KHEMA LETTER SA
 16D43..16D62  ; Consonant # Lo  [32] KIRAT RAI LETTER A..KIRAT RAI LETTER HA
 
 # ================================================

--- a/unicodetools/src/test/java/org/unicode/propstest/TestProperties.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/TestProperties.java
@@ -1034,6 +1034,10 @@ public class TestProperties extends TestFmwkMinusMinus {
 
     @Test
     public void TestVowelCarrierInSc() {
+        // If a script has a single independent vowel character which is the inherent vowel, with
+        // all other independent vowels formed by sticking dependent vowels on it, that independent
+        // vowel is treated as a (null) consonant.
+        // See L2/24-203 and 181-C44.
         final var inSC = iup.getProperty(UcdProperty.Indic_Syllabic_Category);
         final var inSCVowelIndependent =
                 inSC.getSet(UcdPropertyValues.Indic_Syllabic_Category_Values.Vowel_Independent);
@@ -1045,7 +1049,7 @@ public class TestProperties extends TestFmwkMinusMinus {
                             + independentVowels
                             + " of independent vowels in "
                             + script
-                            + " must not have size 1",
+                            + " must not have size 1, see L2/24-203",
                     independentVowels.size(),
                     1);
         }

--- a/unicodetools/src/test/java/org/unicode/propstest/TestProperties.java
+++ b/unicodetools/src/test/java/org/unicode/propstest/TestProperties.java
@@ -1031,4 +1031,23 @@ public class TestProperties extends TestFmwkMinusMinus {
             logln(age + ", gc:N-nt" + diff);
         }
     }
+
+    @Test
+    public void TestVowelCarrierInSc() {
+        final var inSC = iup.getProperty(UcdProperty.Indic_Syllabic_Category);
+        final var inSCVowelIndependent =
+                inSC.getSet(UcdPropertyValues.Indic_Syllabic_Category_Values.Vowel_Independent);
+        final var sc = iup.getProperty(UcdProperty.Script);
+        for (final var script : UcdPropertyValues.Script_Values.values()) {
+            final var independentVowels = sc.getSet(script).retainAll(inSCVowelIndependent);
+            assertNotEquals(
+                    "The set "
+                            + independentVowels
+                            + " of independent vowels in "
+                            + script
+                            + " must not have size 1",
+                    independentVowels.size(),
+                    1);
+        }
+    }
 }


### PR DESCRIPTION
See https://github.com/unicode-org/properties/issues/575.

**[[188-C21](https://www.unicode.org/cgi-bin/GetL2Ref.pl?188-C21)] Consensus:** Change the Indic_Syllabic_Category of U+16100 GURUNG KHEMA LETTER A from Vowel_Independent to Consonant. For Unicode Version 18.0. See [L2/24-203](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/24-203) and [L2/26-154](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/26-154) item 2.3.

**[[188-A37](https://www.unicode.org/cgi-bin/GetL2Ref.pl?188-A37)] Action Item for** Robin Leroy, PAG: In UCD file IndicSyllabicCategory.txt, Change the Indic_Syllabic_Category of U+16100 GURUNG KHEMA LETTER A from Vowel_Independent to Consonant. For Unicode Version 18.0. See [L2/24-203](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/24-203) and [L2/26-154](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/26-154) item 2.3.

Fix #915.

- [ ] Approver: Feel free to merge on my behalf
    - [ ] rebase & merge one or more commits
    - [ ] squash & merge multiple commits into one