### PR TITLE
Updates to the invariant test parser following the new ICU snapshot

### DIFF
--- a/unicodetools/src/main/java/org/unicode/text/UCD/TestUnicodeInvariants.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/TestUnicodeInvariants.java
@@ -345,9 +345,9 @@ public class TestUnicodeInvariants {
                         // Try parsing the next line, but since that may be the rest of what we
                         // failed to parse,
                         // do not report errors until we successfully parse *something*.
-                        final int nextLine = source.indexOf("\n", pp.getIndex());
+                        final int nextLine = source.indexOf("\n", pp.getIndex() + 1);
                         if (nextLine >= 0) {
-                            pp.setIndex(source.indexOf("\n", pp.getIndex()));
+                            pp.setIndex(nextLine);
                             followingParseError = true;
                             continue;
                         } else {
@@ -1998,63 +1998,37 @@ public class TestUnicodeInvariants {
         }
     }
 
-    private static Pattern nameEscape = Pattern.compile("\\\\N\\{[^}]*\\}");
-
     public static UnicodeSet parseUnicodeSet(String source, ParsePosition pp)
             throws ParseException {
-        final int initialPosition = pp.getIndex();
-        UnicodeSet icuSet;
         try {
-            // Let ICU figure out where the UnicodeSet expression ends.
-            icuSet = new UnicodeSet(source, pp, symbolTable);
+            return new UnicodeSet(source, pp, symbolTable);
         } catch (IllegalArgumentException e) {
             // ICU produces unhelpful messages when parsing UnicodeSet deep into
             // a large string in a string that contains line terminators, as the
-            // whole string is escaped and printed.
-            final String message = e.getMessage().split(" at \"", 2)[0];
-            throw new BackwardParseException(message, pp.getIndex());
-        }
-        String unicodeSetExpression = source.substring(initialPosition, pp.getIndex());
-        // ICU incorrectly treats \N{X} as a synonym for \p{Name=X}, returning a
-        // set rather than a character, so that it can be empty, and so that
-        // \N{X}-\N{Y} is a set difference (equal to \N{X}) rather than the range \N{X}-\N{Y}.
-        // This should likely be fixed in ICU, but in the meantime we need to work around it in
-        // the invariant before someone gets hurt.
-        var matcher = nameEscape.matcher(unicodeSetExpression);
-        if (!matcher.find()) {
-            return icuSet;
-        }
-        // Simplest way for the lambda function to report errors.
-        // It cannot throw a ParseException, and it cannot modify local variables.
-        // It _can_ modify what this local variable points to.
-        // Below, we will throw a ParseException for the first bad position.
-        final List<Integer> badEscapePositions = new ArrayList<>();
-        unicodeSetExpression =
-                matcher.replaceAll(
-                        (MatchResult match) -> {
-                            UnicodeSet character =
-                                    new UnicodeSet(
-                                            match.group(), new ParsePosition(0), symbolTable);
-                            if (character.isEmpty()) {
-                                badEscapePositions.add(match.start());
-                                return "";
-                            }
-                            return Strings.padStart(
-                                    "\\\\x{" + Integer.toHexString(character.charAt(0)) + "}",
-                                    match.group().length() + 1,
-                                    ' ');
-                        });
-        for (int p : badEscapePositions) {
-            // Simplest way to throw an exception for only the first list element.
-            throw new ParseException("No character matching \\N escape", initialPosition + p);
-        }
-        var patchedParsePosition = new ParsePosition(0);
-        try {
-            return new UnicodeSet(unicodeSetExpression, patchedParsePosition, symbolTable);
-        } catch (IllegalArgumentException e) {
-            final String message = e.getMessage().split(" at \"", 2)[0];
-            throw new BackwardParseException(
-                    message, patchedParsePosition.getIndex() + initialPosition);
+            // whole string is printed (here `source` is the entire invariant
+            // test source file, with comments stripped).
+            // When ICU gives us context, figure out if the error is meant to be
+            // before or after the parse position, choose the exception type
+            // accordingly, and drop the ICU-provided context; the handler above
+            // will produce a more useful snippet (including pointing indices
+            // based on the type).
+            String message = e.getMessage();
+            ParseException thrown;
+            final int rightPointingIndexIndex = message.indexOf( '☞');
+            final int leftPointingIndexIndex = message.indexOf( '☜');
+            if (rightPointingIndexIndex >= 0) {
+                thrown = new ParseException(message.substring(0, rightPointingIndexIndex - pp.getIndex()), pp.getIndex());
+            } else if (leftPointingIndexIndex >= 0) {
+                thrown = new BackwardParseException(message.substring(0, leftPointingIndexIndex - pp.getIndex()), pp.getIndex());
+            } else {
+                thrown = new BackwardParseException(message, pp.getIndex());
+            }
+            // While we clean up the message which contains the entire source file (and do
+            // not set the cause so that the original message does not show up), we preserve
+            // the stack trace from ICU, as with the recursive descent parser it can provide
+            // some insight into the error.
+            thrown.setStackTrace(e.getStackTrace());
+            throw thrown;
         }
     }
 }

--- a/unicodetools/src/main/java/org/unicode/text/UCD/TestUnicodeInvariants.java
+++ b/unicodetools/src/main/java/org/unicode/text/UCD/TestUnicodeInvariants.java
@@ -1,6 +1,5 @@
 package org.unicode.text.UCD;
 
-import com.google.common.base.Strings;
 import com.ibm.icu.dev.tool.UOption;
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.text.NumberFormat;
@@ -23,7 +22,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.Stack;
 import java.util.function.Function;
-import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.unicode.cldr.draft.FileUtilities;
@@ -2012,14 +2010,20 @@ public class TestUnicodeInvariants {
             // accordingly, and drop the ICU-provided context; the handler above
             // will produce a more useful snippet (including pointing indices
             // based on the type).
-            String message = e.getMessage();
+            final String message = e.getMessage();
             ParseException thrown;
-            final int rightPointingIndexIndex = message.indexOf( '☞');
-            final int leftPointingIndexIndex = message.indexOf( '☜');
+            final int rightPointingIndexIndex = message.indexOf('☞');
+            final int leftPointingIndexIndex = message.indexOf('☜');
             if (rightPointingIndexIndex >= 0) {
-                thrown = new ParseException(message.substring(0, rightPointingIndexIndex - pp.getIndex()), pp.getIndex());
+                thrown =
+                        new ParseException(
+                                message.substring(0, rightPointingIndexIndex - pp.getIndex()),
+                                pp.getIndex());
             } else if (leftPointingIndexIndex >= 0) {
-                thrown = new BackwardParseException(message.substring(0, leftPointingIndexIndex - pp.getIndex()), pp.getIndex());
+                thrown =
+                        new BackwardParseException(
+                                message.substring(0, leftPointingIndexIndex - pp.getIndex()),
+                                pp.getIndex());
             } else {
                 thrown = new BackwardParseException(message, pp.getIndex());
             }

--- a/unicodetools/src/test/java/org/unicode/text/UCD/TestTestUnicodeInvariants.java
+++ b/unicodetools/src/test/java/org/unicode/text/UCD/TestTestUnicodeInvariants.java
@@ -100,20 +100,20 @@ public class TestTestUnicodeInvariants {
                         .size());
         ParseException thrown =
                 assertThrows(
-                        ParseException.class,
+                        BackwardParseException.class,
                         () ->
                                 TestUnicodeInvariants.parseUnicodeSet(
                                         "TEST [\\N{MEOW}]", new ParsePosition(5)));
         assertEquals("No character name nor name alias matches MEOW", thrown.getMessage());
-        assertEquals("TEST [".length(), thrown.getErrorOffset());
+        assertEquals("TEST [\\N{MEOW}".length(), thrown.getErrorOffset());
         thrown =
                 assertThrows(
-                        BackwardParseException.class,
+                        ParseException.class,
                         () ->
                                 TestUnicodeInvariants.parseUnicodeSet(
                                         "TEST [[a-z]-\\N{LATIN SMALL LETTER Z}]",
                                         new ParsePosition(5)));
-        assertEquals("Error: Set expected after operator", thrown.getMessage());
-        assertEquals("TEST [[a-z]-.N{LATIN SMALL LETTER Z}".length(), thrown.getErrorOffset());
+        assertEquals("Expected property-query | [, got named-element '\\N{LATIN SMALL LETTER Z}' ", thrown.getMessage());
+        assertEquals("TEST [[a-z]-".length(), thrown.getErrorOffset());
     }
 }

--- a/unicodetools/src/test/java/org/unicode/text/UCD/TestTestUnicodeInvariants.java
+++ b/unicodetools/src/test/java/org/unicode/text/UCD/TestTestUnicodeInvariants.java
@@ -113,7 +113,9 @@ public class TestTestUnicodeInvariants {
                                 TestUnicodeInvariants.parseUnicodeSet(
                                         "TEST [[a-z]-\\N{LATIN SMALL LETTER Z}]",
                                         new ParsePosition(5)));
-        assertEquals("Expected property-query | [, got named-element '\\N{LATIN SMALL LETTER Z}' ", thrown.getMessage());
+        assertEquals(
+                "Expected property-query | [, got named-element '\\N{LATIN SMALL LETTER Z}' ",
+                thrown.getMessage());
         assertEquals("TEST [[a-z]-".length(), thrown.getErrorOffset());
     }
 }

--- a/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
+++ b/unicodetools/src/test/java/org/unicode/text/UCD/TestVersionedSymbolTable.java
@@ -88,28 +88,31 @@ public class TestVersionedSymbolTable {
         assertThatUnicodeSet("[:^General_Category=Cn:]").contains("a").doesNotContain("\uFFFF");
         assertThatUnicodeSet("\\p{General_Category≠Cn}").contains("a").doesNotContain("\uFFFF");
         assertThatUnicodeSet("[:General_Category≠Cn:]").contains("a").doesNotContain("\uFFFF");
-        assertThatUnicodeSet("[:^General_Category≠Cn:]").doesNotContain("a").contains("\uFFFF");
-        assertThatUnicodeSet("[:^General_Category≠Cn:]").doesNotContain("a").contains("\uFFFF");
-        assertThatUnicodeSet("[:^General_Category≠Cn:]").doesNotContain("a").contains("\uFFFF");
+        assertThatUnicodeSet("[:^General_Category≠Cn:]")
+                .isIllFormed("Found doubly negated property-query [:^General_Category≠☜Cn:]");
+        assertThatUnicodeSet("\\P{General_Category≠Cn}")
+                .isIllFormed("Found doubly negated property-query \\P{General_Category≠☜Cn}");
 
         assertThatUnicodeSet("\\P{Decomposition_Type≠compat}")
-                .contains("∯")
-                .doesNotContain("∮")
-                .isEqualToUnicodeSet("\\p{Decomposition_Type=compat}");
+                .isIllFormed("Found doubly negated property-query \\P{Decomposition_Type≠☜compat}");
     }
 
     @Test
-    void testNamedSingleton() {
-        assertThatUnicodeSet("\\N{SPACE}").consistsOf(" ");
-        assertThatUnicodeSet("\\N{THIS IS NOT A CHARACTER}")
+    void testNamedElement() {
+        // NamedSingleton (from L2/25-127) was rejected.
+        assertThatUnicodeSet("\\N{SPACE}")
+                .isIllFormed("Expected property-query | [, got named-element");
+
+        assertThatUnicodeSet("[\\N{SPACE}]").consistsOf(" ");
+        assertThatUnicodeSet("[\\N{THIS IS NOT A CHARACTER}]")
                 .isIllFormed("No character name nor name alias matches");
-        assertThatUnicodeSet("\\N{PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRAKCET}")
+        assertThatUnicodeSet("[\\N{PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRAKCET}]")
                 .isEqualToUnicodeSet(
-                        "\\N{PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRACKET}")
+                        "[\\N{PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRACKET}]")
                 .consistsOf("︘");
-        assertThatUnicodeSet("\\N{Latin small ligature o-e}").consistsOf("œ");
-        assertThatUnicodeSet("\\N{Hangul jungseong O-E}").consistsOf("ᆀ");
-        assertThatUnicodeSet("\\N{Hangul jungseong OE}").consistsOf("ᅬ");
+        assertThatUnicodeSet("[\\N{Latin small ligature o-e}]").consistsOf("œ");
+        assertThatUnicodeSet("[\\N{Hangul jungseong O-E}]").consistsOf("ᆀ");
+        assertThatUnicodeSet("[\\N{Hangul jungseong OE}]").consistsOf("ᅬ");
     }
 
     @Test


### PR DESCRIPTION
We no longer need the workaround #908 to ICU-22851 (fixed by https://github.com/unicode-org/icu/pull/4030), and indeed our workaround is now broken by the ICU fix.

Also, the exception messages have changed, and since we turn those into error messages for the higher-level syntax of invariant tests, they need to be processed a bit differently.

- [ ] Approver: Feel free to merge on my behalf
    - [ ] rebase & merge one or more commits
    - [ ] squash & merge multiple commits into one