### PR TITLE
ArabicShaping header reference to derived files

### DIFF
--- a/unicodetools/data/ucd/dev/ArabicShaping.txt
+++ b/unicodetools/data/ucd/dev/ArabicShaping.txt
@@ -1,5 +1,5 @@
 # ArabicShaping-18.0.0.txt
-# Date: 2026-02-03, 23:09:37 GMT
+# Date: 2026-08-16, 20:07:38 GMT
 # © 2026 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 # For terms of use and license, see https://www.unicode.org/terms_of_use.html
@@ -10,16 +10,24 @@
 # This file is a normative contributory data file in the
 # Unicode Character Database.
 #
-# This file defines the Joining_Type and Joining_Group property
+# This file lists the Joining_Type and Joining_Group property
 # values for Arabic, Syriac, N'Ko, Mandaic, and Manichaean positional
 # shaping, repeating in machine readable form the information
 # exemplified in various tables of The Unicode Standard core specification.
 #
-# This file also defines Joining_Type values for Mongolian, Phags-pa,
+# This file also lists Joining_Type values for Mongolian, Phags-pa,
 # Psalter Pahlavi, Sogdian, Old Uyghur, Chorasmian, and Adlam positional
 # shaping, and Joining_Type and Joining_Group values for Hanifi Rohingya
 # positional shaping, which are not listed in tables in the core
 # specification.
+#
+# The full definition of these properties are found in the derived property
+# files DerivedJoiningType.txt and DerivedJoiningGroup.txt.
+#
+# Implementers are strongly encouraged to use the derived property files
+# DerivedJoiningType.txt and DerivedJoiningGroup.txt instead of the current
+# file, to avoid the complication of having to calculate the Joining_Type=T
+# values based on General_Category.
 #
 # Script          Section  Table(s)
 #
@@ -109,13 +117,6 @@
 # - Those that are not explicitly listed and that are of General_Category Mn, Me, or Cf
 #   are Joining_Type=T.
 # - All others not explicitly listed are Joining_Type=U.
-#
-# For an explicit listing of all characters of Joining_Type=T, see
-# the derived property file DerivedJoiningType.txt.
-# For an implementation that needs to parse for the values of
-# Joining_Type, it is recommended to use DerivedJoiningType.txt
-# instead of ArabicShaping.txt, to avoid the separate required step of
-# calculating the set for Joining_Type=T based on General_Category values.
 #
 # #############################################################
 

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/MakeUnicodeFiles.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/MakeUnicodeFiles.txt
@@ -1318,16 +1318,24 @@ File:	ArabicShaping
 # This file is a normative contributory data file in the
 # Unicode Character Database.
 #
-# This file defines the Joining_Type and Joining_Group property
+# This file lists the Joining_Type and Joining_Group property
 # values for Arabic, Syriac, N'Ko, Mandaic, and Manichaean positional
 # shaping, repeating in machine readable form the information
 # exemplified in various tables of The Unicode Standard core specification.
 #
-# This file also defines Joining_Type values for Mongolian, Phags-pa,
+# This file also lists Joining_Type values for Mongolian, Phags-pa,
 # Psalter Pahlavi, Sogdian, Old Uyghur, Chorasmian, and Adlam positional
 # shaping, and Joining_Type and Joining_Group values for Hanifi Rohingya
 # positional shaping, which are not listed in tables in the core
 # specification.
+#
+# The full definition of these properties are found in the derived property
+# files DerivedJoiningType.txt and DerivedJoiningGroup.txt.
+#
+# Implementers are strongly encouraged to use the derived property files
+# DerivedJoiningType.txt and DerivedJoiningGroup.txt instead of the current
+# file, to avoid the complication of having to calculate the Joining_Type=T
+# values based on General_Category.
 #
 # Script          Section  Table(s)
 #
@@ -1417,13 +1425,6 @@ File:	ArabicShaping
 # - Those that are not explicitly listed and that are of General_Category Mn, Me, or Cf
 #   are Joining_Type=T.
 # - All others not explicitly listed are Joining_Type=U.
-#
-# For an explicit listing of all characters of Joining_Type=T, see
-# the derived property file DerivedJoiningType.txt.
-# For an implementation that needs to parse for the values of
-# Joining_Type, it is recommended to use DerivedJoiningType.txt
-# instead of ArabicShaping.txt, to avoid the separate required step of
-# calculating the set for Joining_Type=T based on General_Category values.
 #
 # #############################################################
 Property: SPECIAL


### PR DESCRIPTION
[UTC-188-A35] Action Item for Roozbeh Pournader and Robin Leroy, PAG: Change the language and recommendations in ArabicShaping.txt to more strongly recommend that implementers use the derived files. For Unicode 18.0. See L2/26-154 item 2.2.

- [ ] Approver: Feel free to merge on my behalf
    - [ ] rebase & merge one or more commits
    - [ ] squash & merge multiple commits into one