### PR TITLE
uni18 BidiMirroring: don't say uni17

### DIFF
--- a/unicodetools/data/ucd/dev/BidiMirroring.txt
+++ b/unicodetools/data/ucd/dev/BidiMirroring.txt
@@ -16,8 +16,6 @@
 # value, for which there is another Unicode character that typically has a glyph
 # that is the mirror image of the original character's glyph.
 #
-# The repertoire covered by the file is Unicode 17.0.0.
-#
 # The file contains a list of lines with mappings from one code point
 # to another one for character-based mirroring.
 # Note that for "real" mirroring, a rendering engine needs to select


### PR DESCRIPTION
Not true for Unicode 18: “The repertoire covered by the file is Unicode 17.0.0.”

Fixes https://github.com/unicode-org/properties/issues/661

- [ ] Approver: Feel free to merge on my behalf
    - [ ] rebase & merge one or more commits
    - [ ] squash & merge multiple commits into one