### PR TITLE
Meow_Variation_Base

### DIFF
--- a/unicodetools/src/main/java/org/unicode/props/PropertyParsingInfo.java
+++ b/unicodetools/src/main/java/org/unicode/props/PropertyParsingInfo.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.util.RegexUtilities;
 import org.unicode.idna.Regexes;
@@ -1435,6 +1436,22 @@ public class PropertyParsingInfo implements Comparable<PropertyParsingInfo> {
             IndexUnicodeProperties indexUnicodeProperties,
             IndexUnicodeProperties nextProperties,
             Set<PropertyParsingInfo> propInfoSet) {
+        final var binaries =
+                propInfoSet.stream()
+                        .filter(propInfo -> propInfo.property.getType() == PropertyType.Binary)
+                        .toList();
+        if (binaries.size() != 1) {
+            throw new IllegalArgumentException(
+                    "propInfoSet for file of type StandardizedVariants should have one binary property: "
+                            + propInfoSet.stream()
+                                    .map(p -> p.property.toString())
+                                    .collect(Collectors.joining(", ")));
+        }
+        final var baseProperty = binaries.get(0);
+        final var nonBinaries =
+                propInfoSet.stream()
+                        .filter(propInfo -> propInfo.property.getType() != PropertyType.Binary)
+                        .collect(Collectors.toSet());
         for (UcdLineParser.UcdLine line : parser) {
             String[] parts = line.getParts();
             if (!parts[2].isEmpty()) {
@@ -1444,9 +1461,23 @@ public class PropertyParsingInfo implements Comparable<PropertyParsingInfo> {
                     line,
                     indexUnicodeProperties,
                     nextProperties,
-                    propInfoSet,
+                    nonBinaries,
                     IndexUnicodeProperties.ALPHABETIC_JOINER,
                     false);
+            final var hexCodePoints = parts[0].split("\\s+");
+            if (hexCodePoints.length != 2) {
+                throw new IllegalArgumentException("Bad variation sequence line " + line);
+            }
+            final var base = new IntRange();
+            base.start = base.end = Utility.codePointFromHex(hexCodePoints[0]);
+            baseProperty.put(
+                    indexUnicodeProperties.property2UnicodeMap.get(baseProperty.property),
+                    base,
+                    "Yes",
+                    nextProperties == null
+                            ? null
+                            : nextProperties.getProperty(baseProperty.property),
+                    indexUnicodeProperties.ucdVersion);
         }
     }
 

--- a/unicodetools/src/main/java/org/unicode/props/UcdProperty.java
+++ b/unicodetools/src/main/java/org/unicode/props/UcdProperty.java
@@ -1012,6 +1012,12 @@ public enum UcdProperty {
             PropertyType.Binary, DerivedPropertyStatus.Approved, Binary.class, null, "EBase"),
     Emoji_Presentation(
             PropertyType.Binary, DerivedPropertyStatus.Approved, Binary.class, null, "EPres"),
+    Emoji_Variation_Base(
+            PropertyType.Binary,
+            DerivedPropertyStatus.UCDNonProperty,
+            Binary.class,
+            null,
+            "Emoji_Variation_Base"),
     Expands_On_NFC(
             PropertyType.Binary, DerivedPropertyStatus.Approved, Binary.class, null, "XO_NFC"),
     Expands_On_NFD(
@@ -1139,6 +1145,12 @@ public enum UcdProperty {
     Sentence_Terminal(
             PropertyType.Binary, DerivedPropertyStatus.Approved, Binary.class, null, "STerm"),
     Soft_Dotted(PropertyType.Binary, DerivedPropertyStatus.Approved, Binary.class, null, "SD"),
+    Standardized_Variation_Base(
+            PropertyType.Binary,
+            DerivedPropertyStatus.UCDNonProperty,
+            Binary.class,
+            null,
+            "Standardized_Variation_Base"),
     Terminal_Punctuation(
             PropertyType.Binary, DerivedPropertyStatus.Approved, Binary.class, null, "Term"),
     Unified_Ideograph(

--- a/unicodetools/src/main/resources/org/unicode/props/ExtraPropertyAliases.txt
+++ b/unicodetools/src/main/resources/org/unicode/props/ExtraPropertyAliases.txt
@@ -11,6 +11,9 @@ REZS ; RGI_Emoji_Zwj_Sequence ; Emoji_Zwj_Sequence ; NonUCDProperty
 RGI_Emoji ; RGI_Emoji ; NonUCDProperty
 Link_Email ; Link_Email ; NonUCDProperty
 
+Emoji_Variation_Base ; Emoji_Variation_Base ; UCDNonProperty
+Standardized_Variation_Base ; Standardized_Variation_Base ; UCDNonProperty
+
 # ================================================
 # Enumerated Properties
 # ================================================

--- a/unicodetools/src/main/resources/org/unicode/props/ExtraPropertyValueAliases.txt
+++ b/unicodetools/src/main/resources/org/unicode/props/ExtraPropertyValueAliases.txt
@@ -92,6 +92,9 @@
 # @missing: 0000..10FFFF; Link_Bracket; <none>
 # @missing: 0000..10FFFF; Link_Email ; No
 
+# @missing: 0000..10FFFF; Emoji_Variation_Base        ; No
+# @missing: 0000..10FFFF; Standardized_Variation_Base ; No
+
 # End of binary properties.
 
 # Common, until decision 106-C17 made it Unknown (Zzzz).

--- a/unicodetools/src/main/resources/org/unicode/props/IndexUnicodeProperties.txt
+++ b/unicodetools/src/main/resources/org/unicode/props/IndexUnicodeProperties.txt
@@ -514,7 +514,9 @@ EmojiSources ; Emoji_SB ; 3
 NamedSequences ; Named_Sequences
 NamedSequencesProv ; Named_Sequences_Prov
 StandardizedVariants ; Standardized_Variant
+StandardizedVariants ; Standardized_Variation_Base
 emoji-variation-sequences ; emoji-variation-sequence
+emoji-variation-sequences ; Emoji_Variation_Base
 DoNotEmit ; Do_Not_Emit_Preferred ; 1
 DoNotEmit ; Do_Not_Emit_Dispreferred ; "1" ↦ 0
 DoNotEmit ; Do_Not_Emit_Dispreferred_Type ; "1" ↦ 2

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/AdditionComparisons/070.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/AdditionComparisons/070.txt
@@ -3,7 +3,13 @@ Ignoring Name Age:
 # HXG (briefly known as HZXG) and SZP are just like all the other CJK strokes.
 # In particular, they are scx=Hani:
 # https://www.unicode.org/review/pri502/feedback.html#ID20240523095709.
-Propertywise [\N{CJK STROKE HXG}\N{CJK STROKE SZP}
-              \N{CJK STROKE T}] AreAlike
+# Unicode 18.0: SZP has a variation sequence (slanted S form, like S, SZ, SZWG),
+# whereas HXG does not (though H has a variation sequence).
+# We compare SZP with SZWG rather than ㇑ S and ㇗ SZ because those two have an
+# Equivalent_Unified_Ideograph.
+Propertywise [\N{31E5:㇥:CJK STROKE SZP}
+              \N{31C9:㇉:CJK STROKE SZWG}] AreAlike
+Propertywise [\N{31E4:㇤:CJK STROKE HXG}
+              \N{31C2:㇂:CJK STROKE XG}] AreAlike
 
 end Ignoring;

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/AdditionComparisons/293.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/AdditionComparisons/293.txt
@@ -113,11 +113,20 @@ CorrespondTo [\x{2ACD} ⫍ \N{SQUARE LEFT OPEN BOX OPERATOR}]
 end Ignoring;
 
 # A bidi mirorring glyph for the long bidi mirrored ∝.
+Ignoring Pattern_Syntax Standardized_Variation_Base:
+Propertywise [\N{1DB10:CARTESIAN EQUALS SIGN}]
+           : [\N{221D:∝:PROPORTIONAL TO}]
+CorrespondTo [\N{29F5:⧵:REVERSE SOLIDUS OPERATOR}]
+           : [\N{2215:∕:DIVISION SLASH}]
+end Ignoring;
+
+# ⧴ because ∝ is not a variation base contrary to the other three, and because
+# it differs in East_Asian_Width and Line_Break (Ambiguous).
 Ignoring Pattern_Syntax:
-Propertywise [\x{1DB10}  \N{CARTESIAN EQUALS SIGN}]
-           : [\x{221D} ∝ \N{PROPORTIONAL TO}]
-CorrespondTo [\x{29F5} ⧵ \N{REVERSE SOLIDUS OPERATOR}]
-           : [\x{2215} ∕ \N{DIVISION SLASH}]
+Propertywise [\N{1DB10:CARTESIAN EQUALS SIGN}]
+           ⧴ [\N{221D:∝:PROPORTIONAL TO}]
+CorrespondTo [\N{228A:⊊:SUBSET OF WITH NOT EQUAL TO}]
+           ⧴ [\N{228B:⊋:SUPERSET OF WITH NOT EQUAL TO}]
 end Ignoring;
 
 end Ignoring;

--- a/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
+++ b/unicodetools/src/main/resources/org/unicode/text/UCD/UnicodeInvariantTest.txt
@@ -1589,6 +1589,13 @@ OnPairsOf [$code_points - $noncharacter_charts - $uncharted_block_ends - $unchar
 [$uncharted_block_ends $uncharted_pua_planes] ⊂ \p{Names_List_Block_Header=@none@}
 [$noncharacter_charts] = \p{Names_List_Block_Header=Unassigned}
 
+[0] ⊂ \p{Standardized_Variation_Base}
+[0] ⊂ \p{Emoji_Variation_Base}
+[🅾] ⊂ \p{Standardized_Variation_Base=No}
+[🅾] ⊂ \p{Emoji_Variation_Base}
+[∅] ⊂ \p{Standardized_Variation_Base}
+[∅] ⊂ \p{Emoji_Variation_Base=No}
+
 # Basic Propertywise tests.
 Ignoring Name:
 


### PR DESCRIPTION
We already had emoji-variation-sequence and Standardized_Variant mapping the sequences to their descriptions; this adds binary pseudoproperties for the bases, per the 2026-09-10 PAG discussion.

- [x] Approver: Feel free to merge on my behalf
    - [x] rebase & merge one or more commits
    - [ ] squash & merge multiple commits into one